### PR TITLE
[cli] use ProgressBar rather than log spam

### DIFF
--- a/generator/src/DocPage.php
+++ b/generator/src/DocPage.php
@@ -251,7 +251,6 @@ class DocPage
             .'<!DOCTYPE refentry SYSTEM "'.$path.'">'
             .\substr($content, $strpos+1);
 
-        echo 'Loading '.$this->path."\n";
         $elem = \simplexml_load_string($content, \SimpleXMLElement::class, LIBXML_DTDLOAD | LIBXML_NOENT);
         if ($elem === false) {
             throw new \RuntimeException('Invalid XML file for '.$this->path);

--- a/generator/src/GenerateCommand.php
+++ b/generator/src/GenerateCommand.php
@@ -29,7 +29,7 @@ class GenerateCommand extends Command
 
         $paths = $scanner->getFunctionsPaths();
 
-        $res = $scanner->getMethods($paths);
+        $res = $scanner->getMethods($paths, $output);
         $functions = $res->methods;
         $overloadedFunctions = $res->overloadedFunctions;
 

--- a/generator/src/ScanObjectsCommand.php
+++ b/generator/src/ScanObjectsCommand.php
@@ -24,7 +24,7 @@ class ScanObjectsCommand extends Command
 
         $paths = $scanner->getMethodsPaths();
 
-        $res = $scanner->getMethods($paths);
+        $res = $scanner->getMethods($paths, $output);
 
         foreach ($res->methods as $function) {
             $name = $function->getFunctionName();


### PR DESCRIPTION

Before: 3400 lines
```
$ ./.devcontainer/build.sh
[...]
Loading /app/generator/src/../doc/doc-en/en/reference/ibase/functions/ibase-commit.xml
Loading /app/generator/src/../doc/doc-en/en/reference/ibase/functions/ibase-connect.xml
Loading /app/generator/src/../doc/doc-en/en/reference/ibase/functions/ibase-delete-user.xml
Loading /app/generator/src/../doc/doc-en/en/reference/ibase/functions/ibase-drop-db.xml
Loading /app/generator/src/../doc/doc-en/en/reference/ibase/functions/ibase-free-event-handler.xml
Loading /app/generator/src/../doc/doc-en/en/reference/ibase/functions/ibase-free-query.xml
Loading /app/generator/src/../doc/doc-en/en/reference/ibase/functions/ibase-free-result.xml
[...]
```

After: 1 line in interactive mode, ~10 lines in CI mode
```
$ ./.devcontainer/build.sh
    1/3463 [>---------------------------] apache
  347/3463 [==>-------------------------] datetime
  693/3463 [=====>----------------------] fdf
 1039/3463 [========>-------------------] ibase
 1386/3463 [===========>----------------] info
 1732/3463 [==============>-------------] mysql
 2078/3463 [================>-----------] pgsql
 2425/3463 [===================>--------] snmp
 2771/3463 [======================>-----] stream
 3117/3463 [=========================>--] trader
 3463/3463 [============================] zookeeper
```
