### PR TITLE
Indexing performance of PHPStorm: Splitting functions in several files (one per PHP module)

### DIFF
--- a/src/FileCreator.php
+++ b/src/FileCreator.php
@@ -48,23 +48,33 @@ class FileCreator
     /**
      * This function generate an improved php lib function in a php file
      *
-     * @param string[] $phpFunctions
+     * @param Method[] $functions
      * @param string $path
      */
-    public function generatePhpFile(array $phpFunctions, string $path): void
+    public function generatePhpFile(array $functions, string $path): void
     {
-        $stream = \fopen($path, 'w');
-        if ($stream === false) {
-            throw new \RuntimeException('Unable to write to '.$path);
+        $path = rtrim($path, '/').'/';
+        $phpFunctionsByModule = [];
+        foreach ($functions as $function) {
+            $writePhpFunction = new WritePhpFunction($function);
+            $phpFunctionsByModule[$function->getModuleName()][] = $writePhpFunction->getPhpFunctionalFunction();
         }
-        \fwrite($stream, "<?php\n
+
+        foreach ($phpFunctionsByModule as $module => $phpFunctions) {
+            $module = \lcfirst($module);
+            $stream = \fopen($path.$module.'.php', 'w');
+            if ($stream === false) {
+                throw new \RuntimeException('Unable to write to '.$path);
+            }
+            \fwrite($stream, "<?php\n
 namespace Safe;
 
 ");
-        foreach ($phpFunctions as $phpFunction) {
-            \fwrite($stream, $phpFunction."\n");
+            foreach ($phpFunctions as $phpFunction) {
+                \fwrite($stream, $phpFunction."\n");
+            }
+            \fclose($stream);
         }
-        \fclose($stream);
     }
 
 

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -35,15 +35,9 @@ class GenerateCommand extends Command
 
         $output->writeln('These functions have been ignored and must be dealt with manually: '.\implode(', ', $overloadedFunctions));
 
-        $phpFunctions = [];
-        foreach ($functions as $function) {
-            $writePhpFunction = new WritePhpFunction($function);
-            $phpFunctions[] = $writePhpFunction->getPhpFunctionalFunction();
-        }
-
         $fileCreator = new FileCreator();
         //$fileCreator->generateXlsFile($protoFunctions, __DIR__ . '/../generated/lib.xls');
-        $fileCreator->generatePhpFile($phpFunctions, __DIR__ . '/../generated/lib.php');
+        $fileCreator->generatePhpFile($functions, __DIR__ . '/../generated/');
         $fileCreator->generateFunctionsList($functions, __DIR__ . '/../generated/functionsList.php');
 
 
@@ -57,7 +51,11 @@ class GenerateCommand extends Command
         }
 
         // Finally, let's require the generated file to check there is no error.
-        require __DIR__.'/../generated/lib.php';
+        $files = \glob(__DIR__.'/../generated/*.php');
+
+        foreach ($files as $file) {
+            require($file);
+        }
     }
 
     private function rmGenerated(): void
@@ -68,9 +66,12 @@ class GenerateCommand extends Command
             \unlink($exception);
         }
 
-        if (\file_exists(__DIR__.'/../generated/lib.php')) {
-            \unlink(__DIR__.'/../generated/lib.php');
+        $files = \glob(__DIR__.'/../generated/*.php');
+
+        foreach ($files as $file) {
+            \unlink($file);
         }
+
         if (\file_exists(__DIR__.'/../doc/entities/generated.ent')) {
             \unlink(__DIR__.'/../doc/entities/generated.ent');
         }


### PR DESCRIPTION
Before this PR, all Safe functions were generated in one single big file.

Performance of PHPStorm indexing is really poor.

- nb functions: 1426
- nb lines: 46514
- file size: 1.3M
- time to index in PHPStorm: **3m42s**

After this PR, we have the same number of functions split in a lot of smaller files:

- nb functions: 1426
- nb files: 128
- nb lines (total): 48449
- files size (total): 1.5M
- average file size: 12k
- time to index in PHPStorm: **3s** (!!!)

It seems PHPStorm does not like large files.

Closes #5 