### PR TITLE
Fix undefined sleep() function due to autoloading issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
             "deprecated/array.php",
             "deprecated/datetime.php",
             "deprecated/libevent.php",
+            "deprecated/misc.php",
             "deprecated/password.php",
             "deprecated/mssql.php",
             "deprecated/stats.php",


### PR DESCRIPTION
PR #387 moved the now-deprecated `sleep()` function into a new `deprecated/misc.php` file.  However, this file is not present in the autoloader configuration, resulting in this fatal error when using v2.3.0:

```
PHP Fatal error:  Uncaught Error: Call to undefined function Safe\sleep()
```

Adding `deprecated/misc.php` seems to fix this, as tested with this simple script:

```php
<?php

require_once 'vendor/autoload.php';

use function Safe\sleep;

sleep(1);
```