### PR TITLE
Make Safe\Exceptions\JsonException inherits from \JsonException

### DIFF
--- a/lib/Exceptions/JsonException.php
+++ b/lib/Exceptions/JsonException.php
@@ -3,7 +3,7 @@
 
 namespace Safe\Exceptions;
 
-class JsonException extends \Exception implements SafeExceptionInterface
+class JsonException extends \JsonException implements SafeExceptionInterface
 {
     public static function createFromPhpError(): self
     {


### PR DESCRIPTION
Currently the `Safe\json_` functions throws a `Safe\Exceptions\JsonException` which is not related to the standard PHP `JsonException`.

So this PR add intheritance between `Safe\Exceptions\JsonException` and `\JsonException` to solve this issue.