### PR TITLE
[dev] function-info command

### DIFF
--- a/generator/safe.php
+++ b/generator/safe.php
@@ -6,10 +6,12 @@ require __DIR__.'/vendor/autoload.php';
 
 use Safe\GenerateCommand;
 use Safe\ScanObjectsCommand;
+use Safe\FunctionInfoCommand;
 use Symfony\Component\Console\Application;
 
 $application = new Application();
 $application->addCommands([new GenerateCommand()]);
 $application->addCommands([new ScanObjectsCommand()]);
+$application->addCommands([new FunctionInfoCommand()]);
 
 $application->run();

--- a/generator/src/FunctionInfoCommand.php
+++ b/generator/src/FunctionInfoCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Safe;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FunctionInfoCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('function-info')
+            ->setDescription('Displays parsed info about a function.')
+            ->addArgument('function', InputArgument::REQUIRED, 'The function name to display info about.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $scanner = new Scanner(__DIR__ . '/../doc/doc-en/en/reference/');
+        $res = $scanner->getMethods($scanner->getFunctionsPaths(), $output);
+
+        foreach ($res->methods as $function) {
+            $name = $function->getFunctionName();
+            if ($name == $input->getArgument("function")) {
+                $output->writeln("Params: ");
+                foreach ($function->getParams() as $param) {
+                    $output->writeln("  " . $param->getParameterName());
+                    $output->writeln("    ParameterType: " . $param->getParameterType());
+                    $output->writeln("    SignatureType: " . $param->getSignatureType());
+                    $output->writeln("    DocBlockType:  " . $param->getDocBlockType());
+                }
+                $writePhpFunction = new WritePhpFunction($function);
+                $output->writeln($writePhpFunction->getPhpFunctionalFunction());
+                break;
+            }
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION

I'm trying to figure out why some functions claim to take a `resource` when they actually take a `FTP\Connection` or a `GdImage` -- this CLI command helps with debugging.

### Example:

```php
$ php ./generator/safe.php function-info ftp_alloc
Params:
  ftp
    ParameterType: FTP\Connection
    SignatureType:
    DocBlockType:  resource
  size
    ParameterType: int
    SignatureType: int
    DocBlockType:  int
  response
    ParameterType: string
    SignatureType: ?string
    DocBlockType:  string|null

/**
 * Sends an ALLO command to the remote FTP server to
 * allocate space for a file to be uploaded.
 *
 * @param resource $ftp An FTP\Connection instance.
 * @param int $size The number of bytes to allocate.
 * @param string|null $response A textual representation of the servers response will be returned by
 * reference in response if a variable is provided.
 * @throws FtpException
 *
 */
function ftp_alloc($ftp, int $size, ?string &$response = null): void
{
    error_clear_last();
    $safeResult = \ftp_alloc($ftp, $size, $response);
    if ($safeResult === false) {
        throw FtpException::createFromPhpError();
    }
}
```
