### PR TITLE
Fix createFromFormat for PHP 8

### DIFF
--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -24,7 +24,7 @@ class DateTime extends \DateTime
      */
     public static function createFromFormat($format, $time, $timezone = null): self
     {
-        $datetime = parent::createFromFormat($format, $time, $timezone);
+        $datetime = \DateTime::createFromFormat($format, $time, $timezone);
         if ($datetime === false) {
             throw DatetimeException::createFromPhpError();
         }

--- a/lib/DateTimeImmutable.php
+++ b/lib/DateTimeImmutable.php
@@ -57,7 +57,7 @@ class DateTimeImmutable extends \DateTimeImmutable
      */
     public static function createFromFormat($format, $time, $timezone = null): self
     {
-        $datetime = parent::createFromFormat($format, $time, $timezone);
+        $datetime = \DateTimeImmutable::createFromFormat($format, $time, $timezone);
         if ($datetime === false) {
             throw DatetimeException::createFromPhpError();
         }


### PR DESCRIPTION
This should be a transparent fix for #250; I understand that this library should be abandoned, but this fix will allow us to use it under PHP 8.0 without this bug, buying us time to build a new major (or Safe8).