### PR TITLE
Fixing already existing exception detection

### DIFF
--- a/generated/Exceptions/CurlException.php
+++ b/generated/Exceptions/CurlException.php
@@ -1,6 +1,0 @@
-<?php
-namespace Safe\Exceptions;
-
-class CurlException extends AbstractSafeException
-{
-}

--- a/generated/Exceptions/JsonException.php
+++ b/generated/Exceptions/JsonException.php
@@ -1,6 +1,0 @@
-<?php
-namespace Safe\Exceptions;
-
-class JsonException extends AbstractSafeException
-{
-}

--- a/generator/src/FileCreator.php
+++ b/generator/src/FileCreator.php
@@ -4,6 +4,7 @@ namespace Safe;
 
 use function array_merge;
 use Complex\Exception;
+use function file_exists;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 use function ucfirst;
@@ -145,7 +146,7 @@ services:
     public function createExceptionFile(string $moduleName): void
     {
         $exceptionName = self::toExceptionName($moduleName);
-        if (!\class_exists("Safe\\Exceptions\\{$exceptionName}")) {
+        if (!file_exists(__DIR__.'/../../lib/Exceptions/'.$exceptionName.'.php')) {
             \file_put_contents(
                 __DIR__.'/../../generated/Exceptions/'.$exceptionName.'.php',
                 <<<EOF


### PR DESCRIPTION
When an exception already exists in `lib/Exceptions`, it should not be generated in `generated/Exceptions`.

Closes #41 