### PR TITLE
Added PHPStan-generics to preg_replace

### DIFF
--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -152,6 +152,9 @@ function apcu_fetch($key)
  *
  * @throws PcreException
  *
+ * @phpstan-template T of array|string
+ * @phpstan-param T $subject
+ * @phpstan-return T
  */
 function preg_replace($pattern, $replacement, $subject, int $limit = -1, int &$count = null)
 {


### PR DESCRIPTION
The subject in preg_replace can be a string or an arrays of strings. The return value is the same type as the provided subject. By adding the generics PHPStan 'knows' the correct return type in a situation like this:

```php
use function Safe\preg_replace;

$foo = 'some string 123';
$bar = preg_replace('/[0-9]/', '', $foo);
$baz = trim($bar); // PHPStan complains that trim does not accept string|string[]
```