### PR TITLE
stream_filter_append & stream_filter_prepend use mixed instead of array

### DIFF
--- a/generated/curl.php
+++ b/generated/curl.php
@@ -3109,17 +3109,6 @@ function curl_multi_setopt(\CurlMultiHandle $multi_handle, int $option, $value):
  *
  *
  *
- * CURLOPT_XFERINFOFUNCTION
- *
- * A callback accepting two parameters.
- * Has a similar purpose as CURLOPT_PROGRESSFUNCTION but is more modern
- * and the preferred option from cURL.
- *
- *
- * Added in 7.32.0. Available as of PHP 8.2.0.
- *
- *
- *
  *
  *
  *

--- a/generated/curl.php
+++ b/generated/curl.php
@@ -3109,6 +3109,17 @@ function curl_multi_setopt(\CurlMultiHandle $multi_handle, int $option, $value):
  *
  *
  *
+ * CURLOPT_XFERINFOFUNCTION
+ *
+ * A callback accepting two parameters.
+ * Has a similar purpose as CURLOPT_PROGRESSFUNCTION but is more modern
+ * and the preferred option from cURL.
+ *
+ *
+ * Added in 7.32.0. Available as of PHP 8.2.0.
+ *
+ *
+ *
  *
  *
  *

--- a/generated/stream.php
+++ b/generated/stream.php
@@ -73,7 +73,7 @@ function stream_copy_to_stream($from, $to, int $length = null, int $offset = 0):
  * STREAM_FILTER_WRITE, and/or
  * STREAM_FILTER_ALL can also be passed to the
  * read_write parameter to override this behavior.
- * @param array $params This filter will be added with the specified
+ * @param mixed $params This filter will be added with the specified
  * params to the end of
  * the list and will therefore be called last during stream operations.
  * To add a filter to the beginning of the list, use
@@ -87,7 +87,7 @@ function stream_copy_to_stream($from, $to, int $length = null, int $offset = 0):
  * @throws StreamException
  *
  */
-function stream_filter_append($stream, string $filtername, int $read_write = null, array $params = null)
+function stream_filter_append($stream, string $filtername, int $read_write = null, mixed $params = null)
 {
     error_clear_last();
     if ($params !== null) {

--- a/generated/stream.php
+++ b/generated/stream.php
@@ -87,7 +87,7 @@ function stream_copy_to_stream($from, $to, int $length = null, int $offset = 0):
  * @throws StreamException
  *
  */
-function stream_filter_append($stream, string $filtername, int $read_write = null, mixed $params = null)
+function stream_filter_append($stream, string $filtername, int $read_write = null, $params = null)
 {
     error_clear_last();
     if ($params !== null) {
@@ -123,7 +123,7 @@ function stream_filter_append($stream, string $filtername, int $read_write = nul
  * read_write parameter to override this behavior.
  * See stream_filter_append for an example of
  * using this parameter.
- * @param array $params This filter will be added with the specified params
+ * @param mixed $params This filter will be added with the specified params
  * to the beginning of the list and will therefore be
  * called first during stream operations.  To add a filter to the end of the
  * list, use stream_filter_append.
@@ -136,7 +136,7 @@ function stream_filter_append($stream, string $filtername, int $read_write = nul
  * @throws StreamException
  *
  */
-function stream_filter_prepend($stream, string $filtername, int $read_write = null, array $params = null)
+function stream_filter_prepend($stream, string $filtername, int $read_write = null, $params = null)
 {
     error_clear_last();
     if ($params !== null) {

--- a/generator/config/CustomPhpStanFunctionMap.php
+++ b/generator/config/CustomPhpStanFunctionMap.php
@@ -38,4 +38,6 @@ return [
     'fgetcsv' => ['array|false|null', 'fp'=>'resource', 'length='=>'0|positive-int', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'], //phpstan default return type is too hard to analyse
     //todo: edit the reader to turn 0|1 into int
     'preg_match' => ['int|false', 'pattern'=>'string', 'subject'=>'string', '&w_subpatterns='=>'string[]', 'flags='=>'int', 'offset='=>'int'], //int|false instead of 0|1|false
+    'stream_filter_prepend' => ['resource', 'stream' => 'resource', 'filtername' => 'string', 'read_write' => 'int', 'params' => 'mixed'], // params mixed instead of array
+    'stream_filter_append' => ['resource', 'stream' => 'resource', 'filtername' => 'string', 'read_write' => 'int', 'params' => 'mixed'], // params mixed instead of array
 ];


### PR DESCRIPTION
https://www.php.net/manual/en/function.stream-filter-append.php
Defines `stream_filter_append` as :
```
stream_filter_append(
    resource $stream,
    string $filtername,
    int $read_write = ?,
    [mixed](https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.mixed) $params = ?
): resource
```
This PR aims to fix the inconsistency as here `$params` is defined as `array`.

Also updates https://www.php.net/manual/en/function.stream-filter-prepend.php