### PR TITLE
Remove forward_static_call and forward_static_call_array from supported functions

### DIFF
--- a/generated/fileinfo.php
+++ b/generated/fileinfo.php
@@ -43,7 +43,7 @@ function finfo_close($finfo): void
  * @throws FileinfoException
  *
  */
-function finfo_open(int $options = FILEINFO_NONE, ?string $magic_file = null)
+function finfo_open(int $options = FILEINFO_NONE, string $magic_file = "")
 {
     error_clear_last();
     $result = \finfo_open($options, $magic_file);

--- a/generated/filesystem.php
+++ b/generated/filesystem.php
@@ -800,7 +800,7 @@ function fopen(string $filename, string $mode, bool $use_include_path = false, $
 
 /**
  * fputcsv formats a line (passed as a
- * fields array) as CSV and write it (terminated by a
+ * fields array) as CSV and writes it (terminated by a
  * newline) to the specified file handle.
  *
  * @param resource $handle The file pointer must be valid, and must point to

--- a/generated/funchand.php
+++ b/generated/funchand.php
@@ -26,67 +26,6 @@ function create_function(string $args, string $code): string
 
 
 /**
- * Calls a user defined function or method given by the function
- * parameter. This function must be called within a method context, it can't be
- * used outside a class.
- * It uses the late static
- * binding.
- * All arguments of the forwarded method are passed as values,
- * and as an array, similarly to call_user_func_array.
- *
- * @param callable $function The function or method to be called. This parameter may be an array,
- * with the name of the class, and the method, or a string, with a function
- * name.
- * @param array $parameters One parameter, gathering all the method parameter in one array.
- *
- * Note that the parameters for forward_static_call_array are
- * not passed by reference.
- * @return mixed Returns the function result.
- * @throws FunchandException
- *
- */
-function forward_static_call_array(callable $function, array $parameters)
-{
-    error_clear_last();
-    $result = \forward_static_call_array($function, $parameters);
-    if ($result === false) {
-        throw FunchandException::createFromPhpError();
-    }
-    return $result;
-}
-
-
-/**
- * Calls a user defined function or method given by the function
- * parameter, with the following arguments. This function must be called within a method
- * context, it can't be used outside a class.
- * It uses the late static
- * binding.
- *
- * @param callable $function The function or method to be called. This parameter may be an array,
- * with the name of the class, and the method, or a string, with a function
- * name.
- * @param mixed $params Zero or more parameters to be passed to the function.
- * @return mixed Returns the function result.
- * @throws FunchandException
- *
- */
-function forward_static_call(callable $function, ...$params)
-{
-    error_clear_last();
-    if ($params !== []) {
-        $result = \forward_static_call($function, ...$params);
-    } else {
-        $result = \forward_static_call($function);
-    }
-    if ($result === false) {
-        throw FunchandException::createFromPhpError();
-    }
-    return $result;
-}
-
-
-/**
  *
  *
  * @param callable $function The function to register.

--- a/generated/functionsList.php
+++ b/generated/functionsList.php
@@ -201,8 +201,6 @@ return [
     'ftp_ssl_connect',
     'ftp_systype',
     'create_function',
-    'forward_static_call_array',
-    'forward_static_call',
     'register_tick_function',
     'gmp_binomial',
     'gmp_export',

--- a/generator/config/ignoredFunctions.php
+++ b/generator/config/ignoredFunctions.php
@@ -12,4 +12,6 @@ return [
     'call_user_func_array',
     'mb_check_encoding',
     'array_search',
+    'forward_static_call',
+    'forward_static_call_array',
 ];

--- a/rector-migrate.yml
+++ b/rector-migrate.yml
@@ -204,8 +204,6 @@ services:
       ftp_ssl_connect: 'Safe\ftp_ssl_connect'
       ftp_systype: 'Safe\ftp_systype'
       create_function: 'Safe\create_function'
-      forward_static_call_array: 'Safe\forward_static_call_array'
-      forward_static_call: 'Safe\forward_static_call'
       register_tick_function: 'Safe\register_tick_function'
       gmp_binomial: 'Safe\gmp_binomial'
       gmp_export: 'Safe\gmp_export'


### PR DESCRIPTION
These functions need to be called from inside a class and therefore cannot be wrapped by Safe.
Closes #128.