### PR TITLE
make build.sh more accurately match what the github workflow does

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,4 +3,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG XDEBUG_MODE=coverage
 RUN apt update -y && apt install -y git composer php-cli php-dom php-curl php-xdebug vim
 WORKDIR /app
-CMD cd /app/generator/doc && ./update.sh && cd /app/generator && composer install && php ./safe.php generate && composer cs-fix
+CMD cd /app/generator/doc && ./update.sh && \
+    cd /app && composer install && \
+    cd /app/generator && composer install && php ./safe.php generate


### PR DESCRIPTION
we need to do `composer install` for both the generator and the generated files, because phpcbf needs to be run from the output directory, using the output-directory config files -- this PR makes it so that running `./.devcontainer/build.sh` should generate byte-identical output to the regen-bot