### PR TITLE
Add custom base64_decode fcn mapping

### DIFF
--- a/generator/config/CustomPhpStanFunctionMap.php
+++ b/generator/config/CustomPhpStanFunctionMap.php
@@ -6,6 +6,7 @@
  */
 
 return [
+    'base64_decode' => ['string|false', 'str'=>'string', 'strict='=>'bool'], // base64_decode returns false only in strict mode https://github.com/phpstan/phpstan-src/commit/cee66721266ae05f3cc052f82391d2645d74d55f
     'password_hash' => ['string|false', 'password'=>'string', 'algo'=>'int|string|null', 'options='=>'array'],
     'com_load_typelib' => ['bool', 'typelib_name'=>'string', 'case_insensitive='=>'bool'], // case_insensitive is a bool
     'sem_get' => ['resource|false', 'key'=>'int', 'max_acquire='=>'int', 'perm='=>'int', 'auto_release='=>'bool'], // auto_release is a bool


### PR DESCRIPTION
Phpstan defines multiple variants now which breaks it for Safe https://github.com/phpstan/phpstan-src/blob/80ce9a404787133ff3fa266f90602728bf1c349c/resources/functionMap.php#L410-L411