### PR TITLE
Remove phpdoc return type of null for preg_replace

### DIFF
--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -139,7 +139,7 @@ function apcu_fetch($key)
  * -1 (no limit).
  * @param int $count If specified, this variable will be filled with the number of
  * replacements done.
- * @return string|array|null preg_replace returns an array if the
+ * @return string|array preg_replace returns an array if the
  * subject parameter is an array, or a string
  * otherwise.
  *
@@ -147,7 +147,6 @@ function apcu_fetch($key)
  * be returned, otherwise subject will be
  * returned unchanged.
  *
- * Returns a file pointer resource on success, .
  * @throws PcreException
  *
  */


### PR DESCRIPTION
While moving preg_replace to special case the return type wasn't updated as it cannot be null anymore.