### PR TITLE
[generator] make import tests into a unit test

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG XDEBUG_MODE=coverage
 RUN apt update -y && apt install -y git composer php-cli php-dom php-curl php-xdebug vim
 WORKDIR /app
+RUN git config --global --add safe.directory /app/generator/doc/doc-en/en && \
+    git config --global --add safe.directory /app/generator/doc/doc-en/doc-base
 CMD cd /app/generator/doc && ./update.sh && \
     cd /app && composer install && \
     cd /app/generator && composer install && php ./safe.php generate

--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+set -eu
 cd $(dirname $0)/../
 docker run --rm -v ${PWD}:/app $(docker build -q -f .devcontainer/Dockerfile .)

--- a/generator/src/GenerateCommand.php
+++ b/generator/src/GenerateCommand.php
@@ -53,26 +53,6 @@ class GenerateCommand extends Command
 
         $this->runCsFix($output);
 
-        // Let's require the generated file to check there is no error.
-        $files = \glob(__DIR__.'/../../generated/*.php');
-        if ($files === false) {
-            throw new \RuntimeException('Failed to require the generated file');
-        }
-
-        foreach ($files as $file) {
-            require($file);
-        }
-
-        $files = \glob(__DIR__.'/../../generated/Exceptions/*.php');
-        if ($files === false) {
-            throw new \RuntimeException('Failed to require the generated exception file');
-        }
-
-        require_once __DIR__.'/../../lib/Exceptions/SafeExceptionInterface.php';
-        foreach ($files as $file) {
-            require($file);
-        }
-
         // Finally, let's edit the composer.json file
         $output->writeln('Editing composer.json');
         ComposerJsonEditor::editComposerFileForGeneration(\array_values($modules));

--- a/tests/GeneratedFilesTest.php
+++ b/tests/GeneratedFilesTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class GeneratedFilesTest extends TestCase
+{
+    public function testRequireModules(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        $files = \glob(__DIR__.'/../generated/*.php');
+        if ($files === false) {
+            throw new \RuntimeException('Failed to require the generated file');
+        }
+
+        foreach ($files as $file) {
+            require_once($file);
+        }
+    }
+
+    public function testRequireExceptions(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        $files = \glob(__DIR__.'/../generated/Exceptions/*.php');
+        if ($files === false) {
+            throw new \RuntimeException('Failed to require the generated exception file');
+        }
+        foreach ($files as $file) {
+            require_once($file);
+        }
+    }
+
+    public function testRequireExceptionInterface(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        require_once __DIR__.'/../lib/Exceptions/SafeExceptionInterface.php';
+    }
+}


### PR DESCRIPTION

When we run safe with multiple different PHP versions, we want to make sure importing the library works under all versions - not just the version we generate with
