### PR TITLE
Move XML type parsing into PhpStanType

### DIFF
--- a/generated/8.1/dir.php
+++ b/generated/8.1/dir.php
@@ -78,7 +78,7 @@ function getcwd(): string
  * rewinddir calls.
  *
  * @param string $directory The directory path that is to be opened
- * @param resource $context For a description of the context parameter,
+ * @param resource|null $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return resource Returns a directory handle resource on success
@@ -110,7 +110,7 @@ function opendir(string $directory, $context = null)
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
  * SCANDIR_SORT_NONE then the result is unsorted.
- * @param resource $context For a description of the context parameter,
+ * @param resource|null $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return array Returns an array of filenames on success. If directory is not a directory, then

--- a/generated/8.1/image.php
+++ b/generated/8.1/image.php
@@ -267,7 +267,7 @@ function imagearc(\GdImage $image, int $center_x, int $center_y, int $width, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param  $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst quality, smaller file)
  * to 100 (best quality, larger file).
  * If -1 is provided, the default value 30 is used.

--- a/generated/8.1/misc.php
+++ b/generated/8.1/misc.php
@@ -353,7 +353,7 @@ function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): void
  * CTRL+BREAK events. Note that in multithreaded environments,
  * this is only possible when called from the main thread.
  *
- * @param  $handler A callback function to set or remove. If set, this function will be called
+ * @param callable|null $handler A callback function to set or remove. If set, this function will be called
  * whenever a CTRL+C or CTRL+BREAK event
  * occurs. The function is supposed to have the following signature:
  *
@@ -378,7 +378,7 @@ function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): void
  * @throws MiscException
  *
  */
