### PR TITLE
"return.falseproblem;" is not a "false" error.

### DIFF
--- a/src/DocPage.php
+++ b/src/DocPage.php
@@ -38,9 +38,6 @@ class DocPage
             if (preg_match('/&return.falseforfailure;/m', $file)) {
                 return true;
             }
-            if (preg_match('/&return.falseproblem;/m', $file)) {
-                return true;
-            }
         }
         return false;
     }


### PR DESCRIPTION
The function can legitimately return false!

From the documentation:

```
<!ENTITY return.falseproblem '<warning xmlns="http://docbook.org/ns/docbook"><simpara>This function may
return Boolean &false;, but may also return a non-Boolean value which
evaluates to &false;. Please read the section on <link
linkend="language.types.boolean">Booleans</link> for more
information. Use <link linkend="language.operators.comparison">the ===
operator</link> for testing the return value of this
function.</simpara></warning>'>
```