### PR TITLE
Adding preg_replace to special cases functions

### DIFF
--- a/generated/Exceptions/PcreException.php
+++ b/generated/Exceptions/PcreException.php
@@ -1,6 +1,0 @@
-<?php
-namespace Safe\Exceptions;
-
-class PcreException extends AbstractSafeException
-{
-}

--- a/generated/functionsList.php
+++ b/generated/functionsList.php
@@ -1074,4 +1074,5 @@ return [
     'json_decode',
     'apc_fetch',
     'apcu_fetch',
+    'preg_replace',
 ];

--- a/generator/config/specialCasesFunctions.php
+++ b/generator/config/specialCasesFunctions.php
@@ -6,5 +6,6 @@
 return [
     'json_decode',
     'apc_fetch',
-    'apcu_fetch'
+    'apcu_fetch',
+    'preg_replace',
 ];

--- a/generator/tests/GeneratedFilesTest.php
+++ b/generator/tests/GeneratedFilesTest.php
@@ -37,7 +37,7 @@ class GeneratedFilesTest extends TestCase
         require_once __DIR__.'/../../generated/pcre.php';
         require_once __DIR__.'/../../lib/Exceptions/SafeExceptionInterface.php';
         require_once __DIR__.'/../../lib/Exceptions/AbstractSafeException.php';
-        require_once __DIR__.'/../../generated/Exceptions/PcreException.php';
+        require_once __DIR__.'/../../lib/Exceptions/PcreException.php';
 
 
         $url = 'https://open.spotify.com/track/0nCqpKBrvDchO1BIvt7DTR?si=iLUKDfkLSy-IpnLA7qImnw';
@@ -83,7 +83,7 @@ XML;
         require_once __DIR__.'/../../generated/pcre.php';
         require_once __DIR__.'/../../lib/Exceptions/SafeExceptionInterface.php';
         require_once __DIR__.'/../../lib/Exceptions/AbstractSafeException.php';
-        require_once __DIR__.'/../../generated/Exceptions/PcreException.php';
+        require_once __DIR__.'/../../lib/Exceptions/PcreException.php';
 
         $keywords = preg_split("/[\s,]+/", "hypertext language, programming", null);
         $this->assertSame(['hypertext', 'language', 'programming'], $keywords);

--- a/generator/tests/SpecialCasesTest.php
+++ b/generator/tests/SpecialCasesTest.php
@@ -15,7 +15,7 @@ class SpecialCasesTest extends TestCase
         require_once __DIR__.'/../../lib/Exceptions/PcreException.php';
 
         $this->expectException(PcreException::class);
-        $this->expectExceptionMessage('PREG_BAD_UTF8_ERROR');
+        $this->expectExceptionMessage('PREG_BAD_UTF8_ERROR: Invalid UTF8 character');
         preg_replace("/([\s,]+)/u", "foo", "\xc3\x28");
     }
 }

--- a/generator/tests/SpecialCasesTest.php
+++ b/generator/tests/SpecialCasesTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Safe;
+
+use PHPUnit\Framework\TestCase;
+use Safe\Exceptions\PcreException;
+
+class SpecialCasesTest extends TestCase
+{
+    public function testPregReplace()
+    {
+        require_once __DIR__.'/../../lib/special_cases.php';
+        require_once __DIR__.'/../../lib/Exceptions/SafeExceptionInterface.php';
+        require_once __DIR__.'/../../lib/Exceptions/AbstractSafeException.php';
+        require_once __DIR__.'/../../lib/Exceptions/PcreException.php';
+
+        $this->expectException(PcreException::class);
+        $this->expectExceptionMessage('PREG_BAD_UTF8_ERROR');
+        preg_replace("/([\s,]+)/u", "foo", "\xc3\x28");
+    }
+}

--- a/lib/Exceptions/PcreException.php
+++ b/lib/Exceptions/PcreException.php
@@ -7,7 +7,15 @@ class PcreException extends \Exception implements SafeExceptionInterface
 {
     public static function createFromPhpError(): self
     {
-        $errMsg = array_flip(get_defined_constants(true)['pcre'])[preg_last_error()];
+        $errorMap = [
+            PREG_INTERNAL_ERROR => 'PREG_INTERNAL_ERROR: Internal error',
+            PREG_BACKTRACK_LIMIT_ERROR => 'PREG_BACKTRACK_LIMIT_ERROR: Backtrack limit reached',
+            PREG_RECURSION_LIMIT_ERROR => 'PREG_RECURSION_LIMIT_ERROR: Recursion limit reached',
+            PREG_BAD_UTF8_ERROR => 'PREG_BAD_UTF8_ERROR: Invalid UTF8 character',
+            PREG_BAD_UTF8_OFFSET_ERROR => 'PREG_BAD_UTF8_OFFSET_ERROR',
+            PREG_JIT_STACKLIMIT_ERROR => 'PREG_JIT_STACKLIMIT_ERROR',
+        ];
+        $errMsg = $errorMap[preg_last_error()] ?? 'Unknown PCRE error: '.preg_last_error();
         return new static($errMsg, \preg_last_error());
     }
 }

--- a/lib/Exceptions/PcreException.php
+++ b/lib/Exceptions/PcreException.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace Safe\Exceptions;
+
+class PcreException extends \Exception implements SafeExceptionInterface
+{
+    public static function createFromPhpError(): self
+    {
+        $errMsg = array_flip(get_defined_constants(true)['pcre'])[preg_last_error()];
+        return new static($errMsg, \preg_last_error());
+    }
+}

