### PR TITLE
Run phpstan on unit test directory

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ includes:
 parameters:
     paths:
         - ./lib
+        - ./tests
     # The level 9 is the highest level (with check for mixed type)
     level: 8
     ignoreErrors:

--- a/tests/DateTimeImmutableTest.php
+++ b/tests/DateTimeImmutableTest.php
@@ -29,6 +29,9 @@ final class DateTimeImmutableTest extends TestCase
         self::assertSame($dateTime->format(\DATE_ATOM), $safeImmutableDate->format(\DATE_ATOM));
     }
 
+    /**
+     * @return array<array<\DateTimeInterface>>
+     */
     public static function createFromInterfaces(): array
     {
         return [
@@ -197,10 +200,10 @@ final class DateTimeImmutableTest extends TestCase
         $end = (new \Safe\DateTimeImmutable('2020-01-03'))->modify('+1 day');
         $datePeriod = new \DatePeriod($start, new \DateInterval('P1D'), $end);
 
-        /** @var DateTimeImmutable $date */
+        /** @var \Safe\DateTimeImmutable $date */
         foreach ($datePeriod as $date) {
             $this->expectException(\Error::class);
-            $this->assertNull($date->getInnerDateTime());
+            $date->getInnerDateTime();
         }
 
     }

--- a/tests/GeneratedFilesTest.php
+++ b/tests/GeneratedFilesTest.php
@@ -90,7 +90,8 @@ XML;
     {
         $this->assertSame(\strtotime('+1 day'), \Safe\strtotime('+1 day'));
 
-        set_error_handler(function (): void {
+        set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline): bool {
+            return true;
         });
         try {
             $this->expectException(DatetimeException::class);
@@ -105,8 +106,8 @@ XML;
      */
     public function testOpenSslSign(): void
     {
-        \openssl_sign('foo', $signature, file_get_contents(__DIR__ . '/fixtures/id_rsa'));
-        \Safe\openssl_sign('foo', $signatureSafe, file_get_contents(__DIR__ . '/fixtures/id_rsa'));
+        \openssl_sign('foo', $signature, \Safe\file_get_contents(__DIR__ . '/fixtures/id_rsa'));
+        \Safe\openssl_sign('foo', $signatureSafe, \Safe\file_get_contents(__DIR__ . '/fixtures/id_rsa'));
 
         $this->assertSame($signature, $signatureSafe);
     }


### PR DESCRIPTION

Unit tests should _generally_ have correct types - and I specifically want to add a test which covers a type-hinting problem, which will only be revealed by phpstan (#546)
