### PR TITLE
Manage JSON_THROW_ON_ERROR conflict

### DIFF
--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -30,6 +30,15 @@ use Safe\Exceptions\PcreException;
  */
 function json_decode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
 {
+    if ($options & 4194304) { // options has JSON_THROW_ON_ERROR
+        try {
+            $data = \json_decode($json, $assoc, $depth, $options);
+        } catch (\Exception $e) {
+            throw new JsonException($e->getMessage(), (int) $e->getCode());
+        }
+        return $data;
+    }
+
     $data = \json_decode($json, $assoc, $depth, $options);
     if (JSON_ERROR_NONE !== json_last_error()) {
         throw JsonException::createFromPhpError();


### PR DESCRIPTION
Hi,

Consider the following code using the standard `json_decode` PHP function
```php
\json_decode('"incorrect json');
echo 'Error : ' . json_last_error() . PHP_EOL;
\json_decode('"correct json agin"');
echo 'Error : ' . json_last_error() . PHP_EOL;
```
It has the expected behavior.
```
Error : 3
Error : 0
```

---

Now have a look at this the following code using the standard `json_decode` PHP function
```php
\json_decode('"incorrect json');
echo 'Error : ' . json_last_error() . PHP_EOL;
\json_decode('"correct json"', false, 512, JSON_THROW_ON_ERROR);
echo 'Error : ' . json_last_error() . PHP_EOL;
```
It has comes to a weird behavior.
```
Error : 3
Error : 3
```

---

Due to the above, the Safe\json_decode function has this bug :
```php
try {
    json_decode('"incorrect json');
} catch (\Exception $e) {
    echo 'Error : ' . json_last_error() . PHP_EOL;
}
json_decode('"correct json"', false, 512, JSON_THROW_ON_ERROR);
```

This is throwing because of `json_last_error()` not being updated when using `JSON_THROW_ON_ERROR`.

---
For the record I found this bug because of a vendor using standard `json_decode` and then me calling safe version with `JSON_THROW_ON_ERROR`.