### PR TITLE
Dropping call_user_func_array from Safe functions

### DIFF
--- a/generated/funchand.php
+++ b/generated/funchand.php
@@ -5,27 +5,6 @@ namespace Safe;
 use Safe\Exceptions\FunchandException;
 
 /**
- * Calls the callback given by the first parameter with
- * the parameters in param_arr.
- *
- * @param callable $callback The callable to be called.
- * @param array $param_arr The parameters to be passed to the callback, as an indexed array.
- * @return mixed Returns the return value of the callback, .
- * @throws FunchandException
- *
- */
-function call_user_func_array(callable $callback, array $param_arr)
-{
-    error_clear_last();
-    $result = \call_user_func_array($callback, $param_arr);
-    if ($result === false) {
-        throw FunchandException::createFromPhpError();
-    }
-    return $result;
-}
-
-
-/**
  * Creates an anonymous function from the parameters passed, and
  * returns a unique name for it.
  *

--- a/generated/functionsList.php
+++ b/generated/functionsList.php
@@ -198,7 +198,6 @@ return [
     'ftp_site',
     'ftp_ssl_connect',
     'ftp_systype',
-    'call_user_func_array',
     'create_function',
     'forward_static_call_array',
     'forward_static_call',

--- a/generator/config/ignoredFunctions.php
+++ b/generator/config/ignoredFunctions.php
@@ -9,4 +9,5 @@ return [
     'oci_lob_copy',
     'func_get_arg',
     //'mktime', // 7th parameter has been removed in PHP 7
+    'call_user_func_array',
 ];

--- a/rector-migrate.yml
+++ b/rector-migrate.yml
@@ -199,7 +199,6 @@ services:
       ftp_site: 'Safe\ftp_site'
       ftp_ssl_connect: 'Safe\ftp_ssl_connect'
       ftp_systype: 'Safe\ftp_systype'
-      call_user_func_array: 'Safe\call_user_func_array'
       create_function: 'Safe\create_function'
       forward_static_call_array: 'Safe\forward_static_call_array'
       forward_static_call: 'Safe\forward_static_call'


### PR DESCRIPTION
`call_user_func_array` can legitimately return false.
+ there is no sane way to handle protected methods.

Closes #73 

Warning, this PR introduces breaking changes.