### PR TITLE
Link to step 1 rather then svn update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,5 +46,5 @@ All custom objects must be located in lib/ and custom functions must be in lib/s
 The continuous integration hooks will regenerate all the functions and check that the result is exactly what has been
 committed. Therefore, before submitting a PR, please:
 
-- Perform a "svn update"
+- Perform step 1 to update doc
 - Regenerate the files using `php ./safe.php generate`


### PR DESCRIPTION
Since not using svn anymore it seems confusing to talk about svn update at the end.
So I propose to link to step 1 of the contributor procedure which describes how to update doc before doing anything else.