### PR TITLE
Clear previous error for json_decode

### DIFF
--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -35,6 +35,8 @@ use Safe\Exceptions\SimplexmlException;
  */
 function json_decode(string $json, bool $assoc = false, int $depth = 512, int $flags = 0): mixed
 {
+    // Ensure json_last_error() is cleared...
+    \json_decode('[]');
     $data = \json_decode($json, $assoc, $depth, $flags);
     if (JSON_ERROR_NONE !== json_last_error()) {
         throw JsonException::createFromPhpError();

--- a/tests/SpecialCasesTest.php
+++ b/tests/SpecialCasesTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class SpecialCasesTest extends TestCase
+{
+    public function testJsonDecodeThrowsNoErrorOnValidJson(): void
+    {
+        \json_decode('throws an error');
+        $array = \Safe\json_decode('[]', false, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame([], $array);
+    }
+}


### PR DESCRIPTION
If you (or your framework) calls the native `json_decode` function with an invalid JSON string, it will save the last error in `json_last_error()`.

If you then call the Safe function, you will get an error on a valid JSON.

The solution could be to call the native `json_decode` function once with a valid JSON to clear the last error.

Copied from: https://github.com/laravel/framework/pull/42125/files#diff-35f0fed0fb4be3d1d696cb36c7266cd36daed1aa31c9f74394c38620620776b4R77