### PR TITLE
Bring deprecated override files up to php8.4 syntax

### DIFF
--- a/deprecated/datetime.php
+++ b/deprecated/datetime.php
@@ -21,7 +21,7 @@ use Safe\Exceptions\DatetimeException;
  * @deprecated The Safe version of this function is no longer needed in PHP 8.0+
  *
  */
-function gmdate(string $format, int $timestamp = null): string
+function gmdate(string $format, ?int $timestamp = null): string
 {
     error_clear_last();
     if ($timestamp !== null) {
@@ -75,7 +75,7 @@ function gmdate(string $format, int $timestamp = null): string
  * @deprecated The Safe version of this function is no longer needed in PHP 8.0+
  *
  */
-function mktime(int $hour, int $minute = null, int $second = null, int $month = null, int $day = null, int $year = null): int
+function mktime(int $hour, ?int $minute = null, ?int $second = null, ?int $month = null, ?int $day = null, ?int $year = null): int
 {
     error_clear_last();
     if ($year !== null) {

--- a/deprecated/mssql.php
+++ b/deprecated/mssql.php
@@ -97,7 +97,7 @@ function mssql_close($link_identifier = null): void
  * @throws MssqlException
  *
  */
-function mssql_connect(string $servername = null, string $username = null, string $password = null, bool $new_link = false)
+function mssql_connect(?string $servername = null, ?string $username = null, ?string $password = null, bool $new_link = false)
 {
     error_clear_last();
     if ($new_link !== false) {
@@ -330,7 +330,7 @@ function mssql_init(string $sp_name, $link_identifier = null)
  * @throws MssqlException
  *
  */
-function mssql_pconnect(string $servername = null, string $username = null, string $password = null, bool $new_link = false)
+function mssql_pconnect(?string $servername = null, ?string $username = null, ?string $password = null, bool $new_link = false)
 {
     error_clear_last();
     if ($new_link !== false) {

--- a/deprecated/password.php
+++ b/deprecated/password.php
@@ -112,7 +112,7 @@ use Safe\Exceptions\PasswordException;
  * @deprecated The Safe version of this function is no longer needed in PHP 8.0+
  *
  */
-function password_hash(string $password, $algo, array $options = null): string
+function password_hash(string $password, $algo, ?array $options = null): string
 {
     error_clear_last();
     if ($options !== null) {

--- a/deprecated/strings.php
+++ b/deprecated/strings.php
@@ -361,7 +361,7 @@ function sprintf(string $format, ...$params): string
  * @deprecated The Safe version of this function is no longer needed in PHP 8.0+
  *
  */
-function substr(string $string, int $start, int $length = null): string
+function substr(string $string, int $start, ?int $length = null): string
 {
     error_clear_last();
     if ($length !== null) {


### PR DESCRIPTION

(Breaking shish/safe changes down into smaller changes for easier review)

I also note that many of these are deprecated since php8.0 - at what point do we want to delete them?
