### PR TITLE
Fix PHP 7.4 warning for invalid array access

### DIFF
--- a/lib/Exceptions/AbstractSafeException.php
+++ b/lib/Exceptions/AbstractSafeException.php
@@ -8,6 +8,10 @@ abstract class AbstractSafeException extends \ErrorException implements SafeExce
     public static function createFromPhpError(): self
     {
         $error = error_get_last();
+        
+        if ($error === null) {
+            return new static();
+        }
 
         return new static($error['message'], 0, $error['type']);
     }


### PR DESCRIPTION
This warning is easily reproducable under PHP 7.4 with code like this:

```php
\Safe\strtotime('nonsense');
```

error_get_last() might return null and then an invalid array access occurs.
For more information see this RFC: https://wiki.php.net/rfc/notice-for-non-valid-array-container