### PR TITLE
rector 0.3 is not the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ tool that performs instant refactoring of your application.
 First, you need to install Rector:
 
 ```bash
-$ composer require --dev rector/rector ^0.3
+$ composer require --dev rector/rector
 ```
 
 Now, you simply need to run Rector with this command:


### PR DESCRIPTION
This PR removes the version constraint used to install rector as this constraint is now outdated