### PR TITLE
support union type from php documentation

### DIFF
--- a/generated/curl.php
+++ b/generated/curl.php
@@ -57,7 +57,7 @@ function curl_escape(\CurlHandle $handle, string $string): string
  * stdout and returns TRUE.
  * However, if the CURLOPT_RETURNTRANSFER
  * option is set, it will return
- * the result on success, FALSE on failure.
+ * the result on success.
  * @throws CurlException
  *
  */
@@ -284,7 +284,7 @@ function curl_init(?string $url = null): \CurlHandle
  * @param \CurlMultiHandle $multi_handle A cURL multi handle returned by
  * curl_multi_init.
  * @param int|null $queued_messages Number of messages that are still in the queue
- * @return array On success, returns an associative array for the message, FALSE on failure.
+ * @return array On success, returns an associative array for the message.
  *
  *
  * Contents of the returned array

--- a/generated/datetime.php
+++ b/generated/datetime.php
@@ -899,7 +899,7 @@ function strptime(string $timestamp, string $format): array
  * @param string $datetime A date/time string. Valid formats are explained in Date and Time Formats.
  * @param int $baseTimestamp The timestamp which is used as a base for the calculation of relative
  * dates.
- * @return int Returns a timestamp on success, FALSE otherwise.
+ * @return int Returns a timestamp on success.
  * @throws DatetimeException
  *
  */

--- a/generated/image.php
+++ b/generated/image.php
@@ -755,17 +755,18 @@ function imagecreate(int $width, int $height)
  * representing the image obtained from the given filename.
  *
  * @param string $filename Path to the AVIF raster image.
- * @return  Returns an image object on success, FALSE on errors.
+ * @return \GdImage Returns an image object on success, FALSE on errors.
  * @throws ImageException
  *
  */
