### PR TITLE
Hard-coding coveralls secret

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -126,6 +126,9 @@ jobs:
           name: "build"
           path: "generator/build"
 
+      - name: "Debugging env vars"
+        run: "env"
+
       - name: "Upload test coverage to coveralls"
         run: "php vendor/bin/php-coveralls -v"
         working-directory: "generator"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -127,8 +127,7 @@ jobs:
           path: "generator/build"
 
       - name: "Upload test coverage to coveralls"
-        run: "php vendor/bin/php-coveralls -v"
-        working-directory: "generator"
-        env:
-          COVERALLS_REPO_TOKEN: "jkrVNjOvNxoqfyCSQ2QbIgbqP53QCkFmP"
-          COVERALLS_RUN_LOCALLY: 1
+        uses: "coverallsapp/github-action@master"
+        with:
+          github-token: "jkrVNjOvNxoqfyCSQ2QbIgbqP53QCkFmP"
+          path-to-lcov: "generator/build/logs/clover.xml"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -127,9 +127,8 @@ jobs:
           path: "generator/build"
 
       - name: "Upload test coverage to coveralls"
-        continue-on-error: true
         run: "php vendor/bin/php-coveralls -v"
         working-directory: "generator"
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_REPO_TOKEN: "jkrVNjOvNxoqfyCSQ2QbIgbqP53QCkFmP"
           COVERALLS_RUN_LOCALLY: 1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -127,7 +127,8 @@ jobs:
           path: "generator/build"
 
       - name: "Upload test coverage to coveralls"
-        uses: "coverallsapp/github-action@master"
-        with:
-          github-token: "jkrVNjOvNxoqfyCSQ2QbIgbqP53QCkFmP"
-          path-to-lcov: "generator/build/logs/clover.xml"
+        run: "php vendor/bin/php-coveralls -v"
+        working-directory: "generator"
+        env:
+          COVERALLS_REPO_TOKEN: "jkrVNjOvNxoqfyCSQ2QbIgbqP53QCkFmP"
+          COVERALLS_RUN_LOCALLY: 1


### PR DESCRIPTION
Putting the Coveralls secret in clear text (to be able to have coveralls info in forks)
This means anyone can push information in Safe coveralls. We are ok with that "risk"