### PR TITLE
[ci] make rector tests less redundant

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,7 +6,7 @@ on:
       - main
       - master
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@v4"
       - name: "Get current date for the daily cache"
-        id: 'date'
+        id: "date"
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - name: "Cache the php documentation"
         id: cache-php-doc
@@ -182,7 +182,7 @@ jobs:
         with:
           php-version: "8.4"
       - name: "Composer install"
-        run: "composer install && composer rector && composer test"
+        run: "composer install"
         working-directory: "generator/tests/rector"
       - name: "Run rector"
         run: "composer rector"
@@ -190,4 +190,3 @@ jobs:
       - name: "Run tests"
         run: "composer test"
         working-directory: "generator/tests/rector"
-


### PR DESCRIPTION

Looks like a botched merge ended up with the same commands being run twice
