### PR TITLE
Updating the dev-master alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1-dev"
+            "dev-master": "2.2.x-dev"
         }
     }
 }


### PR DESCRIPTION
To be able to test the 2.2 release directly from Composer without tagging, we need  to point the dev-master alias to 2.2