### PR TITLE
Deduplicate (and unit test) logic for selecting the type-hint data source

### DIFF
--- a/generator/src/PhpStanFunctions/PhpStanType.php
+++ b/generator/src/PhpStanFunctions/PhpStanType.php
@@ -117,6 +117,36 @@ class PhpStanType
         $this->falsable = $falsable;
     }
 
+    /**
+     * Given two PhpStanTypes (eg, one from phpstan's internal type
+     * hint database, and one from PHP's XML documentation), come
+     * up with the most useful type data
+     */
+    public static function selectMostUsefulType(
+        ?PhpStanType $phpStanType,
+        PhpStanType $phpDocType,
+        ?int $errorType = null
+    ): PhpStanType {
+        // If phpstan's database doesn't mention this function at all,
+        // use the PHPDoc type
+        if (is_null($phpStanType)) {
+            return $phpDocType;
+        }
+        // If php documentation doesn't have any useful information,
+        // use the phpstan type
+        if ($phpDocType->getDocBlockType($errorType) === "") {
+            return $phpStanType;
+        }
+        // If both sources have some information, but phpstan claims
+        // something is a `resource`, don't trust it, use php docs
+        if ($phpStanType->getDocBlockType($errorType) === "resource") {
+            return $phpDocType;
+        }
+        // If both sources have some information, and both seem to be
+        // vaguely legitimate, prefer phpstan
+        return $phpStanType;
+    }
+
     public function getDocBlockType(?int $errorType = null): string
     {
         $returnTypes = $this->types;

--- a/generator/src/XmlDocParser/Method.php
+++ b/generator/src/XmlDocParser/Method.php
@@ -33,16 +33,11 @@ class Method
     ) {
         $functionName = $this->getFunctionName();
         $this->phpstanSignature = $phpStanFunctionMapReader->hasFunction($functionName) ? $phpStanFunctionMapReader->getFunction($functionName) : null;
-
-        // mostly we trust phpstan, but if phpstan says it's a "resource",
-        // and the PHP docs have a more specific type hint, then we prefer
-        // to use the PHP docs
-        $phpStanType = $this->phpstanSignature ? $this->phpstanSignature->getReturnType() : null;
-        $phpDocType = new PhpStanType($this->functionObject->type);
-        if ($phpStanType && $phpStanType->getDocBlockType($errorType) === "resource" && $phpDocType->getDocBlockType($errorType) !== "") {
-            $phpStanType = null;
-        }
-        $this->returnType = $phpStanType ?? $phpDocType;
+        $this->returnType = PhpStanType::selectMostUsefulType(
+            $this->phpstanSignature?->getReturnType(),
+            new PhpStanType($this->functionObject->type),
+            $errorType
+        );
     }
 
     public function __toString(): string

--- a/generator/src/XmlDocParser/Parameter.php
+++ b/generator/src/XmlDocParser/Parameter.php
@@ -16,17 +16,10 @@ class Parameter
         ?PhpStanFunction $phpStanFunction,
         int $position
     ) {
-        $phpStanParam = $phpStanFunction ? $phpStanFunction->getParameter($this->getParameterName(), $position) : null;
-
-        // mostly we trust phpstan, but if phpstan says it's a "resource",
-        // and the PHP docs have a more specific type hint, then we prefer
-        // to use the PHP docs
-        $phpStanType = $phpStanParam ? $phpStanParam->getType() : null;
-        $phpDocType = new PhpStanType($this->parameter->type);
-        if ($phpStanType && $phpStanType->getDocBlockType() === "resource" && $phpDocType->getDocBlockType() !== "") {
-            $phpStanType = null;
-        }
-        $this->type = $phpStanType ?? $phpDocType;
+        $this->type = PhpStanType::selectMostUsefulType(
+            $phpStanFunction?->getParameter($this->getParameterName(), $position)?->getType(),
+            new PhpStanType($this->parameter->type)
+        );
     }
 
     /**

--- a/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
@@ -219,4 +219,43 @@ class PhpStanTypeTest extends TestCase
         $param = new PhpStanType($xml);
         $this->assertEquals('\OpenSSLCertificate|string', $param->getDocBlockType());
     }
+
+    public function testSelectMostUsefulType(): void
+    {
+        // if phpstan doesn't know about the function, use phpdoc
+        $this->assertEquals(
+            'string',
+            PhpStanType::selectMostUsefulType(
+                null,
+                new PhpStanType('string')
+            )->getDocBlockType()
+        );
+
+        // if phpdoc doesn't have useful information, use phpstan
+        $this->assertEquals(
+            'int',
+            PhpStanType::selectMostUsefulType(
+                new PhpStanType('int'),
+                new PhpStanType('')
+            )->getDocBlockType()
+        );
+
+        // if both have useful information, use phpstan
+        $this->assertEquals(
+            'int',
+            PhpStanType::selectMostUsefulType(
+                new PhpStanType('int'),
+                new PhpStanType('string')
+            )->getDocBlockType()
+        );
+
+        // if phpstan claims something is a resource, don't trust it
+        $this->assertEquals(
+            '\GdImage',
+            PhpStanType::selectMostUsefulType(
+                new PhpStanType('resource'),
+                new PhpStanType('GdImage')
+            )->getDocBlockType()
+        );
+    }
 }


### PR DESCRIPTION

Having the same logic copy-pasted for parameter-types and return-types was messy
