### PR TITLE
Run CI fo PHP 7.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,7 @@ jobs:
         php-version:
           - "7.2"
           - "7.3"
+          - "7.4" 
 
         dependencies:
           - "highest"


### PR DESCRIPTION
**Edit:**
It fails with:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested PHP extension ext-json ^1.5 has the wrong version (7.4.3) installed. Install or enable PHP's json extension.
```

cc @localheinz 