### PR TITLE
Move XML type parsing into PhpStanType

### DIFF
--- a/generator/src/PhpStanFunctions/PhpStanType.php
+++ b/generator/src/PhpStanFunctions/PhpStanType.php
@@ -28,8 +28,16 @@ class PhpStanType
      */
     private array $types;
 
-    public function __construct(string $data, bool $writeOnly = false)
+    public function __construct(string|\SimpleXMLElement $data, bool $writeOnly = false)
     {
+        if ($data instanceof \SimpleXMLElement) {
+            if (isset($data['class']) && ((string)$data['class']) === 'union') {
+                $data = implode('|', (array)$data->type);
+            } else {
+                $data = (string)$data;
+            }
+        }
+
         if (\preg_match('/__benevolent\<(.*)\>/', $data, $regs)) {
             $data = $regs[1];
         }

--- a/generator/src/XmlDocParser/Method.php
+++ b/generator/src/XmlDocParser/Method.php
@@ -38,7 +38,7 @@ class Method
         // and the PHP docs have a more specific type hint, then we prefer
         // to use the PHP docs
         $phpStanType = $this->phpstanSignature ? $this->phpstanSignature->getReturnType() : null;
-        $phpDocType = $this->parsePHPDocType($this->functionObject);
+        $phpDocType = new PhpStanType($this->functionObject->type);
         if ($phpStanType && $phpStanType->getDocBlockType($errorType) === "resource" && $phpDocType->getDocBlockType($errorType) !== "") {
             $phpStanType = null;
         }
@@ -240,14 +240,5 @@ class Method
         \array_pop($params);
         $new->params = $params;
         return $new;
-    }
-
-    public function parsePHPDocType(\SimpleXMLElement $functionObject): PhpStanType
-    {
-        if (isset($functionObject->type['class']) && ((string)$functionObject->type['class']) === 'union') {
-            return new PhpStanType(implode('|', (array)$functionObject->type->type));
-        }
-
-        return new PhpStanType($functionObject->type->__toString());
     }
 }

--- a/generator/src/XmlDocParser/Parameter.php
+++ b/generator/src/XmlDocParser/Parameter.php
@@ -22,7 +22,7 @@ class Parameter
         // and the PHP docs have a more specific type hint, then we prefer
         // to use the PHP docs
         $phpStanType = $phpStanParam ? $phpStanParam->getType() : null;
-        $phpDocType = new PhpStanType($this->getParameterType());
+        $phpDocType = new PhpStanType($this->parameter->type);
         if ($phpStanType && $phpStanType->getDocBlockType() === "resource" && $phpDocType->getDocBlockType() !== "") {
             $phpStanType = null;
         }
@@ -52,7 +52,7 @@ class Parameter
 
     public function getParameterType(): string
     {
-        return $this->parameter->type->__toString();
+        return (new PhpStanType($this->parameter->type))->getDocBlockType();
     }
 
     public function isByReference(): bool

--- a/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
@@ -203,4 +203,20 @@ class PhpStanTypeTest extends TestCase
         $this->assertEquals('string', $param->getDocBlockType(Method::FALSY_TYPE));
         $this->assertEquals('string', $param->getSignatureType(Method::FALSY_TYPE));
     }
+
+    public function testTypeFromXML(): void
+    {
+        $xml = \simplexml_load_string('<type>string</type>');
+        $this->assertNotFalse($xml);
+        $param = new PhpStanType($xml);
+        $this->assertEquals('string', $param->getDocBlockType());
+    }
+
+    public function testUnionFromXML(): void
+    {
+        $xml = \simplexml_load_string('<type class="union"><type>OpenSSLCertificate</type><type>string</type></type>');
+        $this->assertNotFalse($xml);
+        $param = new PhpStanType($xml);
+        $this->assertEquals('\OpenSSLCertificate|string', $param->getDocBlockType());
+    }
 }


### PR DESCRIPTION

Both parameter-types _and_ return-types need to support XML Union Objects
