### PR TITLE
Fix `json_decode` `associative` argument consistency with PHP

### DIFF
--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -24,7 +24,7 @@ use Safe\Exceptions\SimplexmlException;
  * Wrapper for json_decode that throws when an error occurs.
  *
  * @param string $json    JSON data to parse
- * @param bool $assoc     When true, returned objects will be converted
+ * @param bool $associative     When true, returned objects will be converted
  *                        into associative arrays.
  * @param int<1, max> $depth   User specified recursion depth.
  * @param int $flags Bitmask of JSON decode options.
@@ -33,9 +33,9 @@ use Safe\Exceptions\SimplexmlException;
  * @throws JsonException if the JSON cannot be decoded.
  * @link http://www.php.net/manual/en/function.json-decode.php
  */
-function json_decode(string $json, bool $assoc = false, int $depth = 512, int $flags = 0): mixed
+function json_decode(string $json, bool $associative = false, int $depth = 512, int $flags = 0): mixed
 {
-    $data = \json_decode($json, $assoc, $depth, $flags);
+    $data = \json_decode($json, $associative, $depth, $flags);
     if (JSON_ERROR_NONE !== json_last_error()) {
         throw JsonException::createFromPhpError();
     }


### PR DESCRIPTION
I like to use named arguments with `\json_decode()`, particularly with the `associative` argument.

e.g. `\json_decode($json, associative: true);`

Switching to use `thecodingmachine/safe` currently necessitates switching `associative` to `assoc`. This slows down migrations and introduces an inconsistency.

We should fix the named argument of `\Safe\json_decode` so it has the same name as PHP.