### PR TITLE
Convert "true" typehint to "bool"

### DIFF
--- a/generated/stream.php
+++ b/generated/stream.php
@@ -20,14 +20,13 @@ use Safe\Exceptions\StreamException;
  * @throws StreamException
  *
  */
-function stream_context_set_options($context, array $options): true
+function stream_context_set_options($context, array $options): void
 {
     error_clear_last();
     $safeResult = \stream_context_set_options($context, $options);
     if ($safeResult === false) {
         throw StreamException::createFromPhpError();
     }
-    return $safeResult;
 }
 
 

--- a/generator/src/PhpStanFunctions/PhpStanType.php
+++ b/generator/src/PhpStanFunctions/PhpStanType.php
@@ -148,6 +148,8 @@ class PhpStanType
                 $type = ''; // resource cant be typehinted
             } elseif (\strpos($type, 'null') !== false) {
                 $type = ''; // null is a real typehint
+            } elseif (\strpos($type, 'true') !== false) {
+                $type = 'bool'; // php8.1 doesn't support "true" as a typehint
             }
         }
 


### PR DESCRIPTION

php 8.1 doesn't support "true" as a typehint

(The generator will then normally see "function returns bool, except it never returns false because we convert false to exception, which means it only ever returns true, which means the return value is meaningless, so let's convert the return value to void" - which is why this change to the generator results in "returns void" for the generated output)