--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -156,9 +156,7 @@ function preg_replace($pattern, $replacement, $subject, int $limit = -1, int &$c
 {
     error_clear_last();
     $result = \preg_replace($pattern, $replacement, $subject, $limit, $count);
-    var_dump($result);
     if (preg_last_error() !== PREG_NO_ERROR) {
-        // TODO: PcreException should use code here: http://php.net/manual/en/function.preg-last-error.php
         throw PcreException::createFromPhpError();
     }
     return $result;

--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -7,9 +7,12 @@
 
 namespace Safe;
 
+use const PREG_NO_ERROR;
 use Safe\Exceptions\ApcException;
 use Safe\Exceptions\ApcuException;
 use Safe\Exceptions\JsonException;
+use Safe\Exceptions\PcreException;
+use function var_dump;
 
 /**
  * Wrapper for json_decode that throws when an error occurs.
@@ -70,6 +73,93 @@ function apcu_fetch($key)
     $result = \apcu_fetch($key, $success);
     if ($success === false) {
         throw ApcuException::createFromPhpError();
+    }
+    return $result;
+}
+
+/**
+ * Searches subject for matches to
+ * pattern and replaces them with
+ * replacement.
+ *
+ * @param mixed $pattern The pattern to search for. It can be either a string or an array with
+ * strings.
+ *
+ * Several PCRE modifiers
+ * are also available.
+ * @param mixed $replacement The string or an array with strings to replace. If this parameter is a
+ * string and the pattern parameter is an array,
+ * all patterns will be replaced by that string. If both
+ * pattern and replacement
+ * parameters are arrays, each pattern will be
+ * replaced by the replacement counterpart. If
+ * there are fewer elements in the replacement
+ * array than in the pattern array, any extra
+ * patterns will be replaced by an empty string.
+ *
+ * replacement may contain references of the form
+ * \\n or
+ * $n, with the latter form
+ * being the preferred one. Every such reference will be replaced by the text
+ * captured by the n'th parenthesized pattern.
+ * n can be from 0 to 99, and
+ * \\0 or $0 refers to the text matched
+ * by the whole pattern. Opening parentheses are counted from left to right
+ * (starting from 1) to obtain the number of the capturing subpattern.
+ * To use backslash in replacement, it must be doubled
+ * ("\\\\" PHP string).
+ *
+ * When working with a replacement pattern where a backreference is
+ * immediately followed by another number (i.e.: placing a literal number
+ * immediately after a matched pattern), you cannot use the familiar
+ * \\1 notation for your backreference.
+ * \\11, for example, would confuse
+ * preg_replace since it does not know whether you
+ * want the \\1 backreference followed by a literal
+ * 1, or the \\11 backreference
+ * followed by nothing.  In this case the solution is to use
+ * ${1}1.  This creates an isolated
+ * $1 backreference, leaving the 1
+ * as a literal.
+ *
+ * When using the deprecated e modifier, this function escapes
+ * some characters (namely ', ",
+ * \ and NULL) in the strings that replace the
+ * backreferences. This is done to ensure that no syntax errors arise
+ * from backreference usage with either single or double quotes (e.g.
+ * 'strlen(\'$1\')+strlen("$2")'). Make sure you are
+ * aware of PHP's string
+ * syntax to know exactly how the interpreted string will look.
+ * @param string|array $subject The string or an array with strings to search and replace.
+ *
+ * If subject is an array, then the search and
+ * replace is performed on every entry of subject,
+ * and the return value is an array as well.
+ * @param int $limit The maximum possible replacements for each pattern in each
+ * subject string. Defaults to
+ * -1 (no limit).
+ * @param int $count If specified, this variable will be filled with the number of
+ * replacements done.
+ * @return string|array|null preg_replace returns an array if the
+ * subject parameter is an array, or a string
+ * otherwise.
+ *
+ * If matches are found, the new subject will
+ * be returned, otherwise subject will be
+ * returned unchanged.
+ *
+ * Returns a file pointer resource on success, .
+ * @throws PcreException
+ *
+ */
+function preg_replace($pattern, $replacement, $subject, int $limit = -1, int &$count = null)
+{
+    error_clear_last();
+    $result = \preg_replace($pattern, $replacement, $subject, $limit, $count);
+    var_dump($result);
+    if (preg_last_error() !== PREG_NO_ERROR) {
+        // TODO: PcreException should use code here: http://php.net/manual/en/function.preg-last-error.php
+        throw PcreException::createFromPhpError();
     }
     return $result;
 }

--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -12,7 +12,6 @@ use Safe\Exceptions\ApcException;
 use Safe\Exceptions\ApcuException;
 use Safe\Exceptions\JsonException;
 use Safe\Exceptions\PcreException;
-use function var_dump;
 
 /**
  * Wrapper for json_decode that throws when an error occurs.

--- a/rector-migrate.yml
+++ b/rector-migrate.yml
@@ -1075,3 +1075,4 @@ services:
       json_decode: 'Safe\json_decode'
       apc_fetch: 'Safe\apc_fetch'
       apcu_fetch: 'Safe\apcu_fetch'
+      preg_replace: 'Safe\preg_replace'


### PR DESCRIPTION
preg_replace returns "NULL" instead of "false" on error.

This PR adds `preg_replace` to the list of functions.

Closes #71 