-function imagecreatefromavif(string $filename): void
+function imagecreatefromavif(string $filename): \GdImage
 {
     error_clear_last();
     $safeResult = \imagecreatefromavif($filename);
     if ($safeResult === false) {
         throw ImageException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -939,17 +940,18 @@ function imagecreatefromstring(string $data)
  * representing the image obtained from the given filename.
  *
  * @param string $filename Path to the Truevision TGA image.
- * @return  Returns an image object on success, FALSE on errors.
+ * @return \GdImage Returns an image object on success, FALSE on errors.
  * @throws ImageException
  *
  */
-function imagecreatefromtga(string $filename): void
+function imagecreatefromtga(string $filename): \GdImage
 {
     error_clear_last();
     $safeResult = \imagecreatefromtga($filename);
     if ($safeResult === false) {
         throw ImageException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -1825,7 +1827,7 @@ function imagegif($image, $file = null): void
 /**
  * Grabs a screenshot of the whole screen.
  *
- * @return resource Returns an image object on success, FALSE on failure.
+ * @return resource Returns an image object on success.
  * @throws ImageException
  *
  */
@@ -1845,7 +1847,7 @@ function imagegrabscreen()
  *
  * @param int $handle The HWND window ID.
  * @param bool $client_area Include the client area of the application window.
- * @return \GdImage Returns an image object on success, FALSE on failure.
+ * @return \GdImage Returns an image object on success.
  * @throws ImageException
  *
  */

--- a/generated/info.php
+++ b/generated/info.php
@@ -274,7 +274,7 @@ function ini_get(string $option): string
  * ini_set. There is a list of all available options
  * in the appendix.
  * @param string $value The new value for the option.
- * @return string Returns the old value on success, FALSE on failure.
+ * @return string Returns the old value on success.
  * @throws InfoException
  *
  */

--- a/generated/libxml.php
+++ b/generated/libxml.php
@@ -8,7 +8,7 @@ use Safe\Exceptions\LibxmlException;
  * Retrieve last error from libxml.
  *
  * @return \LibXMLError Returns a LibXMLError object if there is any error in the
- * buffer, FALSE otherwise.
+ * buffer.
  * @throws LibxmlException
  *
  */

--- a/generated/misc.php
+++ b/generated/misc.php
@@ -54,7 +54,7 @@ function define(string $constant_name, $value, bool $case_insensitive = false): 
  * highlighted code.
  * @return string|bool If return is set to TRUE, returns the highlighted
  * code as a string instead of printing it out. Otherwise, it will return
- * TRUE on success, FALSE on failure.
+ * TRUE on success.
  * @throws MiscException
  *
  */
@@ -216,7 +216,7 @@ function sapi_windows_set_ctrl_handler($handler, bool $add = true): void
 
 
 /**
- * If enable is NULL, the function returns TRUE if the stream stream has VT100 control codes enabled, FALSE otherwise.
+ * If enable is NULL, the function returns TRUE if the stream stream has VT100 control codes enabled.
  *
  * If enable is a bool, the function will try to enable or disable the VT100 features of the stream stream.
  * If the feature has been successfully enabled (or disabled).

--- a/generated/pgsql.php
+++ b/generated/pgsql.php
@@ -108,8 +108,7 @@ function pg_connection_reset($connection): void
  * as many columns as values has elements. The
  * fieldnames in table_name must match the indices in
  * values and the corresponding datatypes must be
- * compatible. Returns an array with the converted values on success, FALSE
- * otherwise.
+ * compatible. Returns an array with the converted values on success.
  *
  * @param resource $connection An PgSql\Connection instance.
  * @param string $table_name Name of the table against which to convert types.
@@ -819,7 +818,7 @@ function pg_meta_data($connection, string $table_name, bool $extended = false): 
  * is_superuser, session_authorization,
  * DateStyle, TimeZone, and
  * integer_datetimes.  Note that this value is case-sensitive.
- * @return string A string containing the value of the parameter, FALSE on failure or invalid
+ * @return string A string containing the value of the parameter or invalid
  * param_name.
  * @throws PgsqlException
  *

--- a/generated/rnp.php
+++ b/generated/rnp.php
@@ -11,17 +11,18 @@ use Safe\Exceptions\RnpException;
  *
  * @param \RnpFFI $ffi The FFI object returned by rnp_ffi_create.
  * @param string $input Encrypted message.
- * @return  Decrypted message on success.
+ * @return string Decrypted message on success.
  * @throws RnpException
  *
  */
-function rnp_decrypt(\RnpFFI $ffi, string $input): void
+function rnp_decrypt(\RnpFFI $ffi, string $input): string
 {
     error_clear_last();
     $safeResult = \rnp_decrypt($ffi, $input);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -30,17 +31,18 @@ function rnp_decrypt(\RnpFFI $ffi, string $input): void
  *
  * @param string $input Input string containing OpenPGP data, either in binary or ASCII-armored format.
  * @param int $flags See RNP_JSON_DUMP_* predefined constants.
- * @return  JSON string with dump.
+ * @return string JSON string with dump.
  * @throws RnpException
  *
  */
-function rnp_dump_packets_to_json(string $input, int $flags): void
+function rnp_dump_packets_to_json(string $input, int $flags): string
 {
     error_clear_last();
     $safeResult = \rnp_dump_packets_to_json($input, $flags);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -49,17 +51,18 @@ function rnp_dump_packets_to_json(string $input, int $flags): void
  *
  * @param string $input Input string containing OpenPGP data, either in binary or ASCII-armored format.
  * @param int $flags See RNP_DUMP_* predefined constants.
- * @return  Text describing packet sequence.
+ * @return string Text describing packet sequence.
  * @throws RnpException
  *
  */
-function rnp_dump_packets(string $input, int $flags): void
+function rnp_dump_packets(string $input, int $flags): string
 {
     error_clear_last();
     $safeResult = \rnp_dump_packets($input, $flags);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -70,17 +73,18 @@ function rnp_dump_packets(string $input, int $flags): void
  * RNP_KEYSTORE_* constant.
  * @param string $sec_format the format of the secret keyring, RNP_KEYSTORE_GPG or other
  * RNP_KEYSTORE_* constant
- * @return  Returns RnpFFI object on success.
+ * @return \RnpFFI Returns RnpFFI object on success.
  * @throws RnpException
  *
  */
-function rnp_ffi_create(string $pub_format, string $sec_format): void
+function rnp_ffi_create(string $pub_format, string $sec_format): \RnpFFI
 {
     error_clear_last();
     $safeResult = \rnp_ffi_create($pub_format, $sec_format);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -123,17 +127,18 @@ function rnp_ffi_set_pass_provider(\RnpFFI $ffi, callable $password_callback): v
  * @param \RnpFFI $ffi The FFI object returned by rnp_ffi_create.
  * @param string $input OpenPGP packets containing key(s) to be loaded. Can be either binary or ASCII armored.
  * @param int $flags See RNP_LOAD_SAVE_* predefined constants.
- * @return  JSON string with information about new and updated keys on success.
+ * @return string JSON string with information about new and updated keys on success.
  * @throws RnpException
  *
  */
-function rnp_import_keys(\RnpFFI $ffi, string $input, int $flags): void
+function rnp_import_keys(\RnpFFI $ffi, string $input, int $flags): string
 {
     error_clear_last();
     $safeResult = \rnp_import_keys($ffi, $input, $flags);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -143,17 +148,18 @@ function rnp_import_keys(\RnpFFI $ffi, string $input, int $flags): void
  * @param \RnpFFI $ffi The FFI object returned by rnp_ffi_create.
  * @param string $input OpenPGP packets containing signatures to be imported. Can be either binary or ASCII armored.
  * @param int $flags Currently must be 0.
- * @return  JSON string with information about updated keys on success.
+ * @return string JSON string with information about updated keys on success.
  * @throws RnpException
  *
  */
-function rnp_import_signatures(\RnpFFI $ffi, string $input, int $flags): void
+function rnp_import_signatures(\RnpFFI $ffi, string $input, int $flags): string
 {
     error_clear_last();
     $safeResult = \rnp_import_signatures($ffi, $input, $flags);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -168,17 +174,18 @@ function rnp_import_signatures(\RnpFFI $ffi, string $input, int $flags): void
  * if exported key has only one uid.
  * @param int $flags Only RNP_KEY_EXPORT_BASE64 is currently supported. Enabling
  * it would export base64-encoded key data instead of binary.
- * @return  OpenPGP packets of exported key on success.
+ * @return string OpenPGP packets of exported key on success.
  * @throws RnpException
  *
  */
-function rnp_key_export_autocrypt(\RnpFFI $ffi, string $key_fp, string $subkey_fp, string $uid, int $flags): void
+function rnp_key_export_autocrypt(\RnpFFI $ffi, string $key_fp, string $subkey_fp, string $uid, int $flags): string
 {
     error_clear_last();
     $safeResult = \rnp_key_export_autocrypt($ffi, $key_fp, $subkey_fp, $uid, $flags);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -190,11 +197,11 @@ function rnp_key_export_autocrypt(\RnpFFI $ffi, string $key_fp, string $subkey_f
  * @param string $key_fp Key fingerprint of the primary key to be revoked.
  * @param int $flags RNP_KEY_EXPORT_ARMORED or 0.
  * @param array $options An associative array with options.
- * @return  Exported revocation signature on success.
+ * @return string Exported revocation signature on success.
  * @throws RnpException
  *
  */
-function rnp_key_export_revocation(\RnpFFI $ffi, string $key_fp, int $flags, ?array $options = null): void
+function rnp_key_export_revocation(\RnpFFI $ffi, string $key_fp, int $flags, ?array $options = null): string
 {
     error_clear_last();
     if ($options !== null) {
@@ -205,6 +212,7 @@ function rnp_key_export_revocation(\RnpFFI $ffi, string $key_fp, int $flags, ?ar
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -215,17 +223,18 @@ function rnp_key_export_revocation(\RnpFFI $ffi, string $key_fp, int $flags, ?ar
  * @param string $key_fp Key fingerprint.
  * @param int $flags See RNP_KEY_EXPORT_* predefined constants
  * (except RNP_KEY_EXPORT_BASE64).
- * @return  OpenPGP packets of exported key (binary or ASCII-armored) on success.
+ * @return string OpenPGP packets of exported key (binary or ASCII-armored) on success.
  * @throws RnpException
  *
  */
-function rnp_key_export(\RnpFFI $ffi, string $key_fp, int $flags): void
+function rnp_key_export(\RnpFFI $ffi, string $key_fp, int $flags): string
 {
     error_clear_last();
     $safeResult = \rnp_key_export($ffi, $key_fp, $flags);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -234,17 +243,18 @@ function rnp_key_export(\RnpFFI $ffi, string $key_fp, int $flags): void
  *
  * @param \RnpFFI $ffi The FFI object returned by rnp_ffi_create.
  * @param string $key_fp Key fingerprint.
- * @return  An associative array with information about the key.
+ * @return array An associative array with information about the key.
  * @throws RnpException
  *
  */
-function rnp_key_get_info(\RnpFFI $ffi, string $key_fp): void
+function rnp_key_get_info(\RnpFFI $ffi, string $key_fp): array
 {
     error_clear_last();
     $safeResult = \rnp_key_get_info($ffi, $key_fp);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -297,17 +307,18 @@ function rnp_key_revoke(\RnpFFI $ffi, string $key_fp, int $flags, ?array $option
  *
  * @param \RnpFFI $ffi The FFI object returned by rnp_ffi_create.
  * @param string $identifier_type Key identifier type ("userid", "keyid", "grip", "fingerprint").
- * @return  An associative array where key is an identifier string and value is a PGP key fingerprint.
+ * @return array An associative array where key is an identifier string and value is a PGP key fingerprint.
  * @throws RnpException
  *
  */
-function rnp_list_keys(\RnpFFI $ffi, string $identifier_type): void
+function rnp_list_keys(\RnpFFI $ffi, string $identifier_type): array
 {
     error_clear_last();
     $safeResult = \rnp_list_keys($ffi, $identifier_type);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -358,17 +369,18 @@ function rnp_load_keys(\RnpFFI $ffi, string $format, string $input, int $flags):
  * @param string $identifier_type Identifier type string: "userid", "keyid", "fingerprint", "grip".
  * @param string $identifier PGP User ID (name and email) for "userid" type, hexadecimal string
  * that represents key id, fingerprint or key grip correspondingly.
- * @return  Returns hexadecimal fingerprint of the key found on success.
+ * @return string Returns hexadecimal fingerprint of the key found on success.
  * @throws RnpException
  *
  */
-function rnp_locate_key(\RnpFFI $ffi, string $identifier_type, string $identifier): void
+function rnp_locate_key(\RnpFFI $ffi, string $identifier_type, string $identifier): string
 {
     error_clear_last();
     $safeResult = \rnp_locate_key($ffi, $identifier_type, $identifier);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -379,11 +391,11 @@ function rnp_locate_key(\RnpFFI $ffi, string $identifier_type, string $identifie
  * @param string $message Message to be encrypted.
  * @param array $recipient_keys_fp Array with fingerprints of recipient's keys. At least one key must be present.
  * @param array $options An associative array with options.
- * @return  Encrypted data on success.
+ * @return string Encrypted data on success.
  * @throws RnpException
  *
  */
-function rnp_op_encrypt(\RnpFFI $ffi, string $message, array $recipient_keys_fp, ?array $options = null): void
+function rnp_op_encrypt(\RnpFFI $ffi, string $message, array $recipient_keys_fp, ?array $options = null): string
 {
     error_clear_last();
     if ($options !== null) {
@@ -394,6 +406,7 @@ function rnp_op_encrypt(\RnpFFI $ffi, string $message, array $recipient_keys_fp,
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -406,14 +419,14 @@ function rnp_op_encrypt(\RnpFFI $ffi, string $message, array $recipient_keys_fp,
  * @param string $key_alg Primary key algorithm (i.e. 'RSA', 'DSA', etc).
  * @param string $sub_alg Subkey algorithm. If not set, subkey will not be generated.
  * @param array $options An associative array with options.
- * @return  Fingerprint of the generated primary key. This fingerprint can be used
+ * @return string Fingerprint of the generated primary key. This fingerprint can be used
  * later to reference the key in sign and encrypt operations. The key data is stored in FFI
  * memory context and can be saved using
  * rnp_save_keys or rnp_save_keys_to_path.
  * @throws RnpException
  *
  */
-function rnp_op_generate_key(\RnpFFI $ffi, string $userid, string $key_alg, ?string $sub_alg = null, ?array $options = null): void
+function rnp_op_generate_key(\RnpFFI $ffi, string $userid, string $key_alg, ?string $sub_alg = null, ?array $options = null): string
 {
     error_clear_last();
     if ($options !== null) {
@@ -426,6 +439,7 @@ function rnp_op_generate_key(\RnpFFI $ffi, string $userid, string $key_alg, ?str
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -437,12 +451,12 @@ function rnp_op_generate_key(\RnpFFI $ffi, string $userid, string $key_alg, ?str
  * @param array $keys_fp Array with key fingerprints. At least one key must be provided.
  * Keys should be present in ffi.
  * @param array $options An associative array with options.
- * @return  Cleartext signed message containing source data with
+ * @return string Cleartext signed message containing source data with
  * additional headers and ASCII-armored signature on success.
  * @throws RnpException
  *
  */
-function rnp_op_sign_cleartext(\RnpFFI $ffi, string $data, array $keys_fp, ?array $options = null): void
+function rnp_op_sign_cleartext(\RnpFFI $ffi, string $data, array $keys_fp, ?array $options = null): string
 {
     error_clear_last();
     if ($options !== null) {
@@ -453,6 +467,7 @@ function rnp_op_sign_cleartext(\RnpFFI $ffi, string $data, array $keys_fp, ?arra
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -464,11 +479,11 @@ function rnp_op_sign_cleartext(\RnpFFI $ffi, string $data, array $keys_fp, ?arra
  * @param array $keys_fp Array with key fingerprints. At least one key must be provided.
  * Keys should be present in ffi.
  * @param array $options An associative array with options.
- * @return  Detached signature(s) data on success.
+ * @return string Detached signature(s) data on success.
  * @throws RnpException
  *
  */
-function rnp_op_sign_detached(\RnpFFI $ffi, string $data, array $keys_fp, ?array $options = null): void
+function rnp_op_sign_detached(\RnpFFI $ffi, string $data, array $keys_fp, ?array $options = null): string
 {
     error_clear_last();
     if ($options !== null) {
@@ -479,6 +494,7 @@ function rnp_op_sign_detached(\RnpFFI $ffi, string $data, array $keys_fp, ?array
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -490,11 +506,11 @@ function rnp_op_sign_detached(\RnpFFI $ffi, string $data, array $keys_fp, ?array
  * @param array $keys_fp Array with key fingerprints. At least one key must be provided.
  * Keys should be present in ffi.
  * @param array $options An associative array with options.
- * @return  Data with embedded signature(s) on success.
+ * @return string Data with embedded signature(s) on success.
  * @throws RnpException
  *
  */
-function rnp_op_sign(\RnpFFI $ffi, string $data, array $keys_fp, ?array $options = null): void
+function rnp_op_sign(\RnpFFI $ffi, string $data, array $keys_fp, ?array $options = null): string
 {
     error_clear_last();
     if ($options !== null) {
@@ -505,6 +521,7 @@ function rnp_op_sign(\RnpFFI $ffi, string $data, array $keys_fp, ?array $options
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -514,19 +531,20 @@ function rnp_op_sign(\RnpFFI $ffi, string $data, array $keys_fp, ?array $options
  * @param \RnpFFI $ffi The FFI object returned by rnp_ffi_create.
  * @param string $data Source data.
  * @param string $signature Detached signature data.
- * @return  An associative array with information about verification results.
+ * @return array An associative array with information about verification results.
  *
  * "signatures" sub-array.
  * @throws RnpException
  *
  */
-function rnp_op_verify_detached(\RnpFFI $ffi, string $data, string $signature): void
+function rnp_op_verify_detached(\RnpFFI $ffi, string $data, string $signature): array
 {
     error_clear_last();
     $safeResult = \rnp_op_verify_detached($ffi, $data, $signature);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -535,19 +553,20 @@ function rnp_op_verify_detached(\RnpFFI $ffi, string $data, string $signature): 
  *
  * @param \RnpFFI $ffi The FFI object returned by rnp_ffi_create.
  * @param string $data Signed data.
- * @return  An associative array with information about verification results.
+ * @return array An associative array with information about verification results.
  *
  * "signatures" sub-array.
  * @throws RnpException
  *
  */
-function rnp_op_verify(\RnpFFI $ffi, string $data): void
+function rnp_op_verify(\RnpFFI $ffi, string $data): array
 {
     error_clear_last();
     $safeResult = \rnp_op_verify($ffi, $data);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -595,15 +614,16 @@ function rnp_save_keys(\RnpFFI $ffi, string $format, string &$output, int $flags
  * Get the JSON formatted string containing array of supported rnp feature values (algorithms, curves, etc) by type.
  *
  * @param string $type See RNP_FEATURE_* constants for supported values.
- * @return  String containing JSON formatted array of supported algorithms, curves, etc.
+ * @return string String containing JSON formatted array of supported algorithms, curves, etc.
  * @throws RnpException
  *
  */
-function rnp_supported_features(string $type): void
+function rnp_supported_features(string $type): string
 {
     error_clear_last();
     $safeResult = \rnp_supported_features($type);
     if ($safeResult === false) {
         throw RnpException::createFromPhpError();
     }
+    return $safeResult;
 }

--- a/generated/sodium.php
+++ b/generated/sodium.php
@@ -11,17 +11,18 @@ use Safe\Exceptions\SodiumException;
  * @param string $additional_data
  * @param string $nonce
  * @param string $key
- * @return
+ * @return string
  * @throws SodiumException
  *
  */
-function sodium_crypto_aead_aegis128l_decrypt(string $ciphertext, string $additional_data, string $nonce, string $key): void
+function sodium_crypto_aead_aegis128l_decrypt(string $ciphertext, string $additional_data, string $nonce, string $key): string
 {
     error_clear_last();
     $safeResult = \sodium_crypto_aead_aegis128l_decrypt($ciphertext, $additional_data, $nonce, $key);
     if ($safeResult === false) {
         throw SodiumException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -32,17 +33,18 @@ function sodium_crypto_aead_aegis128l_decrypt(string $ciphertext, string $additi
  * @param string $additional_data
  * @param string $nonce
  * @param string $key
- * @return
+ * @return string
  * @throws SodiumException
  *
  */
-function sodium_crypto_aead_aegis256_decrypt(string $ciphertext, string $additional_data, string $nonce, string $key): void
+function sodium_crypto_aead_aegis256_decrypt(string $ciphertext, string $additional_data, string $nonce, string $key): string
 {
     error_clear_last();
     $safeResult = \sodium_crypto_aead_aegis256_decrypt($ciphertext, $additional_data, $nonce, $key);
     if ($safeResult === false) {
         throw SodiumException::createFromPhpError();
     }
+    return $safeResult;
 }
 
 

--- a/generated/ssdeep.php
+++ b/generated/ssdeep.php
@@ -12,7 +12,7 @@ use Safe\Exceptions\SsdeepException;
  *
  * @param string $signature1 The first fuzzy hash signature string.
  * @param string $signature2 The second fuzzy hash signature string.
- * @return int Returns an integer from 0 to 100 on success, FALSE otherwise.
+ * @return int Returns an integer from 0 to 100 on success.
  * @throws SsdeepException
  *
  */
@@ -34,7 +34,7 @@ function ssdeep_fuzzy_compare(string $signature1, string $signature2): int
  * hashing, and returns that hash.
  *
  * @param string $file_name The filename of the file to hash.
- * @return string Returns a string on success, FALSE otherwise.
+ * @return string Returns a string on success.
  * @throws SsdeepException
  *
  */
@@ -55,7 +55,7 @@ function ssdeep_fuzzy_hash_filename(string $file_name): string
  * context-triggered piecewise hashing, and returns that hash.
  *
  * @param string $to_hash The input string.
- * @return string Returns a string on success, FALSE otherwise.
+ * @return string Returns a string on success.
  * @throws SsdeepException
  *
  */

--- a/generated/ssh2.php
+++ b/generated/ssh2.php
@@ -384,17 +384,18 @@ function ssh2_exec($session, string $command, ?string $pty = null, ?array $env =
  * Accepts a connection created by a listener.
  *
  * @param resource $listener An SSH2 Listener resource, obtained from a call to ssh2_forward_listen.
- * @return  Returns a stream resource.
+ * @return resource Returns a stream resource.
  * @throws Ssh2Exception
  *
  */
-function ssh2_forward_accept($listener): void
+function ssh2_forward_accept($listener)
 {
     error_clear_last();
     $safeResult = \ssh2_forward_accept($listener);
     if ($safeResult === false) {
         throw Ssh2Exception::createFromPhpError();
     }
+    return $safeResult;
 }
 
 
@@ -405,11 +406,11 @@ function ssh2_forward_accept($listener): void
  * @param int $port The port of the remote server.
  * @param string $host
  * @param int $max_connections
- * @return  Returns an SSH2 Listener.
+ * @return resource Returns an SSH2 Listener.
  * @throws Ssh2Exception
  *
  */
-function ssh2_forward_listen($session, int $port, ?string $host = null, int $max_connections = 16): void
+function ssh2_forward_listen($session, int $port, ?string $host = null, int $max_connections = 16)
 {
     error_clear_last();
     if ($max_connections !== 16) {
@@ -422,6 +423,7 @@ function ssh2_forward_listen($session, int $port, ?string $host = null, int $max
     if ($safeResult === false) {
         throw Ssh2Exception::createFromPhpError();
     }
+    return $safeResult;
 }
 
 

--- a/generated/stream.php
+++ b/generated/stream.php
@@ -465,7 +465,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * be used together with the other file functions (such as
  * fgets, fgetss,
  * fwrite, fclose, and
- * feof), FALSE on failure.
+ * feof).
  * @throws StreamException
  *
  */

--- a/generated/strings.php
+++ b/generated/strings.php
@@ -52,7 +52,7 @@ function hex2bin(string $string): string
  * @param string $filename The filename
  * @param bool $binary When TRUE, returns the digest in raw binary format with a length of
  * 16.
- * @return string Returns a string on success, FALSE otherwise.
+ * @return string Returns a string on success.
  * @throws StringsException
  *
  */
@@ -73,7 +73,7 @@ function md5_file(string $filename, bool $binary = false): string
  * @param string $filename The filename of the file to hash.
  * @param bool $binary When TRUE, returns the digest in raw binary format with a length of
  * 20.
- * @return string Returns a string on success, FALSE otherwise.
+ * @return string Returns a string on success.
  * @throws StringsException
  *
  */

--- a/generator/tests/MethodTest.php
+++ b/generator/tests/MethodTest.php
@@ -116,4 +116,12 @@ class MethodTest extends TestCase
         $this->assertEquals("@return bool|null Returns TRUE if the next result was successfully retrieved, FALSE if an error \n   occurred, and NULL if there are no more results to retrieve.\n", $method->getReturnDocBlock());
         $this->assertEquals('?bool', $method->getSignatureReturnType());
     }
+
+    public function testOpensslCipherKeyLengthUnionTypeReturnDocBlocks(): void
+    {
+        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/openssl/functions/openssl-cipher-key-length.xml');
+        $xmlObject = $docPage->getMethodSynopsis();
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
+        $this->assertEquals("@return int Returns the cipher length on success,  or false on failure.\n", $method->getReturnDocBlock());
+    }
 }


### PR DESCRIPTION
resolves #504 

This PR adds support for union types from the PHP documentation. They are defined as followed:
```xml
<methodsynopsis>
   <type class="union"><type>int</type><type>false</type></type>
   ...
</methodsynopsis>
```
Before, when a function was defined with this union type notation and it hasn't been corrected by PHPStan (function map), the return has been determined as void. This PR now determines those union type correctly. Several function are affected as you can see in the diff.