### PR TITLE
specify Safe\createFromMutable return changing type for php8.2

### DIFF
--- a/lib/DateTimeImmutable.php
+++ b/lib/DateTimeImmutable.php
@@ -232,6 +232,7 @@ class DateTimeImmutable extends \DateTimeImmutable
      * @param \DateTime $dateTime
      * @return DateTimeImmutable
      */
+	#[\ReturnTypeWillChange]
     public static function createFromMutable($dateTime): self
     {
         $date = \DateTimeImmutable::createFromMutable($dateTime);

--- a/lib/DateTimeImmutable.php
+++ b/lib/DateTimeImmutable.php
@@ -232,7 +232,7 @@ class DateTimeImmutable extends \DateTimeImmutable
      * @param \DateTime $dateTime
      * @return DateTimeImmutable
      */
-	#[\ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public static function createFromMutable($dateTime): self
     {
         $date = \DateTimeImmutable::createFromMutable($dateTime);


### PR DESCRIPTION
When migrating to PHP8.2 I have the following issue with Safe\createFromMutable

<img width="1428" alt="Capture d’écran 2022-12-28 à 15 07 43" src="https://user-images.githubusercontent.com/6584067/209824396-a08b2979-30fd-4780-9c28-0c2784054a4f.png">

Adding #[\ReturnTypeWillChange] fixes it.

I don't know if it's the best solution, but it's my proposition.

Feel free to tell me what should be done if this not the appropriate solution