### PR TITLE
[generator] ignore benevolence properly

### DIFF
--- a/generated/8.1/datetime.php
+++ b/generated/8.1/datetime.php
@@ -51,7 +51,7 @@ function date_parse(string $datetime): ?array
  * @param int $timestamp Unix timestamp.
  * @param float $latitude Latitude in degrees.
  * @param float $longitude Longitude in degrees.
- * @return array{sunrise: int|bool,sunset: int|bool,transit: int|bool,civil_twilight_begin: int|bool,civil_twilight_end: int|bool,nautical_twilight_begin: int|bool,nautical_twilight_end: int|bool,astronomical_twilight_begin: int|bool,astronomical_twilight_end: int|bool}|false Returns array on success.
+ * @return array{sunrise: int|bool,sunset: int|bool,transit: int|bool,civil_twilight_begin: int|bool,civil_twilight_end: int|bool,nautical_twilight_begin: int|bool,nautical_twilight_end: int|bool,astronomical_twilight_begin: int|bool,astronomical_twilight_end: int|bool} Returns array on success.
  * The structure of the array is detailed in the following list:
  *
  *
@@ -603,13 +603,13 @@ function idate(string $format, ?int $timestamp = null): int
  * 1970-2000. On systems where time_t is a 32bit signed integer, as
  * most common today, the valid range for year
  * is somewhere between 1901 and 2038.
- * @return int|false mktime returns the Unix timestamp of the arguments
+ * @return int mktime returns the Unix timestamp of the arguments
  * given.
  * If the arguments are invalid, the function returns FALSE.
  * @throws DatetimeException
  *
  */
