### PR TITLE
Drop double \ from parameter types

### DIFF
--- a/generator/src/WritePhpFunction.php
+++ b/generator/src/WritePhpFunction.php
@@ -170,7 +170,7 @@ class WritePhpFunction
             $paramsAsString[] = $paramAsString;
         }
 
-        return implode(', ', $paramsAsString);
+        return str_replace('\\\\', '\\', implode(', ', $paramsAsString));
     }
 
     private function printFunctionCall(Method $function): string


### PR DESCRIPTION
Currently the generation of files is failing due to ?\\DateTimeZone in a nullable parameter on at least one function. This changeset fixes that a bit crudely but effectively.