### PR TITLE
Replace PSR-4 with classmap autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,13 @@
     "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
     "license": "MIT",
     "autoload": {
-        "psr-4": {
-            "Safe\\": [
-                "lib/",
-                "deprecated/",
-                "generated/"
-            ]
-        },
+        "classmap": [
+            "lib/DateTime.php",
+            "lib/DateTimeImmutable.php",
+            "lib/Exceptions/",
+            "deprecated/Exceptions/",
+            "generated/Exceptions/"
+        ],
         "files": [
             "deprecated/apc.php",
             "deprecated/array.php",


### PR DESCRIPTION
I am once again ~asking for your support~ trying to fix #253. 

I think this is the best approach (as discussed on [the phpdocparser issue](https://github.com/phpstan/phpdoc-parser/issues/117) ) and it's also much less disruptive than the renaming of all files done in #338.

I've tested the code with [this repo](https://github.com/j3j5/phpstan-larastan-bug), but please, test it yourselves to make sure I don't break anything else again :stuck_out_tongue: 

Hope this is the good one!