### PR TITLE
prefer phpdoc when phpstan mentions resource anywhere at all

### DIFF
--- a/generated/8.1/filesystem.php
+++ b/generated/8.1/filesystem.php
@@ -244,7 +244,7 @@ function fflush($stream): void
  * This is not possible if strict typing
  * is enabled, since FILE_USE_INCLUDE_PATH is an
  * int. Use TRUE instead.
- * @param resource|null $context A valid context resource created with
+ * @param resource $context A valid context resource created with
  * stream_context_create. If you don't need to use a
  * custom context, you can skip this parameter by NULL.
  * @param int $offset The offset where the reading starts on the original stream.
@@ -347,7 +347,7 @@ function file_get_contents(string $filename, bool $use_include_path = false, $co
  *
  *
  *
- * @param resource|null $context A valid context resource created with
+ * @param resource $context A valid context resource created with
  * stream_context_create.
  * @return int This function returns the number of bytes that were written to the file.
  * @throws FilesystemException
@@ -828,7 +828,7 @@ function flock($stream, int $operation, ?int &$would_block = null): void
  * @param bool $use_include_path The optional third use_include_path parameter
  * can be set to '1' or TRUE if you want to search for the file in the
  * include_path, too.
- * @param resource|null $context A context stream
+ * @param resource $context A context stream
  * resource.
  * @return resource Returns a file pointer resource on success
  * @throws FilesystemException

--- a/generated/8.1/image.php
+++ b/generated/8.1/image.php
@@ -1740,11 +1740,11 @@ function imagegammacorrect(\GdImage $image, float $input_gamma, float $output_ga
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
-function imagegd(\GdImage $image, $file = null): void
+function imagegd(\GdImage $image, ?string $file = null): void
 {
     error_clear_last();
     if ($file !== null) {
@@ -1763,7 +1763,7 @@ function imagegd(\GdImage $image, $file = null): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $chunk_size Chunk size.
  * @param int $mode Either IMG_GD2_RAW or
  * IMG_GD2_COMPRESSED. Default is
@@ -1771,7 +1771,7 @@ function imagegd(\GdImage $image, $file = null): void
  * @throws ImageException
  *
  */
-function imagegd2(\GdImage $image, $file = null, int $chunk_size = 128, int $mode = IMG_GD2_RAW): void
+function imagegd2(\GdImage $image, ?string $file = null, int $chunk_size = 128, int $mode = IMG_GD2_RAW): void
 {
     error_clear_last();
     if ($mode !== IMG_GD2_RAW) {
@@ -2860,7 +2860,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
+ * @param string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
  *
  * The filename (without the .xbm extension) is also
  * used for the C identifiers of the XBM, whereby non
@@ -2874,7 +2874,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  * @throws ImageException
  *
  */
-function imagexbm(\GdImage $image, $filename, ?int $foreground_color = null): void
+function imagexbm(\GdImage $image, ?string $filename, ?int $foreground_color = null): void
 {
     error_clear_last();
     if ($foreground_color !== null) {

--- a/generated/8.1/ldap.php
+++ b/generated/8.1/ldap.php
@@ -251,7 +251,7 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  * If not provided you may use ldap_parse_exop on the result object
  * later to get this data.
  * @param string|null $retoid Will be filled with the response OID if provided, usually equal to the request OID.
- * @return bool|resource When used with retdata, returns TRUE on success.
+ * @return mixed When used with retdata, returns TRUE on success.
  * When used without retdata, returns a result identifier.
  * @throws LdapException
  *
@@ -1044,7 +1044,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
 /**
  * Sets the value of the specified option to be value.
  *
- * @param resource|null $ldap An LDAP\Connection instance, returned by ldap_connect.
+ * @param \LDAP\Connection|null $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param int $option The parameter option can be one of:
  *
  *
@@ -1217,7 +1217,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
  * @throws LdapException
  *
  */
-function ldap_set_option($ldap, int $option, $value): void
+function ldap_set_option(?\LDAP\Connection $ldap, int $option, $value): void
 {
     error_clear_last();
     $safeResult = \ldap_set_option($ldap, $option, $value);

--- a/generated/8.1/mysql.php
+++ b/generated/8.1/mysql.php
@@ -684,7 +684,7 @@ function mysql_num_rows($result): int
  * will try to create one as if mysql_connect had been called
  * with no arguments. If no connection is found or established, an
  * E_WARNING level error is generated.
- * @return bool|resource For SELECT, SHOW, DESCRIBE, EXPLAIN and other statements returning resultset,
+ * @return mixed For SELECT, SHOW, DESCRIBE, EXPLAIN and other statements returning resultset,
  * mysql_query
  * returns a resource on success.
  *
@@ -918,7 +918,7 @@ function mysql_thread_id($link_identifier = null): int
  * will try to create one as if mysql_connect had been called
  * with no arguments. If no connection is found or established, an
  * E_WARNING level error is generated.
- * @return bool|resource For SELECT, SHOW, DESCRIBE or EXPLAIN statements,
+ * @return resource For SELECT, SHOW, DESCRIBE or EXPLAIN statements,
  * mysql_unbuffered_query
  * returns a resource on success.
  *

--- a/generated/8.1/stream.php
+++ b/generated/8.1/stream.php
@@ -439,11 +439,11 @@ function stream_socket_client(string $remote_socket, ?int &$errno = null, ?strin
  * STREAM_IPPROTO_RAW,
  * STREAM_IPPROTO_TCP or
  * STREAM_IPPROTO_UDP
- * @return resource[] Returns an array with the two socket resources on success.
+ * @return array Returns an array with the two socket resources on success.
  * @throws StreamException
  *
  */
-function stream_socket_pair(int $domain, int $type, int $protocol): iterable
+function stream_socket_pair(int $domain, int $type, int $protocol): array
 {
     error_clear_last();
     $safeResult = \stream_socket_pair($domain, $type, $protocol);

--- a/generated/8.2/image.php
+++ b/generated/8.2/image.php
@@ -1713,11 +1713,11 @@ function imagegammacorrect(\GdImage $image, float $input_gamma, float $output_ga
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
-function imagegd(\GdImage $image, $file = null): void
+function imagegd(\GdImage $image, ?string $file = null): void
 {
     error_clear_last();
     if ($file !== null) {
@@ -1736,7 +1736,7 @@ function imagegd(\GdImage $image, $file = null): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $chunk_size Chunk size.
  * @param int $mode Either IMG_GD2_RAW or
  * IMG_GD2_COMPRESSED. Default is
@@ -1744,7 +1744,7 @@ function imagegd(\GdImage $image, $file = null): void
  * @throws ImageException
  *
  */
-function imagegd2(\GdImage $image, $file = null, int $chunk_size = 128, int $mode = IMG_GD2_RAW): void
+function imagegd2(\GdImage $image, ?string $file = null, int $chunk_size = 128, int $mode = IMG_GD2_RAW): void
 {
     error_clear_last();
     if ($mode !== IMG_GD2_RAW) {
@@ -2845,7 +2845,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
+ * @param string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
  *
  * The filename (without the .xbm extension) is also
  * used for the C identifiers of the XBM, whereby non
@@ -2859,7 +2859,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  * @throws ImageException
  *
  */
-function imagexbm(\GdImage $image, $filename, ?int $foreground_color = null): void
+function imagexbm(\GdImage $image, ?string $filename, ?int $foreground_color = null): void
 {
     error_clear_last();
     if ($foreground_color !== null) {

--- a/generated/8.2/ldap.php
+++ b/generated/8.2/ldap.php
@@ -251,7 +251,7 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  * If not provided you may use ldap_parse_exop on the result object
  * later to get this data.
  * @param string|null $response_oid Will be filled with the response OID if provided, usually equal to the request OID.
- * @return bool|resource When used with response_data, returns TRUE on success.
+ * @return mixed When used with response_data, returns TRUE on success.
  * When used without response_data, returns a result identifier.
  * @throws LdapException
  *
@@ -1044,7 +1044,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
 /**
  * Sets the value of the specified option to be value.
  *
- * @param resource|null $ldap Either an LDAP\Connection instance, returned by
+ * @param \LDAP\Connection|null $ldap Either an LDAP\Connection instance, returned by
  * ldap_connect, to set the option for that connection,
  * or NULL to set the option globally.
  * @param int $option The parameter option can be one of:
@@ -1219,7 +1219,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
  * @throws LdapException
  *
  */
-function ldap_set_option($ldap, int $option, $value): void
+function ldap_set_option(?\LDAP\Connection $ldap, int $option, $value): void
 {
     error_clear_last();
     $safeResult = \ldap_set_option($ldap, $option, $value);

--- a/generated/8.2/mysql.php
+++ b/generated/8.2/mysql.php
@@ -684,7 +684,7 @@ function mysql_num_rows($result): int
  * will try to create one as if mysql_connect had been called
  * with no arguments. If no connection is found or established, an
  * E_WARNING level error is generated.
- * @return bool|resource For SELECT, SHOW, DESCRIBE, EXPLAIN and other statements returning resultset,
+ * @return mixed For SELECT, SHOW, DESCRIBE, EXPLAIN and other statements returning resultset,
  * mysql_query
  * returns a resource on success.
  *
@@ -918,7 +918,7 @@ function mysql_thread_id($link_identifier = null): int
  * will try to create one as if mysql_connect had been called
  * with no arguments. If no connection is found or established, an
  * E_WARNING level error is generated.
- * @return bool|resource For SELECT, SHOW, DESCRIBE or EXPLAIN statements,
+ * @return resource For SELECT, SHOW, DESCRIBE or EXPLAIN statements,
  * mysql_unbuffered_query
  * returns a resource on success.
  *

--- a/generated/8.2/stream.php
+++ b/generated/8.2/stream.php
@@ -502,11 +502,11 @@ function stream_socket_get_name($socket, bool $remote): string
  * STREAM_IPPROTO_RAW,
  * STREAM_IPPROTO_TCP or
  * STREAM_IPPROTO_UDP
- * @return resource[] Returns an array with the two socket resources on success.
+ * @return array Returns an array with the two socket resources on success.
  * @throws StreamException
  *
  */
-function stream_socket_pair(int $domain, int $type, int $protocol): iterable
+function stream_socket_pair(int $domain, int $type, int $protocol): array
 {
     error_clear_last();
     $safeResult = \stream_socket_pair($domain, $type, $protocol);

--- a/generated/8.3/image.php
+++ b/generated/8.3/image.php
@@ -1713,11 +1713,11 @@ function imagegammacorrect(\GdImage $image, float $input_gamma, float $output_ga
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
-function imagegd(\GdImage $image, $file = null): void
+function imagegd(\GdImage $image, ?string $file = null): void
 {
     error_clear_last();
     if ($file !== null) {
@@ -1736,7 +1736,7 @@ function imagegd(\GdImage $image, $file = null): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $chunk_size Chunk size.
  * @param int $mode Either IMG_GD2_RAW or
  * IMG_GD2_COMPRESSED. Default is
@@ -1744,7 +1744,7 @@ function imagegd(\GdImage $image, $file = null): void
  * @throws ImageException
  *
  */
-function imagegd2(\GdImage $image, $file = null, int $chunk_size = 128, int $mode = IMG_GD2_RAW): void
+function imagegd2(\GdImage $image, ?string $file = null, int $chunk_size = 128, int $mode = IMG_GD2_RAW): void
 {
     error_clear_last();
     if ($mode !== IMG_GD2_RAW) {
@@ -2833,7 +2833,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
+ * @param string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
  *
  * The filename (without the .xbm extension) is also
  * used for the C identifiers of the XBM, whereby non
@@ -2847,7 +2847,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  * @throws ImageException
  *
  */
-function imagexbm(\GdImage $image, $filename, ?int $foreground_color = null): void
+function imagexbm(\GdImage $image, ?string $filename, ?int $foreground_color = null): void
 {
     error_clear_last();
     if ($foreground_color !== null) {

--- a/generated/8.3/ldap.php
+++ b/generated/8.3/ldap.php
@@ -251,7 +251,7 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  * If not provided you may use ldap_parse_exop on the result object
  * later to get this data.
  * @param string|null $response_oid Will be filled with the response OID if provided, usually equal to the request OID.
- * @return bool|resource When used with response_data, returns TRUE on success.
+ * @return mixed When used with response_data, returns TRUE on success.
  * When used without response_data, returns a result identifier.
  * @throws LdapException
  *
@@ -1044,7 +1044,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
 /**
  * Sets the value of the specified option to be value.
  *
- * @param resource|null $ldap Either an LDAP\Connection instance, returned by
+ * @param \LDAP\Connection|null $ldap Either an LDAP\Connection instance, returned by
  * ldap_connect, to set the option for that connection,
  * or NULL to set the option globally.
  * @param int $option The parameter option can be one of:
@@ -1219,7 +1219,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
  * @throws LdapException
  *
  */
-function ldap_set_option($ldap, int $option, $value): void
+function ldap_set_option(?\LDAP\Connection $ldap, int $option, $value): void
 {
     error_clear_last();
     $safeResult = \ldap_set_option($ldap, $option, $value);

--- a/generated/8.3/mysql.php
+++ b/generated/8.3/mysql.php
@@ -684,7 +684,7 @@ function mysql_num_rows($result): int
  * will try to create one as if mysql_connect had been called
  * with no arguments. If no connection is found or established, an
  * E_WARNING level error is generated.
- * @return bool|resource For SELECT, SHOW, DESCRIBE, EXPLAIN and other statements returning resultset,
+ * @return mixed For SELECT, SHOW, DESCRIBE, EXPLAIN and other statements returning resultset,
  * mysql_query
  * returns a resource on success.
  *
@@ -918,7 +918,7 @@ function mysql_thread_id($link_identifier = null): int
  * will try to create one as if mysql_connect had been called
  * with no arguments. If no connection is found or established, an
  * E_WARNING level error is generated.
- * @return bool|resource For SELECT, SHOW, DESCRIBE or EXPLAIN statements,
+ * @return resource For SELECT, SHOW, DESCRIBE or EXPLAIN statements,
  * mysql_unbuffered_query
  * returns a resource on success.
  *

--- a/generated/8.3/stream.php
+++ b/generated/8.3/stream.php
@@ -502,11 +502,11 @@ function stream_socket_get_name($socket, bool $remote): string
  * STREAM_IPPROTO_RAW,
  * STREAM_IPPROTO_TCP or
  * STREAM_IPPROTO_UDP
- * @return resource[] Returns an array with the two socket resources on success.
+ * @return array Returns an array with the two socket resources on success.
  * @throws StreamException
  *
  */
-function stream_socket_pair(int $domain, int $type, int $protocol): iterable
+function stream_socket_pair(int $domain, int $type, int $protocol): array
 {
     error_clear_last();
     $safeResult = \stream_socket_pair($domain, $type, $protocol);

--- a/generated/8.4/image.php
+++ b/generated/8.4/image.php
@@ -1713,11 +1713,11 @@ function imagegammacorrect(\GdImage $image, float $input_gamma, float $output_ga
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
-function imagegd(\GdImage $image, $file = null): void
+function imagegd(\GdImage $image, ?string $file = null): void
 {
     error_clear_last();
     if ($file !== null) {
@@ -1736,7 +1736,7 @@ function imagegd(\GdImage $image, $file = null): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $chunk_size Chunk size.
  * @param int $mode Either IMG_GD2_RAW or
  * IMG_GD2_COMPRESSED. Default is
@@ -1744,7 +1744,7 @@ function imagegd(\GdImage $image, $file = null): void
  * @throws ImageException
  *
  */
-function imagegd2(\GdImage $image, $file = null, int $chunk_size = 128, int $mode = IMG_GD2_RAW): void
+function imagegd2(\GdImage $image, ?string $file = null, int $chunk_size = 128, int $mode = IMG_GD2_RAW): void
 {
     error_clear_last();
     if ($mode !== IMG_GD2_RAW) {
@@ -2804,7 +2804,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
+ * @param string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
  *
  * The filename (without the .xbm extension) is also
  * used for the C identifiers of the XBM, whereby non
@@ -2818,7 +2818,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  * @throws ImageException
  *
  */
-function imagexbm(\GdImage $image, $filename, ?int $foreground_color = null): void
+function imagexbm(\GdImage $image, ?string $filename, ?int $foreground_color = null): void
 {
     error_clear_last();
     if ($foreground_color !== null) {

--- a/generated/8.4/ldap.php
+++ b/generated/8.4/ldap.php
@@ -251,7 +251,7 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  * If not provided you may use ldap_parse_exop on the result object
  * later to get this data.
  * @param string|null $response_oid Will be filled with the response OID if provided, usually equal to the request OID.
- * @return bool|resource When used with response_data, returns TRUE on success.
+ * @return mixed When used with response_data, returns TRUE on success.
  * When used without response_data, returns a result identifier.
  * @throws LdapException
  *
@@ -1011,7 +1011,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
 /**
  * Sets the value of the specified option to be value.
  *
- * @param resource|null $ldap Either an LDAP\Connection instance, returned by
+ * @param \LDAP\Connection|null $ldap Either an LDAP\Connection instance, returned by
  * ldap_connect, to set the option for that connection,
  * or NULL to set the option globally.
  * @param int $option The parameter option can be one of:
@@ -1186,7 +1186,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
  * @throws LdapException
  *
  */
-function ldap_set_option($ldap, int $option, $value): void
+function ldap_set_option(?\LDAP\Connection $ldap, int $option, $value): void
 {
     error_clear_last();
     $safeResult = \ldap_set_option($ldap, $option, $value);

--- a/generated/8.4/mysql.php
+++ b/generated/8.4/mysql.php
@@ -684,7 +684,7 @@ function mysql_num_rows($result): int
  * will try to create one as if mysql_connect had been called
  * with no arguments. If no connection is found or established, an
  * E_WARNING level error is generated.
- * @return bool|resource For SELECT, SHOW, DESCRIBE, EXPLAIN and other statements returning resultset,
+ * @return mixed For SELECT, SHOW, DESCRIBE, EXPLAIN and other statements returning resultset,
  * mysql_query
  * returns a resource on success.
  *
@@ -918,7 +918,7 @@ function mysql_thread_id($link_identifier = null): int
  * will try to create one as if mysql_connect had been called
  * with no arguments. If no connection is found or established, an
  * E_WARNING level error is generated.
- * @return bool|resource For SELECT, SHOW, DESCRIBE or EXPLAIN statements,
+ * @return resource For SELECT, SHOW, DESCRIBE or EXPLAIN statements,
  * mysql_unbuffered_query
  * returns a resource on success.
  *

--- a/generated/8.4/stream.php
+++ b/generated/8.4/stream.php
@@ -528,11 +528,11 @@ function stream_socket_get_name($socket, bool $remote): string
  * STREAM_IPPROTO_RAW,
  * STREAM_IPPROTO_TCP or
  * STREAM_IPPROTO_UDP
- * @return resource[] Returns an array with the two socket resources on success.
+ * @return array Returns an array with the two socket resources on success.
  * @throws StreamException
  *
  */
-function stream_socket_pair(int $domain, int $type, int $protocol): iterable
+function stream_socket_pair(int $domain, int $type, int $protocol): array
 {
     error_clear_last();
     $safeResult = \stream_socket_pair($domain, $type, $protocol);

--- a/generated/8.5/image.php
+++ b/generated/8.5/image.php
@@ -1715,11 +1715,11 @@ function imagegammacorrect(\GdImage $image, float $input_gamma, float $output_ga
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
-function imagegd(\GdImage $image, $file = null): void
+function imagegd(\GdImage $image, ?string $file = null): void
 {
     error_clear_last();
     if ($file !== null) {
@@ -1738,7 +1738,7 @@ function imagegd(\GdImage $image, $file = null): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $chunk_size Chunk size.
  * @param int $mode Either IMG_GD2_RAW or
  * IMG_GD2_COMPRESSED. Default is
@@ -1746,7 +1746,7 @@ function imagegd(\GdImage $image, $file = null): void
  * @throws ImageException
  *
  */
-function imagegd2(\GdImage $image, $file = null, int $chunk_size = 128, int $mode = IMG_GD2_RAW): void
+function imagegd2(\GdImage $image, ?string $file = null, int $chunk_size = 128, int $mode = IMG_GD2_RAW): void
 {
     error_clear_last();
     if ($mode !== IMG_GD2_RAW) {
@@ -2806,7 +2806,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
+ * @param string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
  *
  * The filename (without the .xbm extension) is also
  * used for the C identifiers of the XBM, whereby non
@@ -2820,7 +2820,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  * @throws ImageException
  *
  */
-function imagexbm(\GdImage $image, $filename, ?int $foreground_color = null): void
+function imagexbm(\GdImage $image, ?string $filename, ?int $foreground_color = null): void
 {
     error_clear_last();
     if ($foreground_color !== null) {

--- a/generated/8.5/ldap.php
+++ b/generated/8.5/ldap.php
@@ -251,7 +251,7 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  * If not provided you may use ldap_parse_exop on the result object
  * later to get this data.
  * @param string|null $response_oid Will be filled with the response OID if provided, usually equal to the request OID.
- * @return bool|resource When used with response_data, returns TRUE on success.
+ * @return mixed When used with response_data, returns TRUE on success.
  * When used without response_data, returns a result identifier.
  * @throws LdapException
  *
@@ -1011,7 +1011,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
 /**
  * Sets the value of the specified option to be value.
  *
- * @param resource|null $ldap Either an LDAP\Connection instance, returned by
+ * @param \LDAP\Connection|null $ldap Either an LDAP\Connection instance, returned by
  * ldap_connect, to set the option for that connection,
  * or NULL to set the option globally.
  * @param int $option The parameter option can be one of:
@@ -1186,7 +1186,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
  * @throws LdapException
  *
  */
-function ldap_set_option($ldap, int $option, $value): void
+function ldap_set_option(?\LDAP\Connection $ldap, int $option, $value): void
 {
     error_clear_last();
     $safeResult = \ldap_set_option($ldap, $option, $value);

--- a/generated/8.5/mysql.php
+++ b/generated/8.5/mysql.php
@@ -684,7 +684,7 @@ function mysql_num_rows($result): int
  * will try to create one as if mysql_connect had been called
  * with no arguments. If no connection is found or established, an
  * E_WARNING level error is generated.
- * @return bool|resource For SELECT, SHOW, DESCRIBE, EXPLAIN and other statements returning resultset,
+ * @return mixed For SELECT, SHOW, DESCRIBE, EXPLAIN and other statements returning resultset,
  * mysql_query
  * returns a resource on success.
  *
@@ -918,7 +918,7 @@ function mysql_thread_id($link_identifier = null): int
  * will try to create one as if mysql_connect had been called
  * with no arguments. If no connection is found or established, an
  * E_WARNING level error is generated.
- * @return bool|resource For SELECT, SHOW, DESCRIBE or EXPLAIN statements,
+ * @return resource For SELECT, SHOW, DESCRIBE or EXPLAIN statements,
  * mysql_unbuffered_query
  * returns a resource on success.
  *

--- a/generated/8.5/stream.php
+++ b/generated/8.5/stream.php
@@ -528,11 +528,11 @@ function stream_socket_get_name($socket, bool $remote): string
  * STREAM_IPPROTO_RAW,
  * STREAM_IPPROTO_TCP or
  * STREAM_IPPROTO_UDP
- * @return resource[] Returns an array with the two socket resources on success.
+ * @return array Returns an array with the two socket resources on success.
  * @throws StreamException
  *
  */
-function stream_socket_pair(int $domain, int $type, int $protocol): iterable
+function stream_socket_pair(int $domain, int $type, int $protocol): array
 {
     error_clear_last();
     $safeResult = \stream_socket_pair($domain, $type, $protocol);

--- a/generator/src/PhpStanFunctions/PhpStanType.php
+++ b/generator/src/PhpStanFunctions/PhpStanType.php
@@ -133,14 +133,7 @@ class PhpStanType
             return $phpDocType;
         }
         // If phpstan claims something is a `resource`, use php docs.
-        // (Ideally phpstan would have correct types, or less-ideally
-        // we would ignore it whenever it mentions a resource at all,
-        // but that results in too many false positives, so we only
-        // ignore these very specific cases...)
-        if ($phpStanType->getDocBlockType($errorType) === "resource" ||
-            $phpStanType->getDocBlockType($errorType) === "resource|string" ||
-            $phpStanType->getDocBlockType($errorType) === "array|resource|string"
-        ) {
+        if (str_contains($phpStanType->getDocBlockType($errorType), "resource")) {
             return $phpDocType;
         }
         // If phpstan has information, and we don't specifically

--- a/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
@@ -248,5 +248,14 @@ class PhpStanTypeTest extends TestCase
                 new PhpStanType('GdImage')
             )->getDocBlockType()
         );
+
+        // if phpstan claims something might be a resource, don't trust it
+        $this->assertEquals(
+            '\GdImage|string',
+            PhpStanType::selectMostUsefulType(
+                new PhpStanType('resource|string'),
+                new PhpStanType('GdImage|string')
+            )->getDocBlockType()
+        );
     }
 }


### PR DESCRIPTION

Before: Prefer `\GdImage` to `resource`

After: Also prefer `\GdImage[]` to `resource[]`, and `\GdImage|string` to `resource|string`
