### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian:stable
+ARG DEBIAN_FRONTEND=noninteractive
+ARG XDEBUG_MODE=coverage
+RUN apt update -y && apt install -y git composer php-cli php-dom php-curl php-xdebug vim
+WORKDIR /app
+CMD cd /app/generator/doc && ./update.sh && cd /app/generator && composer install && php ./safe.php generate && composer cs-fix

--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd $(dirname $0)/../
+docker run --rm -v ${PWD}:/app $(docker build -q -f .devcontainer/Dockerfile .)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+	"name": "Safe PHP",
+	"build": {
+		"context": "..",
+		"dockerfile": "./Dockerfile"
+	},
+
+	"workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind",
+	"workspaceFolder": "/app"
+}

--- a/.devcontainer/run.sh
+++ b/.devcontainer/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd $(dirname $0)/../
+docker run --rm -ti -v ${PWD}:/app $(docker build -q . -f .devcontainer/Dockerfile) /bin/bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,19 @@
 
 Safe-PHP code is generated automatically from the PHP doc.
 
+## Install dependencies
+
+### With a devcontainer
+
+If you use VSCode or similar, opening the project folder should prompt you to
+re-open the folder inside a docker container with all the relevant tools
+pre-installed.
+
+### Manually
+
+- php8.2+ CLI (with dom and curl modules)
+- composer
+
 ## How to install Safe-PHP development environment
 
 The first step is to download the PHP documentation project locally, using git.


### PR DESCRIPTION

(breaking shish/safe down into smaller parts for easier merging)

These configs make it so that one can open the Safe project in a compatible editor (eg vscode) and the IDE will do all the work (eg build, test) in a self-contained container with all the right versions of all the right tools installed. This is particularly useful for Safe, whose build process only runs with specific PHP versions, which may differ from what is installed on the developer's host system.
