### PR TITLE
FIX: Fix openssl_pkey_get_* functions

### DIFF
--- a/generated/openssl.php
+++ b/generated/openssl.php
@@ -1482,4 +1482,3 @@ function openssl_x509_read($certificate): \OpenSSLCertificate
     }
     return $safeResult;
 }
-

--- a/generated/openssl.php
+++ b/generated/openssl.php
@@ -969,6 +969,35 @@ function openssl_pkey_export($key, ?string &$output, ?string $passphrase = null,
 
 
 /**
+ * This function returns the key details (bits, key, type).
+ *
+ * @param \OpenSSLAsymmetricKey $key Resource holding the key.
+ * @return array Returns an array with the key details on success.
+ * Returned array has indexes bits (number of bits),
+ * key (string representation of the public key) and
+ * type (type of the key which is one of
+ * OPENSSL_KEYTYPE_RSA,
+ * OPENSSL_KEYTYPE_DSA,
+ * OPENSSL_KEYTYPE_DH,
+ * OPENSSL_KEYTYPE_EC or -1 meaning unknown).
+ *
+ * Depending on the key type used, additional details may be returned. Note that
+ * some elements may not always be available.
+ * @throws OpensslException
+ *
+ */
+function openssl_pkey_get_details(\OpenSSLAsymmetricKey $key): array
+{
+    error_clear_last();
+    $safeResult = \openssl_pkey_get_details($key);
+    if ($safeResult === false) {
+        throw OpensslException::createFromPhpError();
+    }
+    return $safeResult;
+}
+
+
+/**
  * openssl_pkey_get_private parses
  * private_key and prepares it for use by other functions.
  *
@@ -1007,7 +1036,7 @@ function openssl_pkey_get_private($private_key, ?string $passphrase = null): \Op
  * public_key and prepares it for use by other
  * functions.
  *
- * @param resource|string $public_key public_key can be one of the following:
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key public_key can be one of the following:
  *
  * an OpenSSLAsymmetricKey instance
  * a string having the format
@@ -1017,11 +1046,11 @@ function openssl_pkey_get_private($private_key, ?string $passphrase = null): \Op
  *
  * A PEM formatted public key.
  *
- * @return resource Returns an OpenSSLAsymmetricKey instance on success.
+ * @return \OpenSSLAsymmetricKey Returns an OpenSSLAsymmetricKey instance on success.
  * @throws OpensslException
  *
  */
-function openssl_pkey_get_public($public_key)
+function openssl_pkey_get_public($public_key): \OpenSSLAsymmetricKey
 {
     error_clear_last();
     $safeResult = \openssl_pkey_get_public($public_key);
@@ -1453,3 +1482,4 @@ function openssl_x509_read($certificate): \OpenSSLCertificate
     }
     return $safeResult;
 }
+

