### PR TITLE
[docker] mark doc directories as safe for git to use

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG XDEBUG_MODE=coverage
 RUN apt update -y && apt install -y git composer php-cli php-dom php-curl php-xdebug vim
 WORKDIR /app
+RUN git config --global --add safe.directory /app/generator/doc/doc-en/en && \
+    git config --global --add safe.directory /app/generator/doc/doc-en/doc-base
 CMD cd /app/generator/doc && ./update.sh && \
     cd /app && composer install && \
     cd /app/generator && composer install && php ./safe.php generate


### PR DESCRIPTION

docker mounting can cause the doc directory to be owned by a different user to the one running inside the container, which git complains about, but is fine for our use-case
