### PR TITLE
Force generator to use PHP 8.1.x

### DIFF
--- a/generator/composer.json
+++ b/generator/composer.json
@@ -26,5 +26,10 @@
     "phpstan": "phpstan analyse",
     "cs-fix": "phpcbf",
     "cs-check": "phpcs"
+  },
+  "config": {
+    "platform": {
+      "php": "8.1.31"
+    }
   }
 }


### PR DESCRIPTION
to improve DX, as before this PR the generator assumed composer would be run using a PHP 8.1 CLI.

lets define a platform version instead, so it no longer matters which PHP CLI version the developer is using to run composer