### PR TITLE
Detect nullable-default parameters and generate appropriate outputs

### DIFF
--- a/generator/src/Parameter.php
+++ b/generator/src/Parameter.php
@@ -80,7 +80,15 @@ class Parameter
 
     public function isNullable(): bool
     {
-        return $this->type->isNullable();
+        if ($this->type->isNullable()) {
+            return true;
+        }
+
+        if ($this->getDefaultValue() === "null") {
+            return true;
+        }
+
+        return $this->getDefaultValue() === "NULL";
     }
 
     /*
@@ -93,7 +101,7 @@ class Parameter
 
     public function hasDefaultValue(): bool
     {
-        return isset($this->parameter->initializer);
+        return property_exists($this->parameter, 'initializer') && $this->parameter->initializer !== null;
     }
 
     public function getDefaultValue(): ?string

--- a/generator/src/WritePhpFunction.php
+++ b/generator/src/WritePhpFunction.php
@@ -136,9 +136,21 @@ class WritePhpFunction
         $optDetected = false;
 
         foreach ($params as $param) {
-            $paramAsString = $param->getSignatureType();
+            $paramAsString = '';
+            $typeDetected = false;
+
+            // parameters can not have type void
+            if ($param->getSignatureType() !== 'void') {
+                $paramAsString = $param->getSignatureType();
+            }
+
             if ($paramAsString !== '') {
                 $paramAsString .= ' ';
+                if ($param->isNullable() && $paramAsString[0] !== "?") {
+                    $paramAsString = "?" . $paramAsString;
+                }
+
+                $typeDetected = true;
             }
 
             $paramName = $param->getParameterName();
@@ -160,6 +172,10 @@ class WritePhpFunction
                 $paramAsString .= ' = '.$this->defaultValueToString($defaultValue);
             } elseif ($optDetected && !$param->isVariadic()) {
                 $paramAsString .= ' = null';
+
+                if ($typeDetected && $paramAsString[0] !== "?") {
+                    $paramAsString = "?" . $paramAsString;
+                }
             }
             $paramsAsString[] = $paramAsString;
         }


### PR DESCRIPTION
This makes sure we are always generating explicitly-nullable parameters, even if the PHP documentation uses implicitly nullable (which is deprecated in php8.4)