### PR TITLE
Fix fputcsv annotation

### DIFF
--- a/generated/filesystem.php
+++ b/generated/filesystem.php
@@ -896,40 +896,6 @@ function fopen(string $filename, string $mode, bool $use_include_path = false, $
 
 
 /**
- * fputcsv formats a line (passed as a
- * fields array) as CSV and writes it (terminated by a
- * newline) to the specified file stream.
- *
- * @param resource $stream The file pointer must be valid, and must point to
- * a file successfully opened by fopen or
- * fsockopen (and not yet closed by
- * fclose).
- * @param array $fields An array of strings.
- * @param string $separator The optional separator parameter sets the field
- * delimiter (one single-byte character only).
- * @param string $enclosure The optional enclosure parameter sets the field
- * enclosure (one single-byte character only).
- * @param string $escape The optional escape parameter sets the
- * escape character (at most one single-byte character).
- * An empty string ("") disables the proprietary escape mechanism.
- * @param string $eol The optional eol parameter sets
- * a custom End of Line sequence.
- * @return int Returns the length of the written string.
- * @throws FilesystemException
- *
- */
-function fputcsv($stream, array $fields, string $separator = ",", string $enclosure = "\"", string $escape = "\\", string $eol = "\n"): int
-{
-    error_clear_last();
-    $result = \fputcsv($stream, $fields, $separator, $enclosure, $escape, $eol);
-    if ($result === false) {
-        throw FilesystemException::createFromPhpError();
-    }
-    return $result;
-}
-
-
-/**
  * fread reads up to
  * length bytes from the file pointer
  * referenced by stream. Reading stops as soon as one

--- a/generator/config/specialCasesFunctions.php
+++ b/generator/config/specialCasesFunctions.php
@@ -7,6 +7,7 @@ return [
     'json_decode',
     'apc_fetch',
     'apcu_fetch',
+    'fputcsv',
     'preg_replace',
     'openssl_encrypt',
     'readdir',

--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -7,6 +7,7 @@
 
 namespace Safe;
 
+use Safe\Exceptions\FilesystemException;
 use const PREG_NO_ERROR;
 
 use Safe\Exceptions\MiscException;
@@ -360,6 +361,47 @@ function posix_getpgid(int $process_id): int
     $result = \posix_getpgid($process_id);
     if ($result === false) {
         throw PosixException::createFromPhpError();
+    }
+    return $result;
+}
+
+
+/**
+ * fputcsv formats a line (passed as a
+ * fields array) as CSV and writes it (terminated by a
+ * newline) to the specified file stream.
+ *
+ * @param resource $stream The file pointer must be valid, and must point to
+ * a file successfully opened by fopen or
+ * fsockopen (and not yet closed by
+ * fclose).
+ * @phpstan-param (scalar|\Stringable|null)[] $fields
+ * @param array $fields An array of strings.
+ * @param string $separator The optional separator parameter sets the field
+ * delimiter (one single-byte character only).
+ * @param string $enclosure The optional enclosure parameter sets the field
+ * enclosure (one single-byte character only).
+ * @param string $escape The optional escape parameter sets the
+ * escape character (at most one single-byte character).
+ * An empty string ("") disables the proprietary escape mechanism.
+ * @param string $eol The optional eol parameter sets
+ * a custom End of Line sequence.
+ * @return int Returns the length of the written string.
+ * @throws FilesystemException
+ *
+ */
+function fputcsv($stream, array $fields, string $separator = ",", string $enclosure = "\"", string $escape = "\\", string $eol = "\n"): int
+{
+    error_clear_last();
+    if (PHP_VERSION_ID >= 80100) {
+        /** @phpstan-ignore-next-line */
+        $result = \fputcsv($stream, $fields, $separator, $enclosure, $escape, $eol);
+    } else {
+        $result = \fputcsv($stream, $fields, $separator, $enclosure, $escape);
+    }
+
+    if ($result === false) {
+        throw FilesystemException::createFromPhpError();
     }
     return $result;
 }


### PR DESCRIPTION
During #316 I restricted the type of the `$field` argument, and that triggered my static analysis tools while importing the fix.

As shown in https://3v4l.org/ahdmn, the original `fputcsv` function will try to cast everything to `string`, so every scalar is safe, array are risky (they become `Array`), objects explode, with the exception of stringable ones.