### PR TITLE
Remove dev-master aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![Latest Stable Version](https://poser.pugx.org/thecodingmachine/safe/v/stable.svg)](https://packagist.org/packages/thecodingmachine/safe)
+[![Latest Version](https://poser.pugx.org/thecodingmachine/safe/v/stable.svg)](https://packagist.org/packages/thecodingmachine/safe)
 [![Total Downloads](https://poser.pugx.org/thecodingmachine/safe/downloads.svg)](https://packagist.org/packages/thecodingmachine/safe)
-[![Latest Unstable Version](https://poser.pugx.org/thecodingmachine/safe/v/unstable.svg)](https://packagist.org/packages/thecodingmachine/safe)
 [![License](https://poser.pugx.org/thecodingmachine/safe/license.svg)](https://packagist.org/packages/thecodingmachine/safe)
 [![Build Status](https://travis-ci.org/thecodingmachine/safe.svg?branch=master)](https://travis-ci.org/thecodingmachine/safe)
 [![Continuous Integration](https://github.com/thecodingmachine/safe/workflows/Continuous%20Integration/badge.svg)](https://github.com/thecodingmachine/safe/actions)

--- a/composer.json
+++ b/composer.json
@@ -114,10 +114,5 @@
         "phpstan": "phpstan analyse lib -c phpstan.neon --level=max --no-progress -vvv",
         "cs-fix": "phpcbf",
         "cs-check": "phpcs"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.2.x-dev"
-        }
     }
 }

--- a/generator/composer.json
+++ b/generator/composer.json
@@ -26,10 +26,5 @@
     "phpstan": "phpstan analyse src -c phpstan.neon --level=max --no-progress -vvv",
     "cs-fix": "phpcbf",
     "cs-check": "phpcs"
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "0.1-dev"
-    }
   }
 }


### PR DESCRIPTION

These are referring to very out-of-date branches and anybody who uses them is going to have a bad time
