### PR TITLE
[docker] exit early if build fails

### DIFF
--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+set -eu
 cd $(dirname $0)/../
 docker run --rm -v ${PWD}:/app $(docker build -q -f .devcontainer/Dockerfile .)


### PR DESCRIPTION

If the build fails, don't then attempt to run the container-which-wasn't-built
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/thecodingmachine/safe/pull/515).
* #503
* #517
* #516
* __->__ #515