### PR TITLE
[generator] reduce hard-coding of directory paths

### DIFF
--- a/generator/src/DocPage.php
+++ b/generator/src/DocPage.php
@@ -13,6 +13,16 @@ class DocPage
     {
     }
 
+    public static function findDocDir(): string
+    {
+        return __DIR__ . '/../doc';
+    }
+
+    public static function findReferenceDir(): string
+    {
+        return DocPage::findDocDir() . '/doc-en/en/reference';
+    }
+
     // Ignore function if it was removed before PHP 7.1
     private function getIsDeprecated(string $file): bool
     {
@@ -241,10 +251,10 @@ class DocPage
             throw new \RuntimeException('An error occurred while reading '.$this->path);
         }
         $strpos = \strpos($content, '?>')+2;
-        if (!\file_exists(__DIR__.'/../doc/entities/generated.ent')) {
+        if (!\file_exists(DocPage::findDocDir() . '/entities/generated.ent')) {
             self::buildEntities();
         }
-        $path = \realpath(__DIR__.'/../doc/entities/generated.ent');
+        $path = \realpath(DocPage::findDocDir() . '/entities/generated.ent');
 
 
         $content = \substr($content, 0, $strpos)
@@ -312,14 +322,14 @@ class DocPage
 
     public static function buildEntities(): void
     {
-        $file1 = \file_get_contents(__DIR__.'/../doc/doc-en/en/language-defs.ent') ?: '';
-        $file2 = \file_get_contents(__DIR__.'/../doc/doc-en/en/language-snippets.ent') ?: '';
-        $file3 = \file_get_contents(__DIR__.'/../doc/doc-en/en/extensions.ent') ?: '';
-        $file4 = \file_get_contents(__DIR__.'/../doc/doc-en/doc-base/entities/global.ent') ?: '';
+        $file1 = \file_get_contents(DocPage::findDocDir() . '/doc-en/en/language-defs.ent') ?: '';
+        $file2 = \file_get_contents(DocPage::findDocDir() . '/doc-en/en/language-snippets.ent') ?: '';
+        $file3 = \file_get_contents(DocPage::findDocDir() . '/doc-en/en/extensions.ent') ?: '';
+        $file4 = \file_get_contents(DocPage::findDocDir() . '/doc-en/doc-base/entities/global.ent') ?: '';
 
         $completeFile = $file1 . self::extractXmlHeader($file2) . self::extractXmlHeader($file3) . $file4;
 
-        \file_put_contents(__DIR__.'/../doc/entities/generated.ent', $completeFile);
+        \file_put_contents(DocPage::findDocDir() . '/entities/generated.ent', $completeFile);
     }
 
     private static function extractXmlHeader(string $content): string

--- a/generator/src/FunctionInfoCommand.php
+++ b/generator/src/FunctionInfoCommand.php
@@ -22,7 +22,7 @@ class FunctionInfoCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $scanner = new Scanner(__DIR__ . '/../doc/doc-en/en/reference/');
+        $scanner = new Scanner(DocPage::findReferenceDir());
         $res = $scanner->getMethods($scanner->getFunctionsPaths(), $output);
 
         foreach ($res->methods as $function) {

--- a/generator/src/GenerateCommand.php
+++ b/generator/src/GenerateCommand.php
@@ -26,7 +26,7 @@ class GenerateCommand extends Command
 
         // Let's build the DTD necessary to load the XML files.
         DocPage::buildEntities();
-        $scanner = new Scanner(__DIR__ . '/../doc/doc-en/en/reference/');
+        $scanner = new Scanner(DocPage::findReferenceDir());
 
         $paths = $scanner->getFunctionsPaths();
 
@@ -81,8 +81,8 @@ class GenerateCommand extends Command
             \unlink($file);
         }
 
-        if (\file_exists(__DIR__.'/../doc/entities/generated.ent')) {
-            \unlink(__DIR__.'/../doc/entities/generated.ent');
+        if (\file_exists(DocPage::findDocDir() . '/entities/generated.ent')) {
+            \unlink(DocPage::findDocDir() . '/entities/generated.ent');
         }
     }
 

--- a/generator/src/ScanObjectsCommand.php
+++ b/generator/src/ScanObjectsCommand.php
@@ -20,7 +20,7 @@ class ScanObjectsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $scanner = new Scanner(__DIR__ . '/../doc/doc-en/en/reference/');
+        $scanner = new Scanner(DocPage::findReferenceDir());
 
         $paths = $scanner->getMethodsPaths();
 

--- a/generator/src/Scanner.php
+++ b/generator/src/Scanner.php
@@ -34,7 +34,7 @@ class Scanner
     public function getFunctionsPaths(): array
     {
         $finder = new Finder();
-        $finder->in($this->path.'*/functions/')->name('*.xml')->sortByName();
+        $finder->in($this->path.'/*/functions/')->name('*.xml')->sortByName();
 
         return iterator_to_array($finder);
     }

--- a/generator/tests/DocPageTest.php
+++ b/generator/tests/DocPageTest.php
@@ -10,17 +10,17 @@ class DocPageTest extends TestCase
 {
     public function testDetectFalsyFunction(): void
     {
-        $pregMatch = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/pcre/functions/preg-match.xml');
-        $implode = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/strings/functions/implode.xml');
-        $getCwd = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/dir/functions/getcwd.xml');
-        $createFromFormat = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/datetime/datetime/createfromformat.xml');
-        $filesize = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/filesystem/functions/filesize.xml');
-        $fsockopen = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/network/functions/fsockopen.xml');
-        $arrayReplace = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/array/functions/array-replace.xml');
-        $classImplement = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/spl/functions/class-implements.xml');
-        $getHeaders = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/url/functions/get-headers.xml');
-        $gzopen = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/zlib/functions/gzopen.xml');
-        $fopen = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/image/functions/imagecreatefromstring.xml');
+        $pregMatch = new DocPage(DocPage::findReferenceDir() . '/pcre/functions/preg-match.xml');
+        $implode = new DocPage(DocPage::findReferenceDir() . '/strings/functions/implode.xml');
+        $getCwd = new DocPage(DocPage::findReferenceDir() . '/dir/functions/getcwd.xml');
+        $createFromFormat = new DocPage(DocPage::findReferenceDir() . '/datetime/datetime/createfromformat.xml');
+        $filesize = new DocPage(DocPage::findReferenceDir() . '/filesystem/functions/filesize.xml');
+        $fsockopen = new DocPage(DocPage::findReferenceDir() . '/network/functions/fsockopen.xml');
+        $arrayReplace = new DocPage(DocPage::findReferenceDir() . '/array/functions/array-replace.xml');
+        $classImplement = new DocPage(DocPage::findReferenceDir() . '/spl/functions/class-implements.xml');
+        $getHeaders = new DocPage(DocPage::findReferenceDir() . '/url/functions/get-headers.xml');
+        $gzopen = new DocPage(DocPage::findReferenceDir() . '/zlib/functions/gzopen.xml');
+        $fopen = new DocPage(DocPage::findReferenceDir() . '/image/functions/imagecreatefromstring.xml');
 
         $this->assertTrue($pregMatch->detectFalsyFunction());
         $this->assertFalse($implode->detectFalsyFunction());
@@ -37,14 +37,14 @@ class DocPageTest extends TestCase
 
     public function testDetectNullsyFunction(): void
     {
-        $implode = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/strings/functions/implode.xml');
+        $implode = new DocPage(DocPage::findReferenceDir() . '/strings/functions/implode.xml');
 
         $this->assertFalse($implode->detectNullsyFunction());
     }
 
     public function testDetectEmptyFunction(): void
     {
-        $pgHost = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/pgsql/functions/pg-host.xml');
+        $pgHost = new DocPage(DocPage::findReferenceDir() . '/pgsql/functions/pg-host.xml');
 
         $this->assertTrue($pgHost->detectEmptyFunction());
     }

--- a/generator/tests/MethodTest.php
+++ b/generator/tests/MethodTest.php
@@ -11,7 +11,7 @@ class MethodTest extends TestCase
 {
     public function testGetFunctionName(): void
     {
-        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/pcre/functions/preg-match.xml');
+        $docPage = new DocPage(DocPage::findReferenceDir() . '/pcre/functions/preg-match.xml');
         $xmlObject = $docPage->getMethodSynopsis();
         $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
         $name = $method->getFunctionName();
@@ -20,7 +20,7 @@ class MethodTest extends TestCase
 
     public function testGetFunctionType(): void
     {
-        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/pcre/functions/preg-match.xml');
+        $docPage = new DocPage(DocPage::findReferenceDir() . '/pcre/functions/preg-match.xml');
         $xmlObject = $docPage->getMethodSynopsis();
         $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
         $type = $method->getSignatureReturnType();
@@ -29,7 +29,7 @@ class MethodTest extends TestCase
 
     public function testGetFunctionParam(): void
     {
-        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/pcre/functions/preg-match.xml');
+        $docPage = new DocPage(DocPage::findReferenceDir() . '/pcre/functions/preg-match.xml');
         $xmlObject = $docPage->getMethodSynopsis();
         $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
         $params = $method->getParams();
@@ -39,7 +39,7 @@ class MethodTest extends TestCase
 
     public function testGetTypeHintFromResource(): void
     {
-        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/strings/functions/sprintf.xml');
+        $docPage = new DocPage(DocPage::findReferenceDir() . '/strings/functions/sprintf.xml');
         $xmlObject = $docPage->getMethodSynopsis();
         $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
         $params = $method->getParams();
@@ -49,7 +49,7 @@ class MethodTest extends TestCase
         $this->assertTrue($params[1]->isVariadic());
         $this->assertEquals('', $params[1]->getSignatureType());
 
-        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/mbstring/functions/mb-ereg-replace-callback.xml');
+        $docPage = new DocPage(DocPage::findReferenceDir() . '/mbstring/functions/mb-ereg-replace-callback.xml');
         $xmlObject = $docPage->getMethodSynopsis();
         $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
         $params = $method->getParams();
@@ -59,7 +59,7 @@ class MethodTest extends TestCase
         $this->assertEquals('callable', $params[1]->getSignatureType());
 
 
-        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/gmp/functions/gmp-export.xml');
+        $docPage = new DocPage(DocPage::findReferenceDir() . '/gmp/functions/gmp-export.xml');
         $xmlObject = $docPage->getMethodSynopsis();
         $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
         $params = $method->getParams();
@@ -68,7 +68,7 @@ class MethodTest extends TestCase
         $this->assertEquals('int', $params[1]->getDocBlockType());
         $this->assertEquals('int', $params[1]->getSignatureType());
 
-        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/hash/functions/hash-update.xml');
+        $docPage = new DocPage(DocPage::findReferenceDir() . '/hash/functions/hash-update.xml');
         $xmlObject = $docPage->getMethodSynopsis();
         $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
         $params = $method->getParams();
@@ -78,7 +78,7 @@ class MethodTest extends TestCase
 
     public function testImapOpen5Parameter(): void
     {
-        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/imap/functions/imap-open.xml');
+        $docPage = new DocPage(DocPage::findReferenceDir() . '/imap/functions/imap-open.xml');
         $xmlObject = $docPage->getMethodSynopsis();
         $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
         $params = $method->getParams();
@@ -88,7 +88,7 @@ class MethodTest extends TestCase
 
     public function testGetInitializer(): void
     {
-        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/apache/functions/apache-getenv.xml');
+        $docPage = new DocPage(DocPage::findReferenceDir() . '/apache/functions/apache-getenv.xml');
         $xmlObject = $docPage->getMethodSynopsis();
         $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
 
@@ -99,18 +99,18 @@ class MethodTest extends TestCase
 
     public function testGetReturnDocBlock(): void
     {
-        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/array/functions/array-replace.xml');
+        $docPage = new DocPage(DocPage::findReferenceDir() . '/array/functions/array-replace.xml');
         $xmlObject = $docPage->getMethodSynopsis();
         $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::NULLSY_TYPE);
         $this->assertEquals("@return array Returns an array.\n", $method->getReturnDocBlock());
 
-        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/shmop/functions/shmop-delete.xml');
+        $docPage = new DocPage(DocPage::findReferenceDir() . '/shmop/functions/shmop-delete.xml');
         $xmlObject = $docPage->getMethodSynopsis();
         $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
         $this->assertEquals('', $method->getReturnDocBlock());
         $this->assertEquals('void', $method->getSignatureReturnType());
 
-        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/sqlsrv/functions/sqlsrv-next-result.xml');
+        $docPage = new DocPage(DocPage::findReferenceDir() . '/sqlsrv/functions/sqlsrv-next-result.xml');
         $xmlObject = $docPage->getMethodSynopsis();
         $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
         $this->assertEquals("@return bool|null Returns TRUE if the next result was successfully retrieved, FALSE if an error \n   occurred, and NULL if there are no more results to retrieve.\n", $method->getReturnDocBlock());
@@ -119,7 +119,7 @@ class MethodTest extends TestCase
 
     public function testOpensslCipherKeyLengthUnionTypeReturnDocBlocks(): void
     {
-        $docPage = new DocPage(__DIR__ . '/../doc/doc-en/en/reference/openssl/functions/openssl-cipher-key-length.xml');
+        $docPage = new DocPage(DocPage::findReferenceDir() . '/openssl/functions/openssl-cipher-key-length.xml');
         $xmlObject = $docPage->getMethodSynopsis();
         $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
         $this->assertEquals("@return int Returns the cipher length on success.\n", $method->getReturnDocBlock());

--- a/generator/tests/ScannerTest.php
+++ b/generator/tests/ScannerTest.php
@@ -11,19 +11,19 @@ class ScannerTest extends TestCase
 
     public function testGetMethodsPaths(): void
     {
-        $scanner = new Scanner(__DIR__ . '/../doc/doc-en/en/reference/');
+        $scanner = new Scanner(DocPage::findReferenceDir());
         $paths = $scanner->getFunctionsPaths();
 
-        $this->assertArrayHasKey(__DIR__.'/../doc/doc-en/en/reference/filesystem/functions/chmod.xml', $paths);
-        $this->assertArrayNotHasKey(__DIR__.'/../doc/doc-en/en/reference/spl/appenditerator/getarrayiterator.xml', $paths);
+        $this->assertArrayHasKey(DocPage::findReferenceDir() . '/filesystem/functions/chmod.xml', $paths);
+        $this->assertArrayNotHasKey(DocPage::findReferenceDir() . '/spl/appenditerator/getarrayiterator.xml', $paths);
     }
 
     public function testGetFunctionsPaths(): void
     {
-        $scanner = new Scanner(__DIR__ . '/../doc/doc-en/en/reference/');
+        $scanner = new Scanner(DocPage::findReferenceDir());
         $paths = $scanner->getMethodsPaths();
 
-        $this->assertArrayNotHasKey(__DIR__.'/../doc/doc-en/en/reference/filesystem/functions/chmod.xml', $paths);
-        $this->assertArrayHasKey(__DIR__.'/../doc/doc-en/en/reference/spl/appenditerator/getarrayiterator.xml', $paths);
+        $this->assertArrayNotHasKey(DocPage::findReferenceDir() . '/filesystem/functions/chmod.xml', $paths);
+        $this->assertArrayHasKey(DocPage::findReferenceDir() . '/spl/appenditerator/getarrayiterator.xml', $paths);
     }
 }


### PR DESCRIPTION

I want to be able to move some files around, and having specific paths hard-coded all over the place makes it hard to move anything without breaking everything
