### PR TITLE
Generate code which better matches our formatting standards

### DIFF
--- a/generator/src/FileCreator.php
+++ b/generator/src/FileCreator.php
@@ -35,10 +35,9 @@ class FileCreator
             \fwrite($stream, "<?php\n
 namespace Safe;
 
-use Safe\\Exceptions\\".self::toExceptionName($module). ';
-');
+use Safe\\Exceptions\\".self::toExceptionName($module). ';');
             foreach ($phpFunctions as $phpFunction) {
-                \fwrite($stream, $phpFunction."\n");
+                \fwrite($stream, "\n".$phpFunction);
             }
             \fclose($stream);
         }

--- a/generator/src/Parameter.php
+++ b/generator/src/Parameter.php
@@ -81,11 +81,7 @@ class Parameter
             return true;
         }
 
-        if ($this->getDefaultValue() === "null") {
-            return true;
-        }
-
-        return $this->getDefaultValue() === "NULL";
+        return ($this->getDefaultValue() === "null");
     }
 
     /*
@@ -112,6 +108,10 @@ class Parameter
         // Some default value have weird values. For instance, first parameter of "mb_internal_encoding" has default value "mb_internal_encoding()"
         if (strpos($initializer, '(') !== false) {
             return null;
+        }
+
+        if ($initializer === "NULL") {
+            return "null";
         }
 
         return $initializer;


### PR DESCRIPTION

Currently we generate it wrong and then the auto-formatter fixes it -- generating it correctly in the first place isn't hard though
