### PR TITLE
Json decode

### DIFF
--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -17,7 +17,7 @@ use Safe\Exceptions\PcreException;
 /**
  * Wrapper for json_decode that throws when an error occurs.
  *
- * @param string $json    JSON data to parse
+ * @param string|int|float|null $json    JSON data to parse
  * @param bool $assoc     When true, returned objects will be converted
  *                        into associative arrays.
  * @param int $depth   User specified recursion depth.
@@ -27,7 +27,7 @@ use Safe\Exceptions\PcreException;
  * @throws JsonException if the JSON cannot be decoded.
  * @link http://www.php.net/manual/en/function.json-decode.php
  */
-function json_decode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
+function json_decode($json, bool $assoc = false, int $depth = 512, int $options = 0)
 {
     $data = \json_decode($json, $assoc, $depth, $options);
     if (JSON_ERROR_NONE !== json_last_error()) {


### PR DESCRIPTION
json_decode accept as parameter integers, float and null in addition of strings. Boolean are casted into integers so i didn't include them 