### PR TITLE
Simplify FunctionMapReader

### DIFF
--- a/generator/src/PhpStanFunctions/PhpStanFunctionMapReader.php
+++ b/generator/src/PhpStanFunctions/PhpStanFunctionMapReader.php
@@ -24,13 +24,11 @@ class PhpStanFunctionMapReader
         $this->customFunctionMap = require FileCreator::getSafeRootDir() . '/generator/config/CustomPhpStanFunctionMap.php';
     }
 
-    public function hasFunction(string $functionName): bool
+    public function getFunction(string $functionName): ?PhpStanFunction
     {
-        return isset($this->functionMap[$functionName]);
-    }
-
-    public function getFunction(string $functionName): PhpStanFunction
-    {
+        if (!isset($this->functionMap[$functionName])) {
+            return null;
+        }
         $map = $this->functionMap[$functionName];
         $customMap = $this->customFunctionMap[$functionName] ?? null;
         if ($map && $customMap) {

--- a/generator/src/XmlDocParser/Method.php
+++ b/generator/src/XmlDocParser/Method.php
@@ -31,8 +31,7 @@ class Method
         PhpStanFunctionMapReader $phpStanFunctionMapReader,
         private int $errorType
     ) {
-        $functionName = $this->getFunctionName();
-        $this->phpstanSignature = $phpStanFunctionMapReader->hasFunction($functionName) ? $phpStanFunctionMapReader->getFunction($functionName) : null;
+        $this->phpstanSignature = $phpStanFunctionMapReader->getFunction($this->getFunctionName());
         $this->returnType = PhpStanType::selectMostUsefulType(
             $this->phpstanSignature?->getReturnType(),
             new PhpStanType($this->functionObject->type),

--- a/generator/tests/PhpStanFunctions/PhpStanFunctionMapReaderTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanFunctionMapReaderTest.php
@@ -8,18 +8,14 @@ use PHPUnit\Framework\TestCase;
 
 class PhpStanFunctionMapReaderTest extends TestCase
 {
-    public function testHas(): void
-    {
-        $mapReader = new PhpStanFunctionMapReader();
-        $this->assertTrue($mapReader->hasFunction('strpos'));
-        $this->assertFalse($mapReader->hasFunction('foobar'));
-    }
-
     public function testGet(): void
     {
         $mapReader = new PhpStanFunctionMapReader();
-        $function = $mapReader->getFunction('apcu_fetch');
 
+        $this->assertNull($mapReader->getFunction('foobar'));
+
+        $function = $mapReader->getFunction('apcu_fetch');
+        $this->assertNotNull($function);
 
         // 'apcu_fetch' => ['mixed', 'key'=>'string|string[]', '&w_success='=>'bool'],
         $this->assertSame('mixed', $function->getReturnType()->getDocBlockType());
@@ -28,7 +24,7 @@ class PhpStanFunctionMapReaderTest extends TestCase
         $this->assertSame('success', $parameters['success']->getName());
         $this->assertSame('bool|null', $parameters['success']->getType()->getDocBlockType());
     }
-    
+
     //todo: find a way to test custom map
     /*public function testCustomMapThrowExceptionIfOutdated()
     {


### PR DESCRIPTION

PHP 8.0 has null-safe operators, which make operating on a single nullable type cleaner than having separate "does X exist" and "give me X" functions