-function sapi_windows_set_ctrl_handler($handler, bool $add = true): void
+function sapi_windows_set_ctrl_handler(?callable $handler, bool $add = true): void
 {
     error_clear_last();
     $safeResult = \sapi_windows_set_ctrl_handler($handler, $add);

--- a/generated/8.1/openssl.php
+++ b/generated/8.1/openssl.php
@@ -28,8 +28,8 @@ function openssl_cipher_iv_length(string $cipher_algo): int
  *
  * @param string $input_filename The name of a file containing encrypted content.
  * @param string $output_filename The name of the file to deposit the decrypted content.
- * @param  $certificate The name of the file containing a certificate of the recipient.
- * @param  $private_key The name of the file containing a PKCS#8 key.
+ * @param \OpenSSLCertificate|string $certificate The name of the file containing a certificate of the recipient.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key The name of the file containing a PKCS#8 key.
  * @param int $encoding The encoding of the input file. One of OPENSSL_CMS_SMIME,
  * OPENSLL_CMS_DER or OPENSSL_CMS_PEM.
  * @throws OpensslException
@@ -57,8 +57,8 @@ function openssl_cms_decrypt(string $input_filename, string $output_filename, $c
  *
  * @param string $input_filename The file to be encrypted.
  * @param string $output_filename The output file.
- * @param  $certificate Recipients to encrypt to.
- * @param  $headers Headers to include when S/MIME is used.
+ * @param \OpenSSLCertificate|array|string $certificate Recipients to encrypt to.
+ * @param array|null $headers Headers to include when S/MIME is used.
  * @param int $flags Flags to be passed to CMS_sign.
  * @param int $encoding An encoding to output. One of OPENSSL_CMS_SMIME,
  * OPENSLL_CMS_DER or OPENSSL_CMS_PEM.
@@ -66,7 +66,7 @@ function openssl_cms_decrypt(string $input_filename, string $output_filename, $c
  * @throws OpensslException
  *
  */
-function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, int $cipher_algo = OPENSSL_CIPHER_RC2_40): void
+function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, int $cipher_algo = OPENSSL_CIPHER_RC2_40): void
 {
     error_clear_last();
     $safeResult = \openssl_cms_encrypt($input_filename, $output_filename, $certificate, $headers, $flags, $encoding, $cipher_algo);
@@ -99,19 +99,19 @@ function openssl_cms_read(string $input_filename, array &$certificates): void
  *
  * @param string $input_filename The name of the file to be signed.
  * @param string $output_filename The name of the file to deposit the results.
- * @param  $certificate The signing certificate.
+ * @param \OpenSSLCertificate|string $certificate The signing certificate.
  * See Key/Certificate parameters for a list of valid values.
- * @param  $private_key The key associated with certificate.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key The key associated with certificate.
  * See Key/Certificate parameters for a list of valid values.
- * @param  $headers An array of headers to be included in S/MIME output.
+ * @param array|null $headers An array of headers to be included in S/MIME output.
  * @param int $flags Flags to be passed to cms_sign.
  * @param int $encoding The encoding of the output file. One of OPENSSL_CMS_SMIME,
  * OPENSLL_CMS_DER or OPENSSL_CMS_PEM.
- * @param  $untrusted_certificates_filename Intermediate certificates to be included in the signature.
+ * @param string|null $untrusted_certificates_filename Intermediate certificates to be included in the signature.
  * @throws OpensslException
  *
  */
-function openssl_cms_sign(string $input_filename, string $output_filename, $certificate, $private_key, $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, $untrusted_certificates_filename = null): void
+function openssl_cms_sign(string $input_filename, string $output_filename, $certificate, $private_key, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, ?string $untrusted_certificates_filename = null): void
 {
     error_clear_last();
     if ($untrusted_certificates_filename !== null) {
@@ -130,18 +130,18 @@ function openssl_cms_sign(string $input_filename, string $output_filename, $cert
  *
  * @param string $input_filename The input file.
  * @param int $flags Flags to pass to cms_verify.
- * @param  $certificates A file with the signer certificate and optionally intermediate certificates.
+ * @param string|null $certificates A file with the signer certificate and optionally intermediate certificates.
  * @param array $ca_info An array containing self-signed certificate authority certificates.
- * @param  $untrusted_certificates_filename A file containing additional intermediate certificates.
- * @param  $content A file pointing to the content when signatures are detached.
- * @param  $pk7
- * @param  $sigfile A file to save the signature to.
+ * @param string|null $untrusted_certificates_filename A file containing additional intermediate certificates.
+ * @param string|null $content A file pointing to the content when signatures are detached.
+ * @param string|null $pk7
+ * @param string|null $sigfile A file to save the signature to.
  * @param int $encoding The encoding of the input file. One of OPENSSL_CMS_SMIME,
  * OPENSLL_CMS_DER or OPENSSL_CMS_PEM.
  * @throws OpensslException
  *
  */
-function openssl_cms_verify(string $input_filename, int $flags = 0, $certificates = null, array $ca_info = [], $untrusted_certificates_filename = null, $content = null, $pk7 = null, $sigfile = null, int $encoding = OPENSSL_ENCODING_SMIME): void
+function openssl_cms_verify(string $input_filename, int $flags = 0, ?string $certificates = null, array $ca_info = [], ?string $untrusted_certificates_filename = null, ?string $content = null, ?string $pk7 = null, ?string $sigfile = null, int $encoding = OPENSSL_ENCODING_SMIME): void
 {
     error_clear_last();
     if ($encoding !== OPENSSL_ENCODING_SMIME) {
@@ -860,9 +860,9 @@ function openssl_pkcs7_sign(string $input_filename, string $output_filename, $ce
  * openssl_pkey_derive takes a set of a public_key
  * and private_key and derives a shared secret, for either DH or EC keys.
  *
- * @param resource $public_key public_key is the public key for the derivation.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key public_key is the public key for the derivation.
  * See Public/Private Key parameters for a list of valid values.
- * @param resource $private_key private_key is the private key for the derivation.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key is the private key for the derivation.
  * See Public/Private Key parameters for a list of valid values.
  * @param int $key_length If not zero, will set the desired length of the derived secret.
  * @return string The derived secret on success.
@@ -917,7 +917,7 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * key as a PEM encoded string and stores it into
  * output (which is passed by reference).
  *
- * @param resource $key
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param string|null $output
  * @param string|null $passphrase The key is optionally protected by passphrase.
  * @param array $options options can be used to fine-tune the export

--- a/generated/8.1/pgsql.php
+++ b/generated/8.1/pgsql.php
@@ -239,7 +239,7 @@ function pg_delete(\PgSql\Connection $connection, string $table_name, array $con
  * must be issued, otherwise the PostgreSQL server may get out of
  * sync with the frontend and will report an error.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -247,7 +247,7 @@ function pg_delete(\PgSql\Connection $connection, string $table_name, array $con
  * @throws PgsqlException
  *
  */
-function pg_end_copy($connection = null): void
+function pg_end_copy(?\PgSql\Connection $connection = null): void
 {
     error_clear_last();
     if ($connection !== null) {
@@ -390,7 +390,7 @@ function pg_free_result(\PgSql\Result $result): void
  * PostgreSQL connection instance is
  * connected to.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -400,7 +400,7 @@ function pg_free_result(\PgSql\Result $result): void
  * @throws PgsqlException
  *
  */
-function pg_host($connection = null): string
+function pg_host(?\PgSql\Connection $connection = null): string
 {
     error_clear_last();
     if ($connection !== null) {
@@ -899,7 +899,7 @@ function pg_pconnect(string $connection_string, int $flags = 0): \PgSql\Connecti
  * pg_ping pings a database connection and tries to
  * reconnect it if it is broken.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -907,7 +907,7 @@ function pg_pconnect(string $connection_string, int $flags = 0): \PgSql\Connecti
  * @throws PgsqlException
  *
  */
-function pg_ping($connection = null): void
+function pg_ping(?\PgSql\Connection $connection = null): void
 {
     error_clear_last();
     if ($connection !== null) {
@@ -1289,7 +1289,7 @@ function pg_socket(\PgSql\Connection $connection)
  * @param string $filename The full path and file name of the file in which to write the
  * trace log.  Same as in fopen.
  * @param string $mode An optional file access mode, same as for fopen.
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -1297,7 +1297,7 @@ function pg_socket(\PgSql\Connection $connection)
  * @throws PgsqlException
  *
  */
-function pg_trace(string $filename, string $mode = "w", $connection = null): void
+function pg_trace(string $filename, string $mode = "w", ?\PgSql\Connection $connection = null): void
 {
     error_clear_last();
     if ($connection !== null) {

--- a/generated/8.1/url.php
+++ b/generated/8.1/url.php
@@ -36,7 +36,7 @@ function base64_decode(string $string, bool $strict = false): string
  * @param bool $associative If the optional associative parameter is set to true,
  * get_headers parses the response and sets the
  * array's keys.
- * @param resource $context A valid context resource created with
+ * @param resource|null $context A valid context resource created with
  * stream_context_create.
  * @return array Returns an indexed or associative array with the headers.
  * @throws UrlException

--- a/generated/8.2/dir.php
+++ b/generated/8.2/dir.php
@@ -78,7 +78,7 @@ function getcwd(): string
  * rewinddir calls.
  *
  * @param string $directory The directory path that is to be opened
- * @param resource $context For a description of the context parameter,
+ * @param resource|null $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return resource Returns a directory handle resource on success
@@ -110,7 +110,7 @@ function opendir(string $directory, $context = null)
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
  * SCANDIR_SORT_NONE then the result is unsorted.
- * @param resource $context For a description of the context parameter,
+ * @param resource|null $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return array Returns an array of filenames on success. If directory is not a directory, then

--- a/generated/8.2/filesystem.php
+++ b/generated/8.2/filesystem.php
@@ -100,7 +100,7 @@ function chown(string $filename, $user): void
  * existing files.
  *
  * If the destination file already exists, it will be overwritten.
- * @param resource $context A valid context resource created with
+ * @param resource|null $context A valid context resource created with
  * stream_context_create.
  * @throws FilesystemException
  *
@@ -406,7 +406,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  *
  *
  *
- * @param resource $context
+ * @param resource|null $context
  * @return array Returns the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns FALSE.
@@ -1213,7 +1213,7 @@ function lstat(string $filename): array
  * umask.
  * @param bool $recursive If TRUE, then any parent directories to the directory specified will
  * also be created, with the same permissions.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1315,7 +1315,7 @@ function parse_ini_string(string $ini_string, bool $process_sections = false, in
  * @param string $filename The filename being read.
  * @param bool $use_include_path You can use the optional second parameter and set it to TRUE, if
  * you want to search for the file in the include_path, too.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @return int Returns the number of bytes read from the file on success
  * @throws FilesystemException
@@ -1411,7 +1411,7 @@ function realpath(string $path): string
  * Otherwise rename fails and issues E_WARNING.
  *
  *
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1455,7 +1455,7 @@ function rewind($stream): void
  * A E_WARNING level error will be generated on failure.
  *
  * @param string $directory Path to the directory.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1586,7 +1586,7 @@ function touch(string $filename, ?int $mtime = null, ?int $atime = null): void
  *
  * If the file is a symlink, the symlink will be deleted. On Windows, to delete
  * a symlink to a directory, rmdir has to be used instead.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *

--- a/generated/8.2/image.php
+++ b/generated/8.2/image.php
@@ -267,7 +267,7 @@ function imagearc(\GdImage $image, int $center_x, int $center_y, int $width, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param  $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst quality, smaller file)
  * to 100 (best quality, larger file).
  * If -1 is provided, the default value 30 is used.

--- a/generated/8.2/misc.php
+++ b/generated/8.2/misc.php
@@ -353,7 +353,7 @@ function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): void
  * CTRL+BREAK events. Note that in multithreaded environments,
  * this is only possible when called from the main thread.
  *
- * @param  $handler A callback function to set or remove. If set, this function will be called
+ * @param callable|null $handler A callback function to set or remove. If set, this function will be called
  * whenever a CTRL+C or CTRL+BREAK event
  * occurs. The function is supposed to have the following signature:
  *
@@ -378,7 +378,7 @@ function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): void
  * @throws MiscException
  *
  */
-function sapi_windows_set_ctrl_handler($handler, bool $add = true): void
+function sapi_windows_set_ctrl_handler(?callable $handler, bool $add = true): void
 {
     error_clear_last();
     $safeResult = \sapi_windows_set_ctrl_handler($handler, $add);

--- a/generated/8.2/openssl.php
+++ b/generated/8.2/openssl.php
@@ -47,8 +47,8 @@ function openssl_cipher_key_length(string $cipher_algo): int
  *
  * @param string $input_filename The name of a file containing encrypted content.
  * @param string $output_filename The name of the file to deposit the decrypted content.
- * @param  $certificate The name of the file containing a certificate of the recipient.
- * @param  $private_key The name of the file containing a PKCS#8 key.
+ * @param \OpenSSLCertificate|string $certificate The name of the file containing a certificate of the recipient.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key The name of the file containing a PKCS#8 key.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
@@ -76,8 +76,8 @@ function openssl_cms_decrypt(string $input_filename, string $output_filename, $c
  *
  * @param string $input_filename The file to be encrypted.
  * @param string $output_filename The output file.
- * @param  $certificate Recipients to encrypt to.
- * @param  $headers Headers to include when S/MIME is used.
+ * @param \OpenSSLCertificate|array|string $certificate Recipients to encrypt to.
+ * @param array|null $headers Headers to include when S/MIME is used.
  * @param int $flags Flags to be passed to CMS_sign.
  * @param int $encoding An encoding to output. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
@@ -85,7 +85,7 @@ function openssl_cms_decrypt(string $input_filename, string $output_filename, $c
  * @throws OpensslException
  *
  */
-function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, int $cipher_algo = OPENSSL_CIPHER_AES_128_CBC): void
+function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, int $cipher_algo = OPENSSL_CIPHER_AES_128_CBC): void
 {
     error_clear_last();
     $safeResult = \openssl_cms_encrypt($input_filename, $output_filename, $certificate, $headers, $flags, $encoding, $cipher_algo);
@@ -118,19 +118,19 @@ function openssl_cms_read(string $input_filename, array &$certificates): void
  *
  * @param string $input_filename The name of the file to be signed.
  * @param string $output_filename The name of the file to deposit the results.
- * @param  $certificate The signing certificate.
+ * @param \OpenSSLCertificate|string $certificate The signing certificate.
  * See Key/Certificate parameters for a list of valid values.
- * @param  $private_key The key associated with certificate.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key The key associated with certificate.
  * See Key/Certificate parameters for a list of valid values.
- * @param  $headers An array of headers to be included in S/MIME output.
+ * @param array|null $headers An array of headers to be included in S/MIME output.
  * @param int $flags Flags to be passed to cms_sign.
  * @param int $encoding The encoding of the output file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
- * @param  $untrusted_certificates_filename Intermediate certificates to be included in the signature.
+ * @param string|null $untrusted_certificates_filename Intermediate certificates to be included in the signature.
  * @throws OpensslException
  *
  */
-function openssl_cms_sign(string $input_filename, string $output_filename, $certificate, $private_key, $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, $untrusted_certificates_filename = null): void
+function openssl_cms_sign(string $input_filename, string $output_filename, $certificate, $private_key, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, ?string $untrusted_certificates_filename = null): void
 {
     error_clear_last();
     if ($untrusted_certificates_filename !== null) {
@@ -149,18 +149,18 @@ function openssl_cms_sign(string $input_filename, string $output_filename, $cert
  *
  * @param string $input_filename The input file.
  * @param int $flags Flags to pass to cms_verify.
- * @param  $certificates A file with the signer certificate and optionally intermediate certificates.
+ * @param string|null $certificates A file with the signer certificate and optionally intermediate certificates.
  * @param array $ca_info An array containing self-signed certificate authority certificates.
- * @param  $untrusted_certificates_filename A file containing additional intermediate certificates.
- * @param  $content A file pointing to the content when signatures are detached.
- * @param  $pk7
- * @param  $sigfile A file to save the signature to.
+ * @param string|null $untrusted_certificates_filename A file containing additional intermediate certificates.
+ * @param string|null $content A file pointing to the content when signatures are detached.
+ * @param string|null $pk7
+ * @param string|null $sigfile A file to save the signature to.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
  *
  */
-function openssl_cms_verify(string $input_filename, int $flags = 0, $certificates = null, array $ca_info = [], $untrusted_certificates_filename = null, $content = null, $pk7 = null, $sigfile = null, int $encoding = OPENSSL_ENCODING_SMIME): void
+function openssl_cms_verify(string $input_filename, int $flags = 0, ?string $certificates = null, array $ca_info = [], ?string $untrusted_certificates_filename = null, ?string $content = null, ?string $pk7 = null, ?string $sigfile = null, int $encoding = OPENSSL_ENCODING_SMIME): void
 {
     error_clear_last();
     if ($encoding !== OPENSSL_ENCODING_SMIME) {
@@ -885,9 +885,9 @@ function openssl_pkcs7_sign(string $input_filename, string $output_filename, $ce
  * openssl_pkey_derive takes a set of a public_key
  * and private_key and derives a shared secret, for either DH or EC keys.
  *
- * @param resource $public_key public_key is the public key for the derivation.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key public_key is the public key for the derivation.
  * See Public/Private Key parameters for a list of valid values.
- * @param resource $private_key private_key is the private key for the derivation.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key is the private key for the derivation.
  * See Public/Private Key parameters for a list of valid values.
  * @param int $key_length If not zero, will set the desired length of the derived secret.
  * @return string The derived secret on success.
@@ -942,7 +942,7 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * key as a PEM encoded string and stores it into
  * output (which is passed by reference).
  *
- * @param resource $key
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param string|null $output
  * @param string|null $passphrase The key is optionally protected by passphrase.
  * @param array $options options can be used to fine-tune the export

--- a/generated/8.2/pgsql.php
+++ b/generated/8.2/pgsql.php
@@ -239,7 +239,7 @@ function pg_delete(\PgSql\Connection $connection, string $table_name, array $con
  * must be issued, otherwise the PostgreSQL server may get out of
  * sync with the frontend and will report an error.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -247,7 +247,7 @@ function pg_delete(\PgSql\Connection $connection, string $table_name, array $con
  * @throws PgsqlException
  *
  */
-function pg_end_copy($connection = null): void
+function pg_end_copy(?\PgSql\Connection $connection = null): void
 {
     error_clear_last();
     if ($connection !== null) {
@@ -390,7 +390,7 @@ function pg_free_result(\PgSql\Result $result): void
  * PostgreSQL connection instance is
  * connected to.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -400,7 +400,7 @@ function pg_free_result(\PgSql\Result $result): void
  * @throws PgsqlException
  *
  */
-function pg_host($connection = null): string
+function pg_host(?\PgSql\Connection $connection = null): string
 {
     error_clear_last();
     if ($connection !== null) {
@@ -899,7 +899,7 @@ function pg_pconnect(string $connection_string, int $flags = 0): \PgSql\Connecti
  * pg_ping pings a database connection and tries to
  * reconnect it if it is broken.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -907,7 +907,7 @@ function pg_pconnect(string $connection_string, int $flags = 0): \PgSql\Connecti
  * @throws PgsqlException
  *
  */
-function pg_ping($connection = null): void
+function pg_ping(?\PgSql\Connection $connection = null): void
 {
     error_clear_last();
     if ($connection !== null) {
@@ -1289,7 +1289,7 @@ function pg_socket(\PgSql\Connection $connection)
  * @param string $filename The full path and file name of the file in which to write the
  * trace log.  Same as in fopen.
  * @param string $mode An optional file access mode, same as for fopen.
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -1297,7 +1297,7 @@ function pg_socket(\PgSql\Connection $connection)
  * @throws PgsqlException
  *
  */
-function pg_trace(string $filename, string $mode = "w", $connection = null): void
+function pg_trace(string $filename, string $mode = "w", ?\PgSql\Connection $connection = null): void
 {
     error_clear_last();
     if ($connection !== null) {

--- a/generated/8.2/stream.php
+++ b/generated/8.2/stream.php
@@ -434,7 +434,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * STREAM_CLIENT_CONNECT (default),
  * STREAM_CLIENT_ASYNC_CONNECT and
  * STREAM_CLIENT_PERSISTENT.
- * @param resource $context A valid context resource created with stream_context_create.
+ * @param resource|null $context A valid context resource created with stream_context_create.
  * @return resource On success a stream resource is returned which may
  * be used together with the other file functions (such as
  * fgets, fgetss,
@@ -641,7 +641,7 @@ function stream_socket_sendto($socket, string $data, int $flags = 0, string $add
  *
  * For UDP sockets, you must use STREAM_SERVER_BIND as
  * the flags parameter.
- * @param resource $context
+ * @param resource|null $context
  * @return resource Returns the created stream.
  * @throws StreamException
  *

--- a/generated/8.2/url.php
+++ b/generated/8.2/url.php
@@ -36,7 +36,7 @@ function base64_decode(string $string, bool $strict = false): string
  * @param bool $associative If the optional associative parameter is set to true,
  * get_headers parses the response and sets the
  * array's keys.
- * @param resource $context A valid context resource created with
+ * @param resource|null $context A valid context resource created with
  * stream_context_create, or NULL to use the
  * default context.
  * @return array Returns an indexed or associative array with the headers.

--- a/generated/8.3/dir.php
+++ b/generated/8.3/dir.php
@@ -78,7 +78,7 @@ function getcwd(): string
  * rewinddir calls.
  *
  * @param string $directory The directory path that is to be opened
- * @param resource $context For a description of the context parameter,
+ * @param resource|null $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return resource Returns a directory handle resource on success
@@ -110,7 +110,7 @@ function opendir(string $directory, $context = null)
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
  * SCANDIR_SORT_NONE then the result is unsorted.
- * @param resource $context For a description of the context parameter,
+ * @param resource|null $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return array Returns an array of filenames on success. If directory is not a directory, then

--- a/generated/8.3/filesystem.php
+++ b/generated/8.3/filesystem.php
@@ -100,7 +100,7 @@ function chown(string $filename, $user): void
  * existing files.
  *
  * If the destination file already exists, it will be overwritten.
- * @param resource $context A valid context resource created with
+ * @param resource|null $context A valid context resource created with
  * stream_context_create.
  * @throws FilesystemException
  *
@@ -406,7 +406,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  *
  *
  *
- * @param resource $context
+ * @param resource|null $context
  * @return array Returns the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns FALSE.
@@ -1213,7 +1213,7 @@ function lstat(string $filename): array
  * umask.
  * @param bool $recursive If TRUE, then any parent directories to the directory specified will
  * also be created, with the same permissions.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1315,7 +1315,7 @@ function parse_ini_string(string $ini_string, bool $process_sections = false, in
  * @param string $filename The filename being read.
  * @param bool $use_include_path You can use the optional second parameter and set it to TRUE, if
  * you want to search for the file in the include_path, too.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @return int Returns the number of bytes read from the file on success
  * @throws FilesystemException
@@ -1411,7 +1411,7 @@ function realpath(string $path): string
  * Otherwise rename fails and issues E_WARNING.
  *
  *
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1455,7 +1455,7 @@ function rewind($stream): void
  * A E_WARNING level error will be generated on failure.
  *
  * @param string $directory Path to the directory.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1586,7 +1586,7 @@ function touch(string $filename, ?int $mtime = null, ?int $atime = null): void
  *
  * If the file is a symlink, the symlink will be deleted. On Windows, to delete
  * a symlink to a directory, rmdir has to be used instead.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *

--- a/generated/8.3/image.php
+++ b/generated/8.3/image.php
@@ -267,7 +267,7 @@ function imagearc(\GdImage $image, int $center_x, int $center_y, int $width, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param  $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst quality, smaller file)
  * to 100 (best quality, larger file).
  * If -1 is provided, the default value 30 is used.

--- a/generated/8.3/misc.php
+++ b/generated/8.3/misc.php
@@ -353,7 +353,7 @@ function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): void
  * CTRL+BREAK events. Note that in multithreaded environments,
  * this is only possible when called from the main thread.
  *
- * @param  $handler A callback function to set or remove. If set, this function will be called
+ * @param callable|null $handler A callback function to set or remove. If set, this function will be called
  * whenever a CTRL+C or CTRL+BREAK event
  * occurs. The function is supposed to have the following signature:
  *
@@ -378,7 +378,7 @@ function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): void
  * @throws MiscException
  *
  */
-function sapi_windows_set_ctrl_handler($handler, bool $add = true): void
+function sapi_windows_set_ctrl_handler(?callable $handler, bool $add = true): void
 {
     error_clear_last();
     $safeResult = \sapi_windows_set_ctrl_handler($handler, $add);

--- a/generated/8.3/openssl.php
+++ b/generated/8.3/openssl.php
@@ -47,8 +47,8 @@ function openssl_cipher_key_length(string $cipher_algo): int
  *
  * @param string $input_filename The name of a file containing encrypted content.
  * @param string $output_filename The name of the file to deposit the decrypted content.
- * @param  $certificate The name of the file containing a certificate of the recipient.
- * @param  $private_key The name of the file containing a PKCS#8 key.
+ * @param \OpenSSLCertificate|string $certificate The name of the file containing a certificate of the recipient.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key The name of the file containing a PKCS#8 key.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
@@ -76,8 +76,8 @@ function openssl_cms_decrypt(string $input_filename, string $output_filename, $c
  *
  * @param string $input_filename The file to be encrypted.
  * @param string $output_filename The output file.
- * @param  $certificate Recipients to encrypt to.
- * @param  $headers Headers to include when S/MIME is used.
+ * @param \OpenSSLCertificate|array|string $certificate Recipients to encrypt to.
+ * @param array|null $headers Headers to include when S/MIME is used.
  * @param int $flags Flags to be passed to CMS_sign.
  * @param int $encoding An encoding to output. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
@@ -85,7 +85,7 @@ function openssl_cms_decrypt(string $input_filename, string $output_filename, $c
  * @throws OpensslException
  *
  */
-function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, int $cipher_algo = OPENSSL_CIPHER_AES_128_CBC): void
+function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, int $cipher_algo = OPENSSL_CIPHER_AES_128_CBC): void
 {
     error_clear_last();
     $safeResult = \openssl_cms_encrypt($input_filename, $output_filename, $certificate, $headers, $flags, $encoding, $cipher_algo);
@@ -118,19 +118,19 @@ function openssl_cms_read(string $input_filename, array &$certificates): void
  *
  * @param string $input_filename The name of the file to be signed.
  * @param string $output_filename The name of the file to deposit the results.
- * @param  $certificate The signing certificate.
+ * @param \OpenSSLCertificate|string $certificate The signing certificate.
  * See Key/Certificate parameters for a list of valid values.
- * @param  $private_key The key associated with certificate.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key The key associated with certificate.
  * See Key/Certificate parameters for a list of valid values.
- * @param  $headers An array of headers to be included in S/MIME output.
+ * @param array|null $headers An array of headers to be included in S/MIME output.
  * @param int $flags Flags to be passed to cms_sign.
  * @param int $encoding The encoding of the output file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
- * @param  $untrusted_certificates_filename Intermediate certificates to be included in the signature.
+ * @param string|null $untrusted_certificates_filename Intermediate certificates to be included in the signature.
  * @throws OpensslException
  *
  */
-function openssl_cms_sign(string $input_filename, string $output_filename, $certificate, $private_key, $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, $untrusted_certificates_filename = null): void
+function openssl_cms_sign(string $input_filename, string $output_filename, $certificate, $private_key, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, ?string $untrusted_certificates_filename = null): void
 {
     error_clear_last();
     if ($untrusted_certificates_filename !== null) {
@@ -149,18 +149,18 @@ function openssl_cms_sign(string $input_filename, string $output_filename, $cert
  *
  * @param string $input_filename The input file.
  * @param int $flags Flags to pass to cms_verify.
- * @param  $certificates A file with the signer certificate and optionally intermediate certificates.
+ * @param string|null $certificates A file with the signer certificate and optionally intermediate certificates.
  * @param array $ca_info An array containing self-signed certificate authority certificates.
- * @param  $untrusted_certificates_filename A file containing additional intermediate certificates.
- * @param  $content A file pointing to the content when signatures are detached.
- * @param  $pk7
- * @param  $sigfile A file to save the signature to.
+ * @param string|null $untrusted_certificates_filename A file containing additional intermediate certificates.
+ * @param string|null $content A file pointing to the content when signatures are detached.
+ * @param string|null $pk7
+ * @param string|null $sigfile A file to save the signature to.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
  *
  */
-function openssl_cms_verify(string $input_filename, int $flags = 0, $certificates = null, array $ca_info = [], $untrusted_certificates_filename = null, $content = null, $pk7 = null, $sigfile = null, int $encoding = OPENSSL_ENCODING_SMIME): void
+function openssl_cms_verify(string $input_filename, int $flags = 0, ?string $certificates = null, array $ca_info = [], ?string $untrusted_certificates_filename = null, ?string $content = null, ?string $pk7 = null, ?string $sigfile = null, int $encoding = OPENSSL_ENCODING_SMIME): void
 {
     error_clear_last();
     if ($encoding !== OPENSSL_ENCODING_SMIME) {
@@ -885,9 +885,9 @@ function openssl_pkcs7_sign(string $input_filename, string $output_filename, $ce
  * openssl_pkey_derive takes a set of a public_key
  * and private_key and derives a shared secret, for either DH or EC keys.
  *
- * @param resource $public_key public_key is the public key for the derivation.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key public_key is the public key for the derivation.
  * See Public/Private Key parameters for a list of valid values.
- * @param resource $private_key private_key is the private key for the derivation.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key is the private key for the derivation.
  * See Public/Private Key parameters for a list of valid values.
  * @param int $key_length If not zero, will set the desired length of the derived secret.
  * @return string The derived secret on success.
@@ -942,7 +942,7 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * key as a PEM encoded string and stores it into
  * output (which is passed by reference).
  *
- * @param resource $key
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param string|null $output
  * @param string|null $passphrase The key is optionally protected by passphrase.
  * @param array $options options can be used to fine-tune the export

--- a/generated/8.3/pgsql.php
+++ b/generated/8.3/pgsql.php
@@ -239,7 +239,7 @@ function pg_delete(\PgSql\Connection $connection, string $table_name, array $con
  * must be issued, otherwise the PostgreSQL server may get out of
  * sync with the frontend and will report an error.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -247,7 +247,7 @@ function pg_delete(\PgSql\Connection $connection, string $table_name, array $con
  * @throws PgsqlException
  *
  */
-function pg_end_copy($connection = null): void
+function pg_end_copy(?\PgSql\Connection $connection = null): void
 {
     error_clear_last();
     if ($connection !== null) {
@@ -390,7 +390,7 @@ function pg_free_result(\PgSql\Result $result): void
  * PostgreSQL connection instance is
  * connected to.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -400,7 +400,7 @@ function pg_free_result(\PgSql\Result $result): void
  * @throws PgsqlException
  *
  */
-function pg_host($connection = null): string
+function pg_host(?\PgSql\Connection $connection = null): string
 {
     error_clear_last();
     if ($connection !== null) {
@@ -899,7 +899,7 @@ function pg_pconnect(string $connection_string, int $flags = 0): \PgSql\Connecti
  * pg_ping pings a database connection and tries to
  * reconnect it if it is broken.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -907,7 +907,7 @@ function pg_pconnect(string $connection_string, int $flags = 0): \PgSql\Connecti
  * @throws PgsqlException
  *
  */
-function pg_ping($connection = null): void
+function pg_ping(?\PgSql\Connection $connection = null): void
 {
     error_clear_last();
     if ($connection !== null) {
@@ -1289,7 +1289,7 @@ function pg_socket(\PgSql\Connection $connection)
  * @param string $filename The full path and file name of the file in which to write the
  * trace log.  Same as in fopen.
  * @param string $mode An optional file access mode, same as for fopen.
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -1297,7 +1297,7 @@ function pg_socket(\PgSql\Connection $connection)
  * @throws PgsqlException
  *
  */
-function pg_trace(string $filename, string $mode = "w", $connection = null): void
+function pg_trace(string $filename, string $mode = "w", ?\PgSql\Connection $connection = null): void
 {
     error_clear_last();
     if ($connection !== null) {

--- a/generated/8.3/stream.php
+++ b/generated/8.3/stream.php
@@ -434,7 +434,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * STREAM_CLIENT_CONNECT (default),
  * STREAM_CLIENT_ASYNC_CONNECT and
  * STREAM_CLIENT_PERSISTENT.
- * @param resource $context A valid context resource created with stream_context_create.
+ * @param resource|null $context A valid context resource created with stream_context_create.
  * @return resource On success a stream resource is returned which may
  * be used together with the other file functions (such as
  * fgets, fgetss,
@@ -641,7 +641,7 @@ function stream_socket_sendto($socket, string $data, int $flags = 0, string $add
  *
  * For UDP sockets, you must use STREAM_SERVER_BIND as
  * the flags parameter.
- * @param resource $context
+ * @param resource|null $context
  * @return resource Returns the created stream.
  * @throws StreamException
  *

--- a/generated/8.3/url.php
+++ b/generated/8.3/url.php
@@ -36,7 +36,7 @@ function base64_decode(string $string, bool $strict = false): string
  * @param bool $associative If the optional associative parameter is set to true,
  * get_headers parses the response and sets the
  * array's keys.
- * @param resource $context A valid context resource created with
+ * @param resource|null $context A valid context resource created with
  * stream_context_create, or NULL to use the
  * default context.
  * @return array Returns an indexed or associative array with the headers.

--- a/generated/8.4/dir.php
+++ b/generated/8.4/dir.php
@@ -78,7 +78,7 @@ function getcwd(): string
  * rewinddir calls.
  *
  * @param string $directory The directory path that is to be opened
- * @param resource $context For a description of the context parameter,
+ * @param resource|null $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return resource Returns a directory handle resource on success
@@ -110,7 +110,7 @@ function opendir(string $directory, $context = null)
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
  * SCANDIR_SORT_NONE then the result is unsorted.
- * @param resource $context For a description of the context parameter,
+ * @param resource|null $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return array Returns an array of filenames on success. If directory is not a directory, then

--- a/generated/8.4/filesystem.php
+++ b/generated/8.4/filesystem.php
@@ -100,7 +100,7 @@ function chown(string $filename, $user): void
  * existing files.
  *
  * If the destination file already exists, it will be overwritten.
- * @param resource $context A valid context resource created with
+ * @param resource|null $context A valid context resource created with
  * stream_context_create.
  * @throws FilesystemException
  *
@@ -416,7 +416,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  *
  *
  *
- * @param resource $context
+ * @param resource|null $context
  * @return array Returns the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns FALSE.
@@ -1175,7 +1175,7 @@ function lstat(string $filename): array
  * umask.
  * @param bool $recursive If TRUE, then any parent directories to the directory specified will
  * also be created, with the same permissions.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1277,7 +1277,7 @@ function parse_ini_string(string $ini_string, bool $process_sections = false, in
  * @param string $filename The filename being read.
  * @param bool $use_include_path You can use the optional second parameter and set it to TRUE, if
  * you want to search for the file in the include_path, too.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @return int Returns the number of bytes read from the file on success
  * @throws FilesystemException
@@ -1373,7 +1373,7 @@ function realpath(string $path): string
  * Otherwise rename fails and issues E_WARNING.
  *
  *
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1417,7 +1417,7 @@ function rewind($stream): void
  * A E_WARNING level error will be generated on failure.
  *
  * @param string $directory Path to the directory.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1548,7 +1548,7 @@ function touch(string $filename, ?int $mtime = null, ?int $atime = null): void
  *
  * If the file is a symlink, the symlink will be deleted. On Windows, to delete
  * a symlink to a directory, rmdir has to be used instead.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *

--- a/generated/8.4/image.php
+++ b/generated/8.4/image.php
@@ -267,7 +267,7 @@ function imagearc(\GdImage $image, int $center_x, int $center_y, int $width, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param  $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst quality, smaller file)
  * to 100 (best quality, larger file).
  * If -1 is provided, the default value 30 is used.

--- a/generated/8.4/misc.php
+++ b/generated/8.4/misc.php
@@ -161,7 +161,7 @@ function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): void
  * CTRL+BREAK events. Note that in multithreaded environments,
  * this is only possible when called from the main thread.
  *
- * @param  $handler A callback function to set or remove. If set, this function will be called
+ * @param callable|null $handler A callback function to set or remove. If set, this function will be called
  * whenever a
  *
  * CTRL
@@ -205,7 +205,7 @@ function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): void
  * @throws MiscException
  *
  */
-function sapi_windows_set_ctrl_handler($handler, bool $add = true): void
+function sapi_windows_set_ctrl_handler(?callable $handler, bool $add = true): void
 {
     error_clear_last();
     $safeResult = \sapi_windows_set_ctrl_handler($handler, $add);

--- a/generated/8.4/openssl.php
+++ b/generated/8.4/openssl.php
@@ -47,8 +47,8 @@ function openssl_cipher_key_length(string $cipher_algo): int
  *
  * @param string $input_filename The name of a file containing encrypted content.
  * @param string $output_filename The name of the file to deposit the decrypted content.
- * @param  $certificate The name of the file containing a certificate of the recipient.
- * @param  $private_key The name of the file containing a PKCS#8 key.
+ * @param \OpenSSLCertificate|string $certificate The name of the file containing a certificate of the recipient.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key The name of the file containing a PKCS#8 key.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
@@ -76,8 +76,8 @@ function openssl_cms_decrypt(string $input_filename, string $output_filename, $c
  *
  * @param string $input_filename The file to be encrypted.
  * @param string $output_filename The output file.
- * @param  $certificate Recipients to encrypt to.
- * @param  $headers Headers to include when S/MIME is used.
+ * @param \OpenSSLCertificate|array|string $certificate Recipients to encrypt to.
+ * @param array|null $headers Headers to include when S/MIME is used.
  * @param int $flags Flags to be passed to CMS_sign.
  * @param int $encoding An encoding to output. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
@@ -85,7 +85,7 @@ function openssl_cms_decrypt(string $input_filename, string $output_filename, $c
  * @throws OpensslException
  *
  */
-function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, int $cipher_algo = OPENSSL_CIPHER_AES_128_CBC): void
+function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, int $cipher_algo = OPENSSL_CIPHER_AES_128_CBC): void
 {
     error_clear_last();
     $safeResult = \openssl_cms_encrypt($input_filename, $output_filename, $certificate, $headers, $flags, $encoding, $cipher_algo);
@@ -118,19 +118,19 @@ function openssl_cms_read(string $input_filename, array &$certificates): void
  *
  * @param string $input_filename The name of the file to be signed.
  * @param string $output_filename The name of the file to deposit the results.
- * @param  $certificate The signing certificate.
+ * @param \OpenSSLCertificate|string $certificate The signing certificate.
  * See Key/Certificate parameters for a list of valid values.
- * @param  $private_key The key associated with certificate.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key The key associated with certificate.
  * See Key/Certificate parameters for a list of valid values.
- * @param  $headers An array of headers to be included in S/MIME output.
+ * @param array|null $headers An array of headers to be included in S/MIME output.
  * @param int $flags Flags to be passed to cms_sign.
  * @param int $encoding The encoding of the output file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
- * @param  $untrusted_certificates_filename Intermediate certificates to be included in the signature.
+ * @param string|null $untrusted_certificates_filename Intermediate certificates to be included in the signature.
  * @throws OpensslException
  *
  */
-function openssl_cms_sign(string $input_filename, string $output_filename, $certificate, $private_key, $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, $untrusted_certificates_filename = null): void
+function openssl_cms_sign(string $input_filename, string $output_filename, $certificate, $private_key, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, ?string $untrusted_certificates_filename = null): void
 {
     error_clear_last();
     if ($untrusted_certificates_filename !== null) {
@@ -149,18 +149,18 @@ function openssl_cms_sign(string $input_filename, string $output_filename, $cert
  *
  * @param string $input_filename The input file.
  * @param int $flags Flags to pass to cms_verify.
- * @param  $certificates A file with the signer certificate and optionally intermediate certificates.
+ * @param string|null $certificates A file with the signer certificate and optionally intermediate certificates.
  * @param array $ca_info An array containing self-signed certificate authority certificates.
- * @param  $untrusted_certificates_filename A file containing additional intermediate certificates.
- * @param  $content A file pointing to the content when signatures are detached.
- * @param  $pk7
- * @param  $sigfile A file to save the signature to.
+ * @param string|null $untrusted_certificates_filename A file containing additional intermediate certificates.
+ * @param string|null $content A file pointing to the content when signatures are detached.
+ * @param string|null $pk7
+ * @param string|null $sigfile A file to save the signature to.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
  *
  */
-function openssl_cms_verify(string $input_filename, int $flags = 0, $certificates = null, array $ca_info = [], $untrusted_certificates_filename = null, $content = null, $pk7 = null, $sigfile = null, int $encoding = OPENSSL_ENCODING_SMIME): void
+function openssl_cms_verify(string $input_filename, int $flags = 0, ?string $certificates = null, array $ca_info = [], ?string $untrusted_certificates_filename = null, ?string $content = null, ?string $pk7 = null, ?string $sigfile = null, int $encoding = OPENSSL_ENCODING_SMIME): void
 {
     error_clear_last();
     if ($encoding !== OPENSSL_ENCODING_SMIME) {
@@ -290,7 +290,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  * based on the information provided by distinguished_names.
  *
  * @param array $distinguished_names The Distinguished Name or subject fields to be used in the certificate.
- * @param resource $private_key private_key should be set to a private key that
+ * @param \OpenSSLAsymmetricKey|null $private_key private_key should be set to a private key that
  * was previously generated by openssl_pkey_new (or
  * otherwise obtained from the other openssl_pkey family of functions), or
  * NULL variable. If its value is NULL variable, a new private key is
@@ -398,7 +398,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  * @throws OpensslException
  *
  */
-function openssl_csr_new(array $distinguished_names, &$private_key, ?array $options = null, ?array $extra_attributes = null)
+function openssl_csr_new(array $distinguished_names, ?\OpenSSLAsymmetricKey &$private_key, ?array $options = null, ?array $extra_attributes = null)
 {
     error_clear_last();
     if ($extra_attributes !== null) {
@@ -434,12 +434,12 @@ function openssl_csr_new(array $distinguished_names, &$private_key, ?array $opti
  * options.
  * @param int $serial An optional the serial number of issued certificate. If not specified
  * it will default to 0.
- * @param  $serial_hex
+ * @param string|null $serial_hex
  * @return \OpenSSLCertificate Returns an OpenSSLCertificate on success.
  * @throws OpensslException
  *
  */
-function openssl_csr_sign($csr, $ca_certificate, $private_key, int $days, ?array $options = null, int $serial = 0, $serial_hex = null): \OpenSSLCertificate
+function openssl_csr_sign($csr, $ca_certificate, $private_key, int $days, ?array $options = null, int $serial = 0, ?string $serial_hex = null): \OpenSSLCertificate
 {
     error_clear_last();
     if ($serial_hex !== null) {
@@ -902,9 +902,9 @@ function openssl_pkcs7_sign(string $input_filename, string $output_filename, $ce
  * openssl_pkey_derive takes a set of a public_key
  * and private_key and derives a shared secret, for either DH or EC keys.
  *
- * @param resource $public_key public_key is the public key for the derivation.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key public_key is the public key for the derivation.
  * See Public/Private Key parameters for a list of valid values.
- * @param resource $private_key private_key is the private key for the derivation.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key is the private key for the derivation.
  * See Public/Private Key parameters for a list of valid values.
  * @param int $key_length If not zero, will attempt to set the desired length of the derived secret.
  * @return string The derived secret on success.
@@ -959,7 +959,7 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * key as a PEM encoded string and stores it into
  * output (which is passed by reference).
  *
- * @param resource $key
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param string|null $output
  * @param string|null $passphrase The key is optionally protected by passphrase.
  * @param array $options options can be used to fine-tune the export

--- a/generated/8.4/pgsql.php
+++ b/generated/8.4/pgsql.php
@@ -239,7 +239,7 @@ function pg_delete(\PgSql\Connection $connection, string $table_name, array $con
  * must be issued, otherwise the PostgreSQL server may get out of
  * sync with the frontend and will report an error.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -247,7 +247,7 @@ function pg_delete(\PgSql\Connection $connection, string $table_name, array $con
  * @throws PgsqlException
  *
  */
-function pg_end_copy($connection = null): void
+function pg_end_copy(?\PgSql\Connection $connection = null): void
 {
     error_clear_last();
     if ($connection !== null) {
@@ -390,7 +390,7 @@ function pg_free_result(\PgSql\Result $result): void
  * PostgreSQL connection instance is
  * connected to.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -400,7 +400,7 @@ function pg_free_result(\PgSql\Result $result): void
  * @throws PgsqlException
  *
  */
-function pg_host($connection = null): string
+function pg_host(?\PgSql\Connection $connection = null): string
 {
     error_clear_last();
     if ($connection !== null) {
@@ -899,7 +899,7 @@ function pg_pconnect(string $connection_string, int $flags = 0): \PgSql\Connecti
  * pg_ping pings a database connection and tries to
  * reconnect it if it is broken.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -907,7 +907,7 @@ function pg_pconnect(string $connection_string, int $flags = 0): \PgSql\Connecti
  * @throws PgsqlException
  *
  */
-function pg_ping($connection = null): void
+function pg_ping(?\PgSql\Connection $connection = null): void
 {
     error_clear_last();
     if ($connection !== null) {
@@ -1322,7 +1322,7 @@ function pg_socket(\PgSql\Connection $connection)
  * @param string $filename The full path and file name of the file in which to write the
  * trace log.  Same as in fopen.
  * @param string $mode An optional file access mode, same as for fopen.
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -1333,7 +1333,7 @@ function pg_socket(\PgSql\Connection $connection)
  * @throws PgsqlException
  *
  */
-function pg_trace(string $filename, string $mode = "w", $connection = null, int $trace_mode = 0): void
+function pg_trace(string $filename, string $mode = "w", ?\PgSql\Connection $connection = null, int $trace_mode = 0): void
 {
     error_clear_last();
     if ($trace_mode !== 0) {

--- a/generated/8.4/posix.php
+++ b/generated/8.4/posix.php
@@ -324,7 +324,7 @@ function posix_getpwuid(int $user_id): array
  * An unprivileged process may only set its soft limit to a value
  * from 0 to the hard limit, and irreversibly lower its hard limit.
  *
- * @param  $resource If NULL all resource limits will be fetched.
+ * @param int|null $resource If NULL all resource limits will be fetched.
  * Otherwise, the only limits of the resource type provided will be returned.
  * @return array Returns an associative array of elements for each
  * limit that is defined. Each limit has a soft and a hard limit.
@@ -414,7 +414,7 @@ function posix_getpwuid(int $user_id): array
  * @throws PosixException
  *
  */
-function posix_getrlimit($resource = null): array
+function posix_getrlimit(?int $resource = null): array
 {
     error_clear_last();
     if ($resource !== null) {

--- a/generated/8.4/stream.php
+++ b/generated/8.4/stream.php
@@ -460,7 +460,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * STREAM_CLIENT_CONNECT (default),
  * STREAM_CLIENT_ASYNC_CONNECT and
  * STREAM_CLIENT_PERSISTENT.
- * @param resource $context A valid context resource created with stream_context_create.
+ * @param resource|null $context A valid context resource created with stream_context_create.
  * @return resource On success a stream resource is returned which may
  * be used together with the other file functions (such as
  * fgets, fgetss,
@@ -667,7 +667,7 @@ function stream_socket_sendto($socket, string $data, int $flags = 0, string $add
  *
  * For UDP sockets, you must use STREAM_SERVER_BIND as
  * the flags parameter.
- * @param resource $context
+ * @param resource|null $context
  * @return resource Returns the created stream.
  * @throws StreamException
  *

--- a/generated/8.4/uodbc.php
+++ b/generated/8.4/uodbc.php
@@ -524,7 +524,7 @@ function odbc_rollback(\Odbc\Connection $odbc): void
  * to use a commercial product, that's all that really
  * matters.
  *
- * @param resource $odbc Is a connection id or result id on which to change the settings.
+ * @param \Odbc\Connection|\Odbc\Result $odbc Is a connection id or result id on which to change the settings.
  * For SQLSetConnectOption(), this is a connection id.
  * For SQLSetStmtOption(), this is a result id.
  * @param int $which Is the ODBC function to use. The value should be

--- a/generated/8.4/url.php
+++ b/generated/8.4/url.php
@@ -36,7 +36,7 @@ function base64_decode(string $string, bool $strict = false): string
  * @param bool $associative If the optional associative parameter is set to true,
  * get_headers parses the response and sets the
  * array's keys.
- * @param resource $context A valid context resource created with
+ * @param resource|null $context A valid context resource created with
  * stream_context_create, or NULL to use the
  * default context.
  * @return array Returns an indexed or associative array with the headers.

--- a/generated/8.5/dir.php
+++ b/generated/8.5/dir.php
@@ -78,7 +78,7 @@ function getcwd(): string
  * rewinddir calls.
  *
  * @param string $directory The directory path that is to be opened
- * @param resource $context For a description of the context parameter,
+ * @param resource|null $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return resource Returns a directory handle resource on success
@@ -110,7 +110,7 @@ function opendir(string $directory, $context = null)
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
  * SCANDIR_SORT_NONE then the result is unsorted.
- * @param resource $context For a description of the context parameter,
+ * @param resource|null $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return array Returns an array of filenames on success. If directory is not a directory, then

--- a/generated/8.5/filesystem.php
+++ b/generated/8.5/filesystem.php
@@ -100,7 +100,7 @@ function chown(string $filename, $user): void
  * existing files.
  *
  * If the destination file already exists, it will be overwritten.
- * @param resource $context A valid context resource created with
+ * @param resource|null $context A valid context resource created with
  * stream_context_create.
  * @throws FilesystemException
  *
@@ -416,7 +416,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  *
  *
  *
- * @param resource $context
+ * @param resource|null $context
  * @return array Returns the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns FALSE.
@@ -1175,7 +1175,7 @@ function lstat(string $filename): array
  * umask.
  * @param bool $recursive If TRUE, then any parent directories to the directory specified will
  * also be created, with the same permissions.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1277,7 +1277,7 @@ function parse_ini_string(string $ini_string, bool $process_sections = false, in
  * @param string $filename The filename being read.
  * @param bool $use_include_path You can use the optional second parameter and set it to TRUE, if
  * you want to search for the file in the include_path, too.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @return int Returns the number of bytes read from the file on success
  * @throws FilesystemException
@@ -1373,7 +1373,7 @@ function realpath(string $path): string
  * Otherwise rename fails and issues E_WARNING.
  *
  *
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1417,7 +1417,7 @@ function rewind($stream): void
  * A E_WARNING level error will be generated on failure.
  *
  * @param string $directory Path to the directory.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1548,7 +1548,7 @@ function touch(string $filename, ?int $mtime = null, ?int $atime = null): void
  *
  * If the file is a symlink, the symlink will be deleted. On Windows, to delete
  * a symlink to a directory, rmdir has to be used instead.
- * @param resource $context A context stream
+ * @param resource|null $context A context stream
  * resource.
  * @throws FilesystemException
  *

--- a/generated/8.5/image.php
+++ b/generated/8.5/image.php
@@ -267,7 +267,7 @@ function imagearc(\GdImage $image, int $center_x, int $center_y, int $width, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param  $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst quality, smaller file)
  * to 100 (best quality, larger file).
  * If -1 is provided, the default value 30 is used.

--- a/generated/8.5/misc.php
+++ b/generated/8.5/misc.php
@@ -161,7 +161,7 @@ function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): void
  * CTRL+BREAK events. Note that in multithreaded environments,
  * this is only possible when called from the main thread.
  *
- * @param  $handler A callback function to set or remove. If set, this function will be called
+ * @param callable|null $handler A callback function to set or remove. If set, this function will be called
  * whenever a
  *
  * CTRL
@@ -205,7 +205,7 @@ function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): void
  * @throws MiscException
  *
  */
-function sapi_windows_set_ctrl_handler($handler, bool $add = true): void
+function sapi_windows_set_ctrl_handler(?callable $handler, bool $add = true): void
 {
     error_clear_last();
     $safeResult = \sapi_windows_set_ctrl_handler($handler, $add);

--- a/generated/8.5/openssl.php
+++ b/generated/8.5/openssl.php
@@ -47,8 +47,8 @@ function openssl_cipher_key_length(string $cipher_algo): int
  *
  * @param string $input_filename The name of a file containing encrypted content.
  * @param string $output_filename The name of the file to deposit the decrypted content.
- * @param  $certificate The name of the file containing a certificate of the recipient.
- * @param  $private_key The name of the file containing a PKCS#8 key.
+ * @param \OpenSSLCertificate|string $certificate The name of the file containing a certificate of the recipient.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key The name of the file containing a PKCS#8 key.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
@@ -76,8 +76,8 @@ function openssl_cms_decrypt(string $input_filename, string $output_filename, $c
  *
  * @param string $input_filename The file to be encrypted.
  * @param string $output_filename The output file.
- * @param  $certificate Recipients to encrypt to.
- * @param  $headers Headers to include when S/MIME is used.
+ * @param \OpenSSLCertificate|array|string $certificate Recipients to encrypt to.
+ * @param array|null $headers Headers to include when S/MIME is used.
  * @param int $flags Flags to be passed to CMS_sign.
  * @param int $encoding An encoding to output. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
@@ -85,7 +85,7 @@ function openssl_cms_decrypt(string $input_filename, string $output_filename, $c
  * @throws OpensslException
  *
  */
-function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, int $cipher_algo = OPENSSL_CIPHER_AES_128_CBC): void
+function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, int $cipher_algo = OPENSSL_CIPHER_AES_128_CBC): void
 {
     error_clear_last();
     $safeResult = \openssl_cms_encrypt($input_filename, $output_filename, $certificate, $headers, $flags, $encoding, $cipher_algo);
@@ -118,19 +118,19 @@ function openssl_cms_read(string $input_filename, array &$certificates): void
  *
  * @param string $input_filename The name of the file to be signed.
  * @param string $output_filename The name of the file to deposit the results.
- * @param  $certificate The signing certificate.
+ * @param \OpenSSLCertificate|string $certificate The signing certificate.
  * See Key/Certificate parameters for a list of valid values.
- * @param  $private_key The key associated with certificate.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key The key associated with certificate.
  * See Key/Certificate parameters for a list of valid values.
- * @param  $headers An array of headers to be included in S/MIME output.
+ * @param array|null $headers An array of headers to be included in S/MIME output.
  * @param int $flags Flags to be passed to cms_sign.
  * @param int $encoding The encoding of the output file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
- * @param  $untrusted_certificates_filename Intermediate certificates to be included in the signature.
+ * @param string|null $untrusted_certificates_filename Intermediate certificates to be included in the signature.
  * @throws OpensslException
  *
  */
-function openssl_cms_sign(string $input_filename, string $output_filename, $certificate, $private_key, $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, $untrusted_certificates_filename = null): void
+function openssl_cms_sign(string $input_filename, string $output_filename, $certificate, $private_key, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, ?string $untrusted_certificates_filename = null): void
 {
     error_clear_last();
     if ($untrusted_certificates_filename !== null) {
@@ -149,18 +149,18 @@ function openssl_cms_sign(string $input_filename, string $output_filename, $cert
  *
  * @param string $input_filename The input file.
  * @param int $flags Flags to pass to cms_verify.
- * @param  $certificates A file with the signer certificate and optionally intermediate certificates.
+ * @param string|null $certificates A file with the signer certificate and optionally intermediate certificates.
  * @param array $ca_info An array containing self-signed certificate authority certificates.
- * @param  $untrusted_certificates_filename A file containing additional intermediate certificates.
- * @param  $content A file pointing to the content when signatures are detached.
- * @param  $pk7
- * @param  $sigfile A file to save the signature to.
+ * @param string|null $untrusted_certificates_filename A file containing additional intermediate certificates.
+ * @param string|null $content A file pointing to the content when signatures are detached.
+ * @param string|null $pk7
+ * @param string|null $sigfile A file to save the signature to.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
  *
  */
-function openssl_cms_verify(string $input_filename, int $flags = 0, $certificates = null, array $ca_info = [], $untrusted_certificates_filename = null, $content = null, $pk7 = null, $sigfile = null, int $encoding = OPENSSL_ENCODING_SMIME): void
+function openssl_cms_verify(string $input_filename, int $flags = 0, ?string $certificates = null, array $ca_info = [], ?string $untrusted_certificates_filename = null, ?string $content = null, ?string $pk7 = null, ?string $sigfile = null, int $encoding = OPENSSL_ENCODING_SMIME): void
 {
     error_clear_last();
     if ($encoding !== OPENSSL_ENCODING_SMIME) {
@@ -294,7 +294,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  * associative array where the keys represent the attribute names of
  * Distinguished Names and the values can either be strings (for single
  * value) or arrays (if multiple values need to be set).
- * @param resource $private_key private_key should be set to a private key that
+ * @param \OpenSSLAsymmetricKey|null $private_key private_key should be set to a private key that
  * was previously generated by openssl_pkey_new (or
  * otherwise obtained from the other openssl_pkey family of functions), or
  * NULL variable. If its value is NULL variable, a new private key is
@@ -402,7 +402,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  * @throws OpensslException
  *
  */
-function openssl_csr_new(array $distinguished_names, &$private_key, ?array $options = null, ?array $extra_attributes = null)
+function openssl_csr_new(array $distinguished_names, ?\OpenSSLAsymmetricKey &$private_key, ?array $options = null, ?array $extra_attributes = null)
 {
     error_clear_last();
     if ($extra_attributes !== null) {
@@ -438,7 +438,7 @@ function openssl_csr_new(array $distinguished_names, &$private_key, ?array $opti
  * options.
  * @param int $serial An optional the serial number of issued certificate. If not specified
  * it will default to 0.
- * @param  $serial_hex An optional hexadecimal string representing the serial number of the
+ * @param string|null $serial_hex An optional hexadecimal string representing the serial number of the
  * issued certificate. If set, it takes precedence over the
  * serial parameter value. If not specified or set
  * to NULL, the serial parameter value is used
@@ -447,7 +447,7 @@ function openssl_csr_new(array $distinguished_names, &$private_key, ?array $opti
  * @throws OpensslException
  *
  */
-function openssl_csr_sign($csr, $ca_certificate, $private_key, int $days, ?array $options = null, int $serial = 0, $serial_hex = null): \OpenSSLCertificate
+function openssl_csr_sign($csr, $ca_certificate, $private_key, int $days, ?array $options = null, int $serial = 0, ?string $serial_hex = null): \OpenSSLCertificate
 {
     error_clear_last();
     if ($serial_hex !== null) {
@@ -910,9 +910,9 @@ function openssl_pkcs7_sign(string $input_filename, string $output_filename, $ce
  * openssl_pkey_derive takes a set of a public_key
  * and private_key and derives a shared secret, for either DH or EC keys.
  *
- * @param resource $public_key public_key is the public key for the derivation.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key public_key is the public key for the derivation.
  * See Public/Private Key parameters for a list of valid values.
- * @param resource $private_key private_key is the private key for the derivation.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key is the private key for the derivation.
  * See Public/Private Key parameters for a list of valid values.
  * @param int $key_length If not zero, will attempt to set the desired length of the derived secret.
  * @return string The derived secret on success.
@@ -967,7 +967,7 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * key as a PEM encoded string and stores it into
  * output (which is passed by reference).
  *
- * @param resource $key
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param string|null $output
  * @param string|null $passphrase The key is optionally protected by passphrase.
  * @param array $options options can be used to fine-tune the export

--- a/generated/8.5/pcntl.php
+++ b/generated/8.5/pcntl.php
@@ -7,12 +7,12 @@ use Safe\Exceptions\PcntlException;
 /**
  *
  *
- * @param  $pid
+ * @param int|null $pid
  * @return bool|array
  * @throws PcntlException
  *
  */
-function pcntl_getcpuaffinity($pid = null)
+function pcntl_getcpuaffinity(?int $pid = null)
 {
     error_clear_last();
     if ($pid !== null) {
@@ -62,12 +62,12 @@ function pcntl_getpriority(?int $process_id = null, int $mode = PRIO_PROCESS): i
 /**
  *
  *
- * @param  $pid
+ * @param int|null $pid
  * @param array $hmask
  * @throws PcntlException
  *
  */
-function pcntl_setcpuaffinity($pid = null, ?array $hmask = null): void
+function pcntl_setcpuaffinity(?int $pid = null, ?array $hmask = null): void
 {
     error_clear_last();
     if ($hmask !== null) {

--- a/generated/8.5/pgsql.php
+++ b/generated/8.5/pgsql.php
@@ -239,7 +239,7 @@ function pg_delete(\PgSql\Connection $connection, string $table_name, array $con
  * must be issued, otherwise the PostgreSQL server may get out of
  * sync with the frontend and will report an error.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -247,7 +247,7 @@ function pg_delete(\PgSql\Connection $connection, string $table_name, array $con
  * @throws PgsqlException
  *
  */
-function pg_end_copy($connection = null): void
+function pg_end_copy(?\PgSql\Connection $connection = null): void
 {
     error_clear_last();
     if ($connection !== null) {
@@ -390,7 +390,7 @@ function pg_free_result(\PgSql\Result $result): void
  * PostgreSQL connection instance is
  * connected to.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -400,7 +400,7 @@ function pg_free_result(\PgSql\Result $result): void
  * @throws PgsqlException
  *
  */
-function pg_host($connection = null): string
+function pg_host(?\PgSql\Connection $connection = null): string
 {
     error_clear_last();
     if ($connection !== null) {
@@ -902,7 +902,7 @@ function pg_pconnect(string $connection_string, int $flags = 0): \PgSql\Connecti
  * pg_ping pings a database connection and tries to
  * reconnect it if it is broken.
  *
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -910,7 +910,7 @@ function pg_pconnect(string $connection_string, int $flags = 0): \PgSql\Connecti
  * @throws PgsqlException
  *
  */
-function pg_ping($connection = null): void
+function pg_ping(?\PgSql\Connection $connection = null): void
 {
     error_clear_last();
     if ($connection !== null) {
@@ -1325,7 +1325,7 @@ function pg_socket(\PgSql\Connection $connection)
  * @param string $filename The full path and file name of the file in which to write the
  * trace log.  Same as in fopen.
  * @param string $mode An optional file access mode, same as for fopen.
- * @param resource $connection An PgSql\Connection instance.
+ * @param \PgSql\Connection|null $connection An PgSql\Connection instance.
  * When connection is NULL, the default connection is used.
  * The default connection is the last connection made by pg_connect
  * or pg_pconnect.
@@ -1336,7 +1336,7 @@ function pg_socket(\PgSql\Connection $connection)
  * @throws PgsqlException
  *
  */
-function pg_trace(string $filename, string $mode = "w", $connection = null, int $trace_mode = 0): void
+function pg_trace(string $filename, string $mode = "w", ?\PgSql\Connection $connection = null, int $trace_mode = 0): void
 {
     error_clear_last();
     if ($trace_mode !== 0) {

--- a/generated/8.5/posix.php
+++ b/generated/8.5/posix.php
@@ -324,7 +324,7 @@ function posix_getpwuid(int $user_id): array
  * An unprivileged process may only set its soft limit to a value
  * from 0 to the hard limit, and irreversibly lower its hard limit.
  *
- * @param  $resource If NULL all resource limits will be fetched.
+ * @param int|null $resource If NULL all resource limits will be fetched.
  * Otherwise, the only limits of the resource type provided will be returned.
  * @return array Returns an associative array of elements for each
  * limit that is defined. Each limit has a soft and a hard limit.
@@ -414,7 +414,7 @@ function posix_getpwuid(int $user_id): array
  * @throws PosixException
  *
  */
-function posix_getrlimit($resource = null): array
+function posix_getrlimit(?int $resource = null): array
 {
     error_clear_last();
     if ($resource !== null) {

--- a/generated/8.5/stream.php
+++ b/generated/8.5/stream.php
@@ -460,7 +460,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * STREAM_CLIENT_CONNECT (default),
  * STREAM_CLIENT_ASYNC_CONNECT and
  * STREAM_CLIENT_PERSISTENT.
- * @param resource $context A valid context resource created with stream_context_create.
+ * @param resource|null $context A valid context resource created with stream_context_create.
  * @return resource On success a stream resource is returned which may
  * be used together with the other file functions (such as
  * fgets, fgetss,
@@ -667,7 +667,7 @@ function stream_socket_sendto($socket, string $data, int $flags = 0, string $add
  *
  * For UDP sockets, you must use STREAM_SERVER_BIND as
  * the flags parameter.
- * @param resource $context
+ * @param resource|null $context
  * @return resource Returns the created stream.
  * @throws StreamException
  *

--- a/generated/8.5/uodbc.php
+++ b/generated/8.5/uodbc.php
@@ -546,7 +546,7 @@ function odbc_rollback(\Odbc\Connection $odbc): void
  * to use a commercial product, that's all that really
  * matters.
  *
- * @param resource $odbc Is a connection id or result id on which to change the settings.
+ * @param \Odbc\Connection|\Odbc\Result $odbc Is a connection id or result id on which to change the settings.
  * For SQLSetConnectOption(), this is a connection id.
  * For SQLSetStmtOption(), this is a result id.
  * @param int $which Is the ODBC function to use. The value should be

--- a/generated/8.5/url.php
+++ b/generated/8.5/url.php
@@ -36,7 +36,7 @@ function base64_decode(string $string, bool $strict = false): string
  * @param bool $associative If the optional associative parameter is set to true,
  * get_headers parses the response and sets the
  * array's keys.
- * @param resource $context A valid context resource created with
+ * @param resource|null $context A valid context resource created with
  * stream_context_create, or NULL to use the
  * default context.
  * @return array Returns an indexed or associative array with the headers.

--- a/generator/src/Generator/WritePhpFunction.php
+++ b/generator/src/Generator/WritePhpFunction.php
@@ -106,7 +106,7 @@ class WritePhpFunction
         // Special case for CURL: we need the first argument of the method if this is a resource.
         if ($moduleName === 'Curl') {
             $params = $method->getParams();
-            if (\count($params) > 0 && in_array($params[0]->getParameterType(), ['CurlHandle', 'CurlMultiHandle', 'CurlShareHandle'])) {
+            if (\count($params) > 0 && in_array($params[0]->getParameterType(), ['\CurlHandle', '\CurlMultiHandle', '\CurlShareHandle'])) {
                 $name = $params[0]->getParameterName();
                 return "
     if (\$safeResult === $errorValue) {

--- a/generator/src/PhpStanFunctions/PhpStanType.php
+++ b/generator/src/PhpStanFunctions/PhpStanType.php
@@ -28,8 +28,16 @@ class PhpStanType
      */
     private array $types;
 
-    public function __construct(string $data, bool $writeOnly = false)
+    public function __construct(string|\SimpleXMLElement $data, bool $writeOnly = false)
     {
+        if ($data instanceof \SimpleXMLElement) {
+            if (isset($data['class']) && ((string)$data['class']) === 'union') {
+                $data = implode('|', (array)$data->type);
+            } else {
+                $data = (string)$data;
+            }
+        }
+
         if (\preg_match('/__benevolent\<(.*)\>/', $data, $regs)) {
             $data = $regs[1];
         }

--- a/generator/src/XmlDocParser/Method.php
+++ b/generator/src/XmlDocParser/Method.php
@@ -38,7 +38,7 @@ class Method
         // and the PHP docs have a more specific type hint, then we prefer
         // to use the PHP docs
         $phpStanType = $this->phpstanSignature ? $this->phpstanSignature->getReturnType() : null;
-        $phpDocType = $this->parsePHPDocType($this->functionObject);
+        $phpDocType = new PhpStanType($this->functionObject->type);
         if ($phpStanType && $phpStanType->getDocBlockType($errorType) === "resource" && $phpDocType->getDocBlockType($errorType) !== "") {
             $phpStanType = null;
         }
@@ -240,14 +240,5 @@ class Method
         \array_pop($params);
         $new->params = $params;
         return $new;
-    }
-
-    public function parsePHPDocType(\SimpleXMLElement $functionObject): PhpStanType
-    {
-        if (isset($functionObject->type['class']) && ((string)$functionObject->type['class']) === 'union') {
-            return new PhpStanType(implode('|', (array)$functionObject->type->type));
-        }
-
-        return new PhpStanType($functionObject->type->__toString());
     }
 }

--- a/generator/src/XmlDocParser/Parameter.php
+++ b/generator/src/XmlDocParser/Parameter.php
@@ -22,7 +22,7 @@ class Parameter
         // and the PHP docs have a more specific type hint, then we prefer
         // to use the PHP docs
         $phpStanType = $phpStanParam ? $phpStanParam->getType() : null;
-        $phpDocType = new PhpStanType($this->getParameterType());
+        $phpDocType = new PhpStanType($this->parameter->type);
         if ($phpStanType && $phpStanType->getDocBlockType() === "resource" && $phpDocType->getDocBlockType() !== "") {
             $phpStanType = null;
         }
@@ -52,7 +52,7 @@ class Parameter
 
     public function getParameterType(): string
     {
-        return $this->parameter->type->__toString();
+        return (new PhpStanType($this->parameter->type))->getDocBlockType();
     }
 
     public function isByReference(): bool

--- a/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
@@ -203,4 +203,20 @@ class PhpStanTypeTest extends TestCase
         $this->assertEquals('string', $param->getDocBlockType(Method::FALSY_TYPE));
         $this->assertEquals('string', $param->getSignatureType(Method::FALSY_TYPE));
     }
+
+    public function testTypeFromXML(): void
+    {
+        $xml = \simplexml_load_string('<type>string</type>');
+        $this->assertNotFalse($xml);
+        $param = new PhpStanType($xml);
+        $this->assertEquals('string', $param->getDocBlockType());
+    }
+
+    public function testUnionFromXML(): void
+    {
+        $xml = \simplexml_load_string('<type class="union"><type>OpenSSLCertificate</type><type>string</type></type>');
+        $this->assertNotFalse($xml);
+        $param = new PhpStanType($xml);
+        $this->assertEquals('\OpenSSLCertificate|string', $param->getDocBlockType());
+    }
 }


### PR DESCRIPTION

Both parameter-types _and_ return-types need to support XML Union Objects

Before:
```
$ ./safe.php function-info openssl_x509_export

Parameters:
  certificate:
    phpstan type: \OpenSSLCertificate|string
    phpdoc type:  (unknown)
```

After:
```
$ ./safe.php function-info openssl_x509_export

Parameters:
  certificate:
    phpstan type: \OpenSSLCertificate|string
    phpdoc type:  \OpenSSLCertificate|string
```
