### PR TITLE
Change PHP requirement to prevent errors in PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
         ]
     },
     "require": {
-        "php": ">=7.2"
+        "php": "^7.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12",


### PR DESCRIPTION
Because the current code results in errors (at least when using Safe\DateTimeImmutable) in PHP 8, this package should not advertize compatibility with PHP 8.