### PR TITLE
remove apcu_delete from the safe list

### DIFF
--- a/generated/apcu.php
+++ b/generated/apcu.php
@@ -70,29 +70,6 @@ function apcu_dec(string $key, int $step = 1, ?bool &$success = null, int $ttl =
 
 
 /**
- * Removes a stored variable from the cache.
- *
- * @param string|string[]|\APCUIterator $key A key used to store the value as a
- * string for a single key,
- * or as an array of strings for several keys,
- * or as an APCUIterator object.
- * @return bool|array If key is an array, an indexed array of the keys is returned.
- * Otherwise TRUE is returned on success.
- * @throws ApcuException
- *
- */
-function apcu_delete($key)
-{
-    error_clear_last();
-    $result = \apcu_delete($key);
-    if ($result === false) {
-        throw ApcuException::createFromPhpError();
-    }
-    return $result;
-}
-
-
-/**
  * Increases a stored number.
  *
  * @param string $key The key of the value being increased.

--- a/generated/functionsList.php
+++ b/generated/functionsList.php
@@ -22,7 +22,6 @@ return [
     'apcu_cache_info',
     'apcu_cas',
     'apcu_dec',
-    'apcu_delete',
     'apcu_inc',
     'apcu_sma_info',
     'array_combine',

--- a/generator/config/ignoredFunctions.php
+++ b/generator/config/ignoredFunctions.php
@@ -15,4 +15,5 @@ return [
     'forward_static_call',
     'forward_static_call_array',
     'readdir', //the documentation is false: the function return false at the end of the iteration
+    'apcu_delete', //apcu_delete returns false when the $key does not exist in the cache store
 ];

--- a/rector-migrate.yml
+++ b/rector-migrate.yml
@@ -25,7 +25,6 @@ services:
       apcu_cache_info: 'Safe\apcu_cache_info'
       apcu_cas: 'Safe\apcu_cas'
       apcu_dec: 'Safe\apcu_dec'
-      apcu_delete: 'Safe\apcu_delete'
       apcu_inc: 'Safe\apcu_inc'
       apcu_sma_info: 'Safe\apcu_sma_info'
       array_combine: 'Safe\array_combine'


### PR DESCRIPTION
apcu_delete returns false when the $key does not exist in the cache store, and error_get_last() returns null in this case.