### PR TITLE
Fix broken generation

### DIFF
--- a/generator/composer.json
+++ b/generator/composer.json
@@ -19,7 +19,7 @@
     "thecodingmachine/phpstan-strict-rules": "^1.0",
     "squizlabs/php_codesniffer": "^3.2",
     "php-coveralls/php-coveralls": "^2.1",
-    "phpstan/phpstan": "^1.5"
+    "phpstan/phpstan": "^1.10.40"
   },
   "scripts": {
     "test": "vendor/bin/phpunit",

--- a/generator/composer.lock
+++ b/generator/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6c94263becd754b8ce74fbcf96c6508",
+    "content-hash": "a43476896e0a54cafaec559e0b9a68f6",
     "packages": [
         {
             "name": "psr/container",
@@ -1596,16 +1596,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.5.0",
+            "version": "1.10.62",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "2be8dd6dfa09ab1a21c49956ff591979cd5ab29e"
+                "reference": "cd5c8a1660ed3540b211407c77abf4af193a6af9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2be8dd6dfa09ab1a21c49956ff591979cd5ab29e",
-                "reference": "2be8dd6dfa09ab1a21c49956ff591979cd5ab29e",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/cd5c8a1660ed3540b211407c77abf4af193a6af9",
+                "reference": "cd5c8a1660ed3540b211407c77abf4af193a6af9",
                 "shasum": ""
             },
             "require": {
@@ -1629,9 +1629,16 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
             "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.5.0"
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
             },
             "funding": [
                 {
@@ -1643,15 +1650,11 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://www.patreon.com/phpstan",
-                    "type": "patreon"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-24T18:18:00+00:00"
+            "time": "2024-03-13T12:27:20+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3962,5 +3965,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/generator/src/PhpStanFunctions/PhpStanFunction.php
+++ b/generator/src/PhpStanFunctions/PhpStanFunction.php
@@ -23,7 +23,7 @@ class PhpStanFunction
         if (count($signature) < 1) {
             throw new \RuntimeException('Invalid signoatures');
         }
-        $this->returnType = new PhpStanType(\array_shift($signature));
+        $this->returnType = new PhpStanType(\array_shift($signature), false, true);
         foreach ($signature as $name => $type) {
             $param = new PhpStanParameter($name, $type);
             $this->parameters[$param->getName()] = $param;

--- a/generator/src/PhpStanFunctions/PhpStanParameter.php
+++ b/generator/src/PhpStanFunctions/PhpStanParameter.php
@@ -26,7 +26,7 @@ class PhpStanParameter
         $name = trim($name, '=.&');
 
         $this->name = $name;
-        $this->type = new PhpStanType($type, $writeOnly);
+        $this->type = new PhpStanType($type, $writeOnly, false);
     }
 
     /**

--- a/generator/src/PhpStanFunctions/PhpStanType.php
+++ b/generator/src/PhpStanFunctions/PhpStanType.php
@@ -30,7 +30,7 @@ class PhpStanType
      */
     private $types;
 
-    public function __construct(string $data, bool $writeOnly = false)
+    public function __construct(string $data, bool $writeOnly = false, bool $isReturnType = false)
     {
         //weird case: null|false => null
         if ($data === 'null|false') {
@@ -57,6 +57,9 @@ class PhpStanType
         if (($falsablePosition = \array_search('false', $returnTypes)) !== false) {
             $falsable = true;
             \array_splice($returnTypes, (int) $falsablePosition, 1);
+            if ($isReturnType === false) {
+                $returnTypes[] = 'bool';
+            }
         }
         /** @var int $count */
         $count = \count($returnTypes);
@@ -76,9 +79,13 @@ class PhpStanType
             //here we deal with some weird phpstan typings
             if ($returnType === 'non-empty-string') {
                 $returnType = 'string';
+            } elseif ($returnType === 'non-falsy-string') {
+                $returnType = 'string';
             } elseif ($returnType === 'positive-int') {
                 $returnType = 'int';
             } elseif (is_numeric($returnType)) {
+                $returnType = 'int';
+            } elseif (\strpos($returnType, 'int<') !== false) {
                 $returnType = 'int';
             }
             if (\strpos($returnType, 'list<') !== false) {


### PR DESCRIPTION
This PR fixes currently broken generation by:
- Upgrading minimum PHPStan version to one where [this fix was release](https://github.com/phpstan/phpstan-src/commit/110ab291cdd70be080c0a023c467052b8b461c74);
- Adding conditions for extra functionality that has been added to PHPStans `functionMap`.