-function mktime(int $hour, ?int $minute = null, ?int $second = null, ?int $month = null, ?int $day = null, ?int $year = null): int|false
+function mktime(int $hour, ?int $minute = null, ?int $second = null, ?int $month = null, ?int $day = null, ?int $year = null): int
 {
     error_clear_last();
     if ($year !== null) {

--- a/generated/8.1/filesystem.php
+++ b/generated/8.1/filesystem.php
@@ -1520,7 +1520,7 @@ function tempnam(string $directory, string $prefix): string
  * the file handle returned by tmpfile), or when the
  * script ends.
  *
- * @return resource|false Returns a file handle, similar to the one returned by
+ * @return resource Returns a file handle, similar to the one returned by
  * fopen, for the new file.
  * @throws FilesystemException
  *

--- a/generated/8.1/image.php
+++ b/generated/8.1/image.php
@@ -727,7 +727,7 @@ function imagecopyresized(\GdImage $dst_image, \GdImage $src_image, int $dst_x, 
  *
  * @param int $width The image width.
  * @param int $height The image height.
- * @return resource|false Returns an image object on success.
+ * @return resource Returns an image object on success.
  * @throws ImageException
  *
  */
@@ -1033,7 +1033,7 @@ function imagecreatefromxpm(string $filename)
  *
  * @param int $width Image width.
  * @param int $height Image height.
- * @return resource|false Returns an image object on success.
+ * @return resource Returns an image object on success.
  * @throws ImageException
  *
  */

--- a/generated/8.1/info.php
+++ b/generated/8.1/info.php
@@ -207,11 +207,11 @@ function dl(string $extension_filename): void
 /**
  *
  *
- * @return string|false Returns the path, as a string.
+ * @return string Returns the path, as a string.
  * @throws InfoException
  *
  */
-function get_include_path(): string|false
+function get_include_path(): string
 {
     error_clear_last();
     $safeResult = \get_include_path();
@@ -323,7 +323,7 @@ function getmyuid(): int
  * @param string $short_options
  * @param array $long_options
  * @param int|null $rest_index
- * @return array|array|array|false This function will return an array of option / argument pairs.
+ * @return array|array|array This function will return an array of option / argument pairs.
  * @throws InfoException
  *
  */

--- a/generated/8.2/datetime.php
+++ b/generated/8.2/datetime.php
@@ -135,7 +135,7 @@ function date_parse(string $datetime): ?array
  * @param int $timestamp Unix timestamp.
  * @param float $latitude Latitude in degrees.
  * @param float $longitude Longitude in degrees.
- * @return array{sunrise: int|bool,sunset: int|bool,transit: int|bool,civil_twilight_begin: int|bool,civil_twilight_end: int|bool,nautical_twilight_begin: int|bool,nautical_twilight_end: int|bool,astronomical_twilight_begin: int|bool,astronomical_twilight_end: int|bool}|false Returns array on success.
+ * @return array{sunrise: int|bool,sunset: int|bool,transit: int|bool,civil_twilight_begin: int|bool,civil_twilight_end: int|bool,nautical_twilight_begin: int|bool,nautical_twilight_end: int|bool,astronomical_twilight_begin: int|bool,astronomical_twilight_end: int|bool} Returns array on success.
  * The structure of the array is detailed in the following list:
  *
  *

--- a/generated/8.2/filesystem.php
+++ b/generated/8.2/filesystem.php
@@ -1526,7 +1526,7 @@ function tempnam(string $directory, string $prefix): string
  * the file handle returned by tmpfile), or when the
  * script ends.
  *
- * @return resource|false Returns a file handle, similar to the one returned by
+ * @return resource Returns a file handle, similar to the one returned by
  * fopen, for the new file.
  * @throws FilesystemException
  *

--- a/generated/8.2/image.php
+++ b/generated/8.2/image.php
@@ -705,7 +705,7 @@ function imagecopyresized(\GdImage $dst_image, \GdImage $src_image, int $dst_x, 
  *
  * @param int $width The image width.
  * @param int $height The image height.
- * @return resource|false Returns an image object on success.
+ * @return resource Returns an image object on success.
  * @throws ImageException
  *
  */
@@ -1012,7 +1012,7 @@ function imagecreatefromxpm(string $filename)
  *
  * @param int $width Image width.
  * @param int $height Image height.
- * @return resource|false Returns an image object on success.
+ * @return resource Returns an image object on success.
  * @throws ImageException
  *
  */

--- a/generated/8.2/info.php
+++ b/generated/8.2/info.php
@@ -207,11 +207,11 @@ function dl(string $extension_filename): void
 /**
  *
  *
- * @return string|false Returns the path, as a string.
+ * @return string Returns the path, as a string.
  * @throws InfoException
  *
  */
-function get_include_path(): string|false
+function get_include_path(): string
 {
     error_clear_last();
     $safeResult = \get_include_path();
@@ -323,7 +323,7 @@ function getmyuid(): int
  * @param string $short_options
  * @param array $long_options
  * @param int|null $rest_index
- * @return array|array|array|false This function will return an array of option / argument pairs.
+ * @return array|array|array This function will return an array of option / argument pairs.
  * @throws InfoException
  *
  */

--- a/generated/8.3/datetime.php
+++ b/generated/8.3/datetime.php
@@ -135,7 +135,7 @@ function date_parse(string $datetime): ?array
  * @param int $timestamp Unix timestamp.
  * @param float $latitude Latitude in degrees.
  * @param float $longitude Longitude in degrees.
- * @return array{sunrise: int|bool,sunset: int|bool,transit: int|bool,civil_twilight_begin: int|bool,civil_twilight_end: int|bool,nautical_twilight_begin: int|bool,nautical_twilight_end: int|bool,astronomical_twilight_begin: int|bool,astronomical_twilight_end: int|bool}|false Returns array on success.
+ * @return array{sunrise: int|bool,sunset: int|bool,transit: int|bool,civil_twilight_begin: int|bool,civil_twilight_end: int|bool,nautical_twilight_begin: int|bool,nautical_twilight_end: int|bool,astronomical_twilight_begin: int|bool,astronomical_twilight_end: int|bool} Returns array on success.
  * The structure of the array is detailed in the following list:
  *
  *

--- a/generated/8.3/filesystem.php
+++ b/generated/8.3/filesystem.php
@@ -1526,7 +1526,7 @@ function tempnam(string $directory, string $prefix): string
  * the file handle returned by tmpfile), or when the
  * script ends.
  *
- * @return resource|false Returns a file handle, similar to the one returned by
+ * @return resource Returns a file handle, similar to the one returned by
  * fopen, for the new file.
  * @throws FilesystemException
  *

--- a/generated/8.3/image.php
+++ b/generated/8.3/image.php
@@ -705,7 +705,7 @@ function imagecopyresized(\GdImage $dst_image, \GdImage $src_image, int $dst_x, 
  *
  * @param int $width The image width.
  * @param int $height The image height.
- * @return resource|false Returns an image object on success.
+ * @return resource Returns an image object on success.
  * @throws ImageException
  *
  */
@@ -1012,7 +1012,7 @@ function imagecreatefromxpm(string $filename)
  *
  * @param int $width Image width.
  * @param int $height Image height.
- * @return resource|false Returns an image object on success.
+ * @return resource Returns an image object on success.
  * @throws ImageException
  *
  */

--- a/generated/8.3/info.php
+++ b/generated/8.3/info.php
@@ -207,11 +207,11 @@ function dl(string $extension_filename): void
 /**
  *
  *
- * @return string|false Returns the path, as a string.
+ * @return string Returns the path, as a string.
  * @throws InfoException
  *
  */
-function get_include_path(): string|false
+function get_include_path(): string
 {
     error_clear_last();
     $safeResult = \get_include_path();
@@ -323,7 +323,7 @@ function getmyuid(): int
  * @param string $short_options
  * @param array $long_options
  * @param int|null $rest_index
- * @return array|array|array|false This function will return an array of option / argument pairs.
+ * @return array|array|array This function will return an array of option / argument pairs.
  * @throws InfoException
  *
  */

--- a/generated/8.4/filesystem.php
+++ b/generated/8.4/filesystem.php
@@ -1488,7 +1488,7 @@ function tempnam(string $directory, string $prefix): string
  * the file handle returned by tmpfile), or when the
  * script ends.
  *
- * @return resource|false Returns a file handle, similar to the one returned by
+ * @return resource Returns a file handle, similar to the one returned by
  * fopen, for the new file.
  * @throws FilesystemException
  *

--- a/generated/8.4/image.php
+++ b/generated/8.4/image.php
@@ -705,7 +705,7 @@ function imagecopyresized(\GdImage $dst_image, \GdImage $src_image, int $dst_x, 
  *
  * @param int $width The image width.
  * @param int $height The image height.
- * @return resource|false Returns an image object on success.
+ * @return resource Returns an image object on success.
  * @throws ImageException
  *
  */
@@ -1012,7 +1012,7 @@ function imagecreatefromxpm(string $filename)
  *
  * @param int $width Image width.
  * @param int $height Image height.
- * @return resource|false Returns an image object on success.
+ * @return resource Returns an image object on success.
  * @throws ImageException
  *
  */

--- a/generated/8.4/info.php
+++ b/generated/8.4/info.php
@@ -90,11 +90,11 @@ function dl(string $extension_filename): void
 /**
  *
  *
- * @return string|false Returns the path, as a string.
+ * @return string Returns the path, as a string.
  * @throws InfoException
  *
  */
-function get_include_path(): string|false
+function get_include_path(): string
 {
     error_clear_last();
     $safeResult = \get_include_path();
@@ -206,7 +206,7 @@ function getmyuid(): int
  * @param string $short_options
  * @param array $long_options
  * @param int|null $rest_index
- * @return array|array|array|false This function will return an array of option / argument pairs.
+ * @return array|array|array This function will return an array of option / argument pairs.
  * @throws InfoException
  *
  */

--- a/generated/8.5/filesystem.php
+++ b/generated/8.5/filesystem.php
@@ -1488,7 +1488,7 @@ function tempnam(string $directory, string $prefix): string
  * the file handle returned by tmpfile), or when the
  * script ends.
  *
- * @return resource|false Returns a file handle, similar to the one returned by
+ * @return resource Returns a file handle, similar to the one returned by
  * fopen, for the new file.
  * @throws FilesystemException
  *

--- a/generated/8.5/image.php
+++ b/generated/8.5/image.php
@@ -705,7 +705,7 @@ function imagecopyresized(\GdImage $dst_image, \GdImage $src_image, int $dst_x, 
  *
  * @param int $width The image width.
  * @param int $height The image height.
- * @return resource|false Returns an image object on success.
+ * @return resource Returns an image object on success.
  * @throws ImageException
  *
  */
@@ -1012,7 +1012,7 @@ function imagecreatefromxpm(string $filename)
  *
  * @param int $width Image width.
  * @param int $height Image height.
- * @return resource|false Returns an image object on success.
+ * @return resource Returns an image object on success.
  * @throws ImageException
  *
  */

--- a/generated/8.5/info.php
+++ b/generated/8.5/info.php
@@ -90,11 +90,11 @@ function dl(string $extension_filename): void
 /**
  *
  *
- * @return string|false Returns the path, as a string.
+ * @return string Returns the path, as a string.
  * @throws InfoException
  *
  */
-function get_include_path(): string|false
+function get_include_path(): string
 {
     error_clear_last();
     $safeResult = \get_include_path();
@@ -206,7 +206,7 @@ function getmyuid(): int
  * @param string $short_options
  * @param array $long_options
  * @param int|null $rest_index
- * @return array|array|array|false This function will return an array of option / argument pairs.
+ * @return array|array|array This function will return an array of option / argument pairs.
  * @throws InfoException
  *
  */

--- a/generator/src/PhpStanFunctions/PhpStanParameter.php
+++ b/generator/src/PhpStanFunctions/PhpStanParameter.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Safe\PhpStanFunctions;
 
-use Safe\XmlDocParser\Type;
-
 class PhpStanParameter
 {
     private readonly string $name;

--- a/generator/src/PhpStanFunctions/PhpStanType.php
+++ b/generator/src/PhpStanFunctions/PhpStanType.php
@@ -30,6 +30,10 @@ class PhpStanType
 
     public function __construct(string $data, bool $writeOnly = false)
     {
+        if (\preg_match('/__benevolent\<(.*)\>/', $data, $regs)) {
+            $data = $regs[1];
+        }
+
         //weird case: null|false => null
         if ($data === 'null|false') {
             $this->nullable = false;
@@ -95,10 +99,6 @@ class PhpStanType
 
             if (str_contains($returnType, 'int<')) {
                 $returnType = 'int';
-            }
-
-            if (\preg_match('/__benevolent\<(.*)\>/', $returnType, $regs)) {
-                $returnType = $regs[1];
             }
 
             $returnType = Type::toRootNamespace($returnType);

--- a/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
@@ -111,11 +111,11 @@ class PhpStanTypeTest extends TestCase
     {
         $param = new PhpStanType('');
         $this->assertEquals('', $param->getDocBlockType());
-		if (PHP_VERSION_ID >= 80200) {
-        	$this->assertEquals('void', $param->getSignatureType());
-		} else {
-        	$this->assertEquals('', $param->getSignatureType());
-		}
+        if (PHP_VERSION_ID >= 80200) {
+            $this->assertEquals('void', $param->getSignatureType());
+        } else {
+            $this->assertEquals('', $param->getSignatureType());
+        }
 
         $param = new PhpStanType('void');
         $this->assertEquals('void', $param->getDocBlockType());
@@ -197,4 +197,10 @@ class PhpStanTypeTest extends TestCase
         $this->assertEquals('int', $param->getSignatureType());
     }
 
+    public function testIgnoreBenevolence(): void
+    {
+        $param = new PhpStanType('__benevolent<string|false>');
+        $this->assertEquals('string', $param->getDocBlockType(Method::FALSY_TYPE));
+        $this->assertEquals('string', $param->getSignatureType(Method::FALSY_TYPE));
+    }
 }


### PR DESCRIPTION

functions which phpstan marked as `__benevolent<foo|bar>` were being type-hinted as `foo|bar` verbatim, when what we actually want to do is look inside the `benevolent` marker and check each type individually (which allows us to do things like stripping "false" from the return type when returning false becomes an exception and we never actually return false)
