### PR TITLE
Adding a file to handle special cases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
 - cd generator && ./vendor/bin/phpunit && cd ..
 - cd generator && composer cs-check && cd ..
 - cd generator && composer phpstan && cd ..
+- composer dump-autoload
 - composer cs-check
 - composer phpstan
 # Now, let's regenerate all files and see if we obtain the same set of files as the ones commited:

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,8 @@
             "generated/yaml.php",
             "generated/yaz.php",
             "generated/zip.php",
-            "generated/zlib.php"
+            "generated/zlib.php",
+            "lib/special_cases.php"
         ]
     },
     "require": {

--- a/generated/functionsList.php
+++ b/generated/functionsList.php
@@ -931,4 +931,5 @@ return [
     'inflate_add',
     'inflate_init',
     'zlib_decode',
+    'json_decode',
 ];

--- a/generator/config/specialCasesFunctions.php
+++ b/generator/config/specialCasesFunctions.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * A list of functions that must be dealt with manually.
+ * They are declared in lib/special_cases.php
+ */
+return [
+    'json_decode'
+];

--- a/generator/src/ComposerJsonEditor.php
+++ b/generator/src/ComposerJsonEditor.php
@@ -16,6 +16,7 @@ class ComposerJsonEditor
         $files = \array_map(function (string $module) {
             return 'generated/'.lcfirst($module).'.php';
         }, $modules);
+        $files[] = 'lib/special_cases.php';
         $composerContent = file_get_contents(__DIR__.'/../../composer.json');
         if ($composerContent === false) {
             throw new \RuntimeException('Error while loading composer.json file for edition.');

--- a/generator/src/FileCreator.php
+++ b/generator/src/FileCreator.php
@@ -2,6 +2,7 @@
 
 namespace Safe;
 
+use function array_merge;
 use Complex\Exception;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
@@ -89,6 +90,8 @@ namespace Safe;
         $functionNames = array_map(function (Method $function) {
             return $function->getFunctionName();
         }, $functions);
+        $specialCases = require __DIR__.'/../config/specialCasesFunctions.php';
+        $functionNames = array_merge($functionNames, $specialCases);
         $stream = fopen($path, 'w');
         if ($stream === false) {
             throw new \RuntimeException('Unable to write to '.$path);

--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * This file contains all the functions that could not be dealt with automatically using the code generator.
+ * If you add a function in this list, do not forget to add it in the generator/config/speicalCasesFunctions.php
+ *
+ */
+
+namespace Safe;
+
+use Safe\Exceptions\JsonException;
+
+/**
+ * Wrapper for json_decode that throws when an error occurs.
+ *
+ * @param string $json    JSON data to parse
+ * @param bool $assoc     When true, returned objects will be converted
+ *                        into associative arrays.
+ * @param int $depth   User specified recursion depth.
+ * @param int $options Bitmask of JSON decode options.
+ *
+ * @return mixed
+ * @throws JsonException if the JSON cannot be decoded.
+ * @link http://www.php.net/manual/en/function.json-decode.php
+ */
+function json_decode($json, $assoc = false, $depth = 512, $options = 0)
+{
+    $data = \json_decode($json, $assoc, $depth, $options);
+    if (JSON_ERROR_NONE !== json_last_error()) {
+        throw JsonException::createFromPhpError();
+    }
+    return $data;
+}

--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -22,7 +22,7 @@ use Safe\Exceptions\JsonException;
  * @throws JsonException if the JSON cannot be decoded.
  * @link http://www.php.net/manual/en/function.json-decode.php
  */
-function json_decode($json, $assoc = false, $depth = 512, $options = 0)
+function json_decode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
 {
     $data = \json_decode($json, $assoc, $depth, $options);
     if (JSON_ERROR_NONE !== json_last_error()) {


### PR DESCRIPTION
The `lib/special_cases.php` file can now handle special cases (like json_decode that returns null on error).

Files with special cases must be declared in `generator/config/specialCasesFunctions.php`