--- a/generated/openssl.php
+++ b/generated/openssl.php
@@ -972,7 +972,7 @@ function openssl_pkey_export($key, ?string &$output, ?string $passphrase = null,
  * openssl_pkey_get_private parses
  * private_key and prepares it for use by other functions.
  *
- * @param string $private_key private_key can be one of the following:
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key can be one of the following:
  *
  * a string having the format
  * file://path/to/file.pem. The named file must
@@ -981,13 +981,13 @@ function openssl_pkey_export($key, ?string &$output, ?string $passphrase = null,
  *
  * A PEM formatted private key.
  *
- * @param string $passphrase The optional parameter passphrase must be used
+ * @param string|null $passphrase The optional parameter passphrase must be used
  * if the specified key is encrypted (protected by a passphrase).
- * @return resource Returns an OpenSSLAsymmetricKey instance on success.
+ * @return \OpenSSLAsymmetricKey Returns an OpenSSLAsymmetricKey instance on success.
  * @throws OpensslException
  *
  */
-function openssl_pkey_get_private(string $private_key, string $passphrase = null)
+function openssl_pkey_get_private($private_key, ?string $passphrase = null): \OpenSSLAsymmetricKey
 {
     error_clear_last();
     if ($passphrase !== null) {

--- a/generator/config/CustomPhpStanFunctionMap.php
+++ b/generator/config/CustomPhpStanFunctionMap.php
@@ -26,6 +26,8 @@ return [
     'curl_share_errno' => ['int', 'share_handle' => 'CurlShareHandle'],
     'curl_share_setopt' => ['void', 'share_handle' => 'CurlShareHandle', 'option' => 'int', 'value' => 'mixed'],
     'curl_unescape' => ['string', 'handle' => 'CurlHandle', 'string' => 'string'],
+    // theses replace ressource by OpenSSLAsymmetricKey
+    'openssl_pkey_get_private' => ['OpenSSLAsymmetricKey|false', 'private_key'=>'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string', 'passphrase='=>'null|string'],
     // theses replace ressource by OpenSSLCertificate
     'openssl_verify' => ['-1|0|1|false', 'data'=>'string', 'signature'=>'string', 'pub_key_id'=>' OpenSSLAsymmetricKey|OpenSSLCertificate|string', 'signature_alg='=>'int|string'],
     'openssl_x509_read' => ['OpenSSLCertificate|false', 'x509certdata'=>'OpenSSLCertificate|string'], // this replaces ressource by OpenSSLCertificate

--- a/generator/config/CustomPhpStanFunctionMap.php
+++ b/generator/config/CustomPhpStanFunctionMap.php
@@ -27,7 +27,9 @@ return [
     'curl_share_setopt' => ['void', 'share_handle' => 'CurlShareHandle', 'option' => 'int', 'value' => 'mixed'],
     'curl_unescape' => ['string', 'handle' => 'CurlHandle', 'string' => 'string'],
     // theses replace ressource by OpenSSLAsymmetricKey
+    'openssl_pkey_get_details' => ['array|false', 'key'=>'OpenSSLAsymmetricKey'],
     'openssl_pkey_get_private' => ['OpenSSLAsymmetricKey|false', 'private_key'=>'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string', 'passphrase='=>'null|string'],
+    'openssl_pkey_get_public' => ['OpenSSLAsymmetricKey|false', 'public_key'=>'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string'],
     // theses replace ressource by OpenSSLCertificate
     'openssl_verify' => ['-1|0|1|false', 'data'=>'string', 'signature'=>'string', 'pub_key_id'=>' OpenSSLAsymmetricKey|OpenSSLCertificate|string', 'signature_alg='=>'int|string'],
     'openssl_x509_read' => ['OpenSSLCertificate|false', 'x509certdata'=>'OpenSSLCertificate|string'], // this replaces ressource by OpenSSLCertificate

--- a/rector-migrate.php
+++ b/rector-migrate.php
@@ -675,6 +675,7 @@ return static function (RectorConfig $rectorConfig): void {
             'openssl_pkey_derive' => 'Safe\openssl_pkey_derive',
             'openssl_pkey_export' => 'Safe\openssl_pkey_export',
             'openssl_pkey_export_to_file' => 'Safe\openssl_pkey_export_to_file',
+            'openssl_pkey_get_details' => 'Safe\openssl_pkey_get_details',
             'openssl_pkey_get_private' => 'Safe\openssl_pkey_get_private',
             'openssl_pkey_get_public' => 'Safe\openssl_pkey_get_public',
             'openssl_pkey_new' => 'Safe\openssl_pkey_new',


### PR DESCRIPTION
- Fixed the input and output of the `openssl_pkey_get_private` function as starting from PHP 8.0 it accepts:
	- `\OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string` for `$private_key`
	- `null|string` for `$passphrase`
and returns `OpenSSLAsymmetricKey|false`.

- Fixed the input and output of the `openssl_pkey_get_public` function as starting from PHP 8.0 it accepts:
	- `\OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string` for `$public_key`
and returns `OpenSSLAsymmetricKey|false`.

- Added `openssl_pkey_get_details` function as it's actually falsy, but was not picked up by automatic code generation because of wording in PHP docs, but now is after [this change](https://github.com/php/doc-en/commit/0e80601cabf499c7db372149916b5cb3e2740f1b).