### PR TITLE
Fixing json_decode error handling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ if ($content === false) {
     throw new FileLoadingException('Could not load file foobar.json');
 }
 $foobar = json_decode($content);
-if ($foobar === null) {
+if (json_last_error() !== JSON_ERROR_NONE) {
     throw new FileLoadingException('foobar.json does not contain valid JSON: '.json_last_error());
 }
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ if ($content === false) {
 }
 $foobar = json_decode($content);
 if (json_last_error() !== JSON_ERROR_NONE) {
-    throw new FileLoadingException('foobar.json does not contain valid JSON: '.json_last_error());
+    throw new FileLoadingException('foobar.json does not contain valid JSON: '.json_last_error_msg());
 }
 ```
 

--- a/generated/sem.php
+++ b/generated/sem.php
@@ -31,7 +31,7 @@ function msg_queue_exists(int $key): void
  * of the queue is returned. If desiredmsgtype is
  * greater than 0, then the first message of that type is returned.
  * If desiredmsgtype is less than 0, the first
- * message on the queue with the lowest type less than or equal to the
+ * message on the queue with a type less than or equal to the
  * absolute value of desiredmsgtype will be read.
  * If no messages match the criteria, your script will wait until a suitable
  * message arrives on the queue.  You can prevent the script from blocking


### PR DESCRIPTION
As noticed in #35, the sample error handling in the README with incorrect.
This PR fixes the example.

Closes #35 