### PR TITLE
Allow `non-empty-string` / `non-falsey-string` in docblocks, fixes #398

### DIFF
--- a/generated/8.1/dir.php
+++ b/generated/8.1/dir.php
@@ -51,7 +51,7 @@ function chroot(string $directory): void
 /**
  * Gets the current working directory.
  *
- * @return string Returns the current working directory on success.
+ * @return non-empty-string Returns the current working directory on success.
  *
  * On some Unix variants, getcwd will return
  * FALSE if any one of the parent directories does not have the

--- a/generated/8.1/filesystem.php
+++ b/generated/8.1/filesystem.php
@@ -1389,7 +1389,7 @@ function readlink(string $path): string
  *
  * Whilst a path must be supplied, the value can be an empty string.
  * In this case, the value is interpreted as the current directory.
- * @return string Returns the canonicalized absolute pathname on success. The resulting path
+ * @return non-empty-string Returns the canonicalized absolute pathname on success. The resulting path
  * will have no symbolic link, /./ or /../ components. Trailing delimiters,
  * such as \ and /, are also removed.
  *
@@ -1520,7 +1520,7 @@ function symlink(string $target, string $link): void
  *
  * @param string $directory The directory where the temporary filename will be created.
  * @param string $prefix The prefix of the generated temporary filename.
- * @return string Returns the new temporary filename (with path).
+ * @return non-falsy-string Returns the new temporary filename (with path).
  * @throws FilesystemException
  *
  */

--- a/generated/8.1/hash.php
+++ b/generated/8.1/hash.php
@@ -26,7 +26,7 @@ use Safe\Exceptions\HashException;
  * @param string $salt Salt to use during derivation.
  *
  * While optional, adding random salt significantly improves the strength of HKDF.
- * @return string Returns a string containing a raw binary representation of the derived key
+ * @return non-falsy-string Returns a string containing a raw binary representation of the derived key
  * (also known as output keying material - OKM);.
  * @throws HashException
  *

--- a/generated/8.1/info.php
+++ b/generated/8.1/info.php
@@ -436,7 +436,7 @@ function ini_set(string $option, string $value): string
 /**
  *
  *
- * @return string Returns the interface type, as a lowercase string.
+ * @return non-empty-string Returns the interface type, as a lowercase string.
  *
  * Although not exhaustive, the possible return values include
  * apache,

--- a/generated/8.1/json.php
+++ b/generated/8.1/json.php
@@ -38,7 +38,7 @@ use Safe\Exceptions\JsonException;
  * The behaviour of these constants is described on the
  * JSON constants page.
  * @param int $depth Set the maximum depth. Must be greater than zero.
- * @return string Returns a JSON encoded string on success.
+ * @return non-empty-string Returns a JSON encoded string on success.
  * @throws JsonException
  *
  */

--- a/generated/8.1/mbstring.php
+++ b/generated/8.1/mbstring.php
@@ -93,7 +93,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * For UTF-16, UTF-32,
  * UCS2 and UCS4, encoding
  * detection will fail always.
- * @return bool|string When setting the encoding detection order, TRUE is returned on success.
+ * @return array|bool When setting the encoding detection order, TRUE is returned on success.
  *
  * When getting the encoding detection order, an ordered array of the encodings is returned.
  * @throws MbstringException
@@ -118,11 +118,11 @@ function mb_detect_order($encoding = null)
  * Returns an array of aliases for a known encoding type.
  *
  * @param string $encoding The encoding type being checked, for aliases.
- * @return string Returns a numerically indexed array of encoding aliases on success
+ * @return array Returns a numerically indexed array of encoding aliases on success
  * @throws MbstringException
  *
  */
-function mb_encoding_aliases(string $encoding): string
+function mb_encoding_aliases(string $encoding): array
 {
     error_clear_last();
     $safeResult = \mb_encoding_aliases($encoding);

--- a/generated/8.1/session.php
+++ b/generated/8.1/session.php
@@ -229,7 +229,7 @@ function session_module_name(?string $module = null): string
  *
  * The session name can't consist of digits only, at least one letter
  * must be present. Otherwise a new session id is generated every time.
- * @return string Returns the name of the current session. If name is given
+ * @return non-falsy-string Returns the name of the current session. If name is given
  * and function updates the session name, name of the old session
  * is returned.
  * @throws SessionException

--- a/generated/8.1/sodium.php
+++ b/generated/8.1/sodium.php
@@ -249,7 +249,7 @@ function sodium_crypto_box_seal_open(string $ciphertext, string $key_pair): stri
 /**
  * Appends a message to the internal hash state.
  *
- * @param string $state The return value of sodium_crypto_generichash_init.
+ * @param non-empty-string $state The return value of sodium_crypto_generichash_init.
  * @param string $message Data to append to the hashing state.
  * @throws SodiumException
  *
@@ -291,7 +291,7 @@ function sodium_crypto_secretbox_open(string $ciphertext, string $nonce, string 
  * Verify the signature attached to a message and return the message
  *
  * @param string $signed_message A message signed with sodium_crypto_sign
- * @param string $public_key An Ed25519 public key
+ * @param non-empty-string $public_key An Ed25519 public key
  * @return string Returns the original signed message on success.
  * @throws SodiumException
  *
@@ -310,9 +310,9 @@ function sodium_crypto_sign_open(string $signed_message, string $public_key): st
 /**
  * Verify signature for the message
  *
- * @param string $signature The cryptographic signature obtained from sodium_crypto_sign_detached
+ * @param non-empty-string $signature The cryptographic signature obtained from sodium_crypto_sign_detached
  * @param string $message The message being verified
- * @param string $public_key Ed25519 public key
+ * @param non-empty-string $public_key Ed25519 public key
  * @throws SodiumException
  *
  */

--- a/generated/8.1/strings.php
+++ b/generated/8.1/strings.php
@@ -52,7 +52,7 @@ function hex2bin(string $string): string
  * @param string $filename The filename
  * @param bool $binary When TRUE, returns the digest in raw binary format with a length of
  * 16.
- * @return string Returns a string on success.
+ * @return non-falsy-string&lowercase-string Returns a string on success.
  * @throws StringsException
  *
  */
@@ -73,7 +73,7 @@ function md5_file(string $filename, bool $binary = false): string
  * @param string $filename The filename of the file to hash.
  * @param bool $binary When TRUE, returns the digest in raw binary format with a length of
  * 20.
- * @return string Returns a string on success.
+ * @return non-falsy-string&lowercase-string Returns a string on success.
  * @throws StringsException
  *
  */

--- a/generated/8.2/dir.php
+++ b/generated/8.2/dir.php
@@ -51,7 +51,7 @@ function chroot(string $directory): void
 /**
  * Gets the current working directory.
  *
- * @return string Returns the current working directory on success.
+ * @return non-empty-string Returns the current working directory on success.
  *
  * On some Unix variants, getcwd will return
  * FALSE if any one of the parent directories does not have the

--- a/generated/8.2/filesystem.php
+++ b/generated/8.2/filesystem.php
@@ -1395,7 +1395,7 @@ function readlink(string $path): string
  *
  * Whilst a path must be supplied, the value can be an empty string.
  * In this case, the value is interpreted as the current directory.
- * @return string Returns the canonicalized absolute pathname on success. The resulting path
+ * @return non-empty-string Returns the canonicalized absolute pathname on success. The resulting path
  * will have no symbolic link, /./ or /../ components. Trailing delimiters,
  * such as \ and /, are also removed.
  *
@@ -1526,7 +1526,7 @@ function symlink(string $target, string $link): void
  *
  * @param string $directory The directory where the temporary filename will be created.
  * @param string $prefix The prefix of the generated temporary filename.
- * @return string Returns the new temporary filename (with path).
+ * @return non-falsy-string Returns the new temporary filename (with path).
  * @throws FilesystemException
  *
  */

--- a/generated/8.2/info.php
+++ b/generated/8.2/info.php
@@ -436,7 +436,7 @@ function ini_set(string $option, string $value): string
 /**
  *
  *
- * @return string Returns the interface type, as a lowercase string.
+ * @return non-empty-string Returns the interface type, as a lowercase string.
  *
  * Although not exhaustive, the possible return values include
  * apache,

--- a/generated/8.2/json.php
+++ b/generated/8.2/json.php
@@ -43,7 +43,7 @@ use Safe\Exceptions\JsonException;
  * The behaviour of these constants is described on the
  * JSON constants page.
  * @param int $depth Set the maximum depth. Must be greater than zero.
- * @return string Returns a JSON encoded string on success.
+ * @return non-empty-string Returns a JSON encoded string on success.
  * @throws JsonException
  *
  */

--- a/generated/8.2/mbstring.php
+++ b/generated/8.2/mbstring.php
@@ -96,7 +96,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * For UTF-16, UTF-32,
  * UCS2 and UCS4, encoding
  * detection will fail always.
- * @return bool|string When setting the encoding detection order, TRUE is returned on success.
+ * @return array|bool When setting the encoding detection order, TRUE is returned on success.
  *
  * When getting the encoding detection order, an ordered array of the encodings is returned.
  * @throws MbstringException
@@ -121,11 +121,11 @@ function mb_detect_order($encoding = null)
  * Returns an array of aliases for a known encoding type.
  *
  * @param string $encoding The encoding type being checked, for aliases.
- * @return string Returns a numerically indexed array of encoding aliases on success
+ * @return array Returns a numerically indexed array of encoding aliases on success
  * @throws MbstringException
  *
  */
-function mb_encoding_aliases(string $encoding): string
+function mb_encoding_aliases(string $encoding): array
 {
     error_clear_last();
     $safeResult = \mb_encoding_aliases($encoding);

--- a/generated/8.2/session.php
+++ b/generated/8.2/session.php
@@ -229,7 +229,7 @@ function session_module_name(?string $module = null): string
  *
  * The session name can't consist of digits only, at least one letter
  * must be present. Otherwise a new session id is generated every time.
- * @return string Returns the name of the current session. If name is given
+ * @return non-falsy-string Returns the name of the current session. If name is given
  * and function updates the session name, name of the old session
  * is returned.
  * @throws SessionException

--- a/generated/8.2/sodium.php
+++ b/generated/8.2/sodium.php
@@ -249,7 +249,7 @@ function sodium_crypto_box_seal_open(string $ciphertext, string $key_pair): stri
 /**
  * Appends a message to the internal hash state.
  *
- * @param string $state The return value of sodium_crypto_generichash_init.
+ * @param non-empty-string $state The return value of sodium_crypto_generichash_init.
  * @param string $message Data to append to the hashing state.
  * @throws SodiumException
  *
@@ -291,7 +291,7 @@ function sodium_crypto_secretbox_open(string $ciphertext, string $nonce, string 
  * Verify the signature attached to a message and return the message
  *
  * @param string $signed_message A message signed with sodium_crypto_sign
- * @param string $public_key An Ed25519 public key
+ * @param non-empty-string $public_key An Ed25519 public key
  * @return string Returns the original signed message on success.
  * @throws SodiumException
  *
@@ -310,9 +310,9 @@ function sodium_crypto_sign_open(string $signed_message, string $public_key): st
 /**
  * Verify signature for the message
  *
- * @param string $signature The cryptographic signature obtained from sodium_crypto_sign_detached
+ * @param non-empty-string $signature The cryptographic signature obtained from sodium_crypto_sign_detached
  * @param string $message The message being verified
- * @param string $public_key Ed25519 public key
+ * @param non-empty-string $public_key Ed25519 public key
  * @throws SodiumException
  *
  */

--- a/generated/8.2/strings.php
+++ b/generated/8.2/strings.php
@@ -52,7 +52,7 @@ function hex2bin(string $string): string
  * @param string $filename The filename
  * @param bool $binary When TRUE, returns the digest in raw binary format with a length of
  * 16.
- * @return string Returns a string on success.
+ * @return non-falsy-string&lowercase-string Returns a string on success.
  * @throws StringsException
  *
  */
@@ -73,7 +73,7 @@ function md5_file(string $filename, bool $binary = false): string
  * @param string $filename The filename of the file to hash.
  * @param bool $binary When TRUE, returns the digest in raw binary format with a length of
  * 20.
- * @return string Returns a string on success.
+ * @return non-falsy-string&lowercase-string Returns a string on success.
  * @throws StringsException
  *
  */

--- a/generated/8.3/dir.php
+++ b/generated/8.3/dir.php
@@ -51,7 +51,7 @@ function chroot(string $directory): void
 /**
  * Gets the current working directory.
  *
- * @return string Returns the current working directory on success.
+ * @return non-empty-string Returns the current working directory on success.
  *
  * On some Unix variants, getcwd will return
  * FALSE if any one of the parent directories does not have the

--- a/generated/8.3/filesystem.php
+++ b/generated/8.3/filesystem.php
@@ -1395,7 +1395,7 @@ function readlink(string $path): string
  *
  * Whilst a path must be supplied, the value can be an empty string.
  * In this case, the value is interpreted as the current directory.
- * @return string Returns the canonicalized absolute pathname on success. The resulting path
+ * @return non-empty-string Returns the canonicalized absolute pathname on success. The resulting path
  * will have no symbolic link, /./ or /../ components. Trailing delimiters,
  * such as \ and /, are also removed.
  *
@@ -1526,7 +1526,7 @@ function symlink(string $target, string $link): void
  *
  * @param string $directory The directory where the temporary filename will be created.
  * @param string $prefix The prefix of the generated temporary filename.
- * @return string Returns the new temporary filename (with path).
+ * @return non-falsy-string Returns the new temporary filename (with path).
  * @throws FilesystemException
  *
  */

--- a/generated/8.3/info.php
+++ b/generated/8.3/info.php
@@ -436,7 +436,7 @@ function ini_set(string $option, string $value): string
 /**
  *
  *
- * @return string Returns the interface type, as a lowercase string.
+ * @return non-empty-string Returns the interface type, as a lowercase string.
  *
  * Although not exhaustive, the possible return values include
  * apache,

--- a/generated/8.3/json.php
+++ b/generated/8.3/json.php
@@ -43,7 +43,7 @@ use Safe\Exceptions\JsonException;
  * The behaviour of these constants is described on the
  * JSON constants page.
  * @param int $depth Set the maximum depth. Must be greater than zero.
- * @return string Returns a JSON encoded string on success.
+ * @return non-empty-string Returns a JSON encoded string on success.
  * @throws JsonException
  *
  */

--- a/generated/8.3/mbstring.php
+++ b/generated/8.3/mbstring.php
@@ -96,7 +96,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * For UTF-16, UTF-32,
  * UCS2 and UCS4, encoding
  * detection will fail always.
- * @return bool|string When setting the encoding detection order, TRUE is returned on success.
+ * @return array|bool When setting the encoding detection order, TRUE is returned on success.
  *
  * When getting the encoding detection order, an ordered array of the encodings is returned.
  * @throws MbstringException
@@ -121,11 +121,11 @@ function mb_detect_order($encoding = null)
  * Returns an array of aliases for a known encoding type.
  *
  * @param string $encoding The encoding type being checked, for aliases.
- * @return string Returns a numerically indexed array of encoding aliases on success
+ * @return array Returns a numerically indexed array of encoding aliases on success
  * @throws MbstringException
  *
  */
-function mb_encoding_aliases(string $encoding): string
+function mb_encoding_aliases(string $encoding): array
 {
     error_clear_last();
     $safeResult = \mb_encoding_aliases($encoding);

--- a/generated/8.3/session.php
+++ b/generated/8.3/session.php
@@ -229,7 +229,7 @@ function session_module_name(?string $module = null): string
  *
  * The session name can't consist of digits only, at least one letter
  * must be present. Otherwise a new session id is generated every time.
- * @return string Returns the name of the current session. If name is given
+ * @return non-falsy-string Returns the name of the current session. If name is given
  * and function updates the session name, name of the old session
  * is returned.
  * @throws SessionException

--- a/generated/8.3/sodium.php
+++ b/generated/8.3/sodium.php
@@ -249,7 +249,7 @@ function sodium_crypto_box_seal_open(string $ciphertext, string $key_pair): stri
 /**
  * Appends a message to the internal hash state.
  *
- * @param string $state The return value of sodium_crypto_generichash_init.
+ * @param non-empty-string $state The return value of sodium_crypto_generichash_init.
  * @param string $message Data to append to the hashing state.
  * @throws SodiumException
  *
@@ -291,7 +291,7 @@ function sodium_crypto_secretbox_open(string $ciphertext, string $nonce, string 
  * Verify the signature attached to a message and return the message
  *
  * @param string $signed_message A message signed with sodium_crypto_sign
- * @param string $public_key An Ed25519 public key
+ * @param non-empty-string $public_key An Ed25519 public key
  * @return string Returns the original signed message on success.
  * @throws SodiumException
  *
@@ -310,9 +310,9 @@ function sodium_crypto_sign_open(string $signed_message, string $public_key): st
 /**
  * Verify signature for the message
  *
- * @param string $signature The cryptographic signature obtained from sodium_crypto_sign_detached
+ * @param non-empty-string $signature The cryptographic signature obtained from sodium_crypto_sign_detached
  * @param string $message The message being verified
- * @param string $public_key Ed25519 public key
+ * @param non-empty-string $public_key Ed25519 public key
  * @throws SodiumException
  *
  */

--- a/generated/8.3/strings.php
+++ b/generated/8.3/strings.php
@@ -52,7 +52,7 @@ function hex2bin(string $string): string
  * @param string $filename The filename
  * @param bool $binary When TRUE, returns the digest in raw binary format with a length of
  * 16.
- * @return string Returns a string on success.
+ * @return non-falsy-string&lowercase-string Returns a string on success.
  * @throws StringsException
  *
  */
@@ -73,7 +73,7 @@ function md5_file(string $filename, bool $binary = false): string
  * @param string $filename The filename of the file to hash.
  * @param bool $binary When TRUE, returns the digest in raw binary format with a length of
  * 20.
- * @return string Returns a string on success.
+ * @return non-falsy-string&lowercase-string Returns a string on success.
  * @throws StringsException
  *
  */

--- a/generated/8.4/dir.php
+++ b/generated/8.4/dir.php
@@ -51,7 +51,7 @@ function chroot(string $directory): void
 /**
  * Gets the current working directory.
  *
- * @return string Returns the current working directory on success.
+ * @return non-empty-string Returns the current working directory on success.
  *
  * On some Unix variants, getcwd will return
  * FALSE if any one of the parent directories does not have the

--- a/generated/8.4/filesystem.php
+++ b/generated/8.4/filesystem.php
@@ -1357,7 +1357,7 @@ function readlink(string $path): string
  *
  * Whilst a path must be supplied, the value can be an empty string.
  * In this case, the value is interpreted as the current directory.
- * @return string Returns the canonicalized absolute pathname on success. The resulting path
+ * @return non-empty-string Returns the canonicalized absolute pathname on success. The resulting path
  * will have no symbolic link, /./ or /../ components. Trailing delimiters,
  * such as \ and /, are also removed.
  *
@@ -1488,7 +1488,7 @@ function symlink(string $target, string $link): void
  *
  * @param string $directory The directory where the temporary filename will be created.
  * @param string $prefix The prefix of the generated temporary filename.
- * @return string Returns the new temporary filename (with path).
+ * @return non-falsy-string Returns the new temporary filename (with path).
  * @throws FilesystemException
  *
  */

--- a/generated/8.4/info.php
+++ b/generated/8.4/info.php
@@ -319,7 +319,7 @@ function ini_set(string $option, string $value): string
 /**
  *
  *
- * @return string Returns the interface type, as a lowercase string.
+ * @return non-empty-string Returns the interface type, as a lowercase string.
  *
  * Although not exhaustive, the possible return values include
  * apache,

--- a/generated/8.4/json.php
+++ b/generated/8.4/json.php
@@ -43,7 +43,7 @@ use Safe\Exceptions\JsonException;
  * The behaviour of these constants is described on the
  * JSON constants page.
  * @param int $depth Set the maximum depth. Must be greater than zero.
- * @return string Returns a JSON encoded string on success.
+ * @return non-empty-string Returns a JSON encoded string on success.
  * @throws JsonException
  *
  */

--- a/generated/8.4/mbstring.php
+++ b/generated/8.4/mbstring.php
@@ -96,7 +96,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * For UTF-16, UTF-32,
  * UCS2 and UCS4, encoding
  * detection will fail always.
- * @return bool|string When setting the encoding detection order, TRUE is returned on success.
+ * @return array|bool When setting the encoding detection order, TRUE is returned on success.
  *
  * When getting the encoding detection order, an ordered array of the encodings is returned.
  * @throws MbstringException

--- a/generated/8.4/session.php
+++ b/generated/8.4/session.php
@@ -228,7 +228,7 @@ function session_module_name(?string $module = null): string
  *
  * The session name can't consist of digits only, at least one letter
  * must be present. Otherwise a new session id is generated every time.
- * @return string Returns the name of the current session. If name is given
+ * @return non-falsy-string Returns the name of the current session. If name is given
  * and function updates the session name, name of the old session
  * is returned.
  * @throws SessionException

--- a/generated/8.4/sodium.php
+++ b/generated/8.4/sodium.php
@@ -317,7 +317,7 @@ function sodium_crypto_secretbox_open(string $ciphertext, string $nonce, string 
  * Verify the signature attached to a message and return the message
  *
  * @param string $signed_message A message signed with sodium_crypto_sign
- * @param string $public_key An Ed25519 public key
+ * @param non-empty-string $public_key An Ed25519 public key
  * @return string Returns the original signed message on success.
  * @throws SodiumException
  *
@@ -336,9 +336,9 @@ function sodium_crypto_sign_open(string $signed_message, string $public_key): st
 /**
  * Verify signature for the message
  *
- * @param string $signature The cryptographic signature obtained from sodium_crypto_sign_detached
+ * @param non-empty-string $signature The cryptographic signature obtained from sodium_crypto_sign_detached
  * @param string $message The message being verified
- * @param string $public_key Ed25519 public key
+ * @param non-empty-string $public_key Ed25519 public key
  * @throws SodiumException
  *
  */

--- a/generated/8.4/strings.php
+++ b/generated/8.4/strings.php
@@ -52,7 +52,7 @@ function hex2bin(string $string): string
  * @param string $filename The filename
  * @param bool $binary When TRUE, returns the digest in raw binary format with a length of
  * 16.
- * @return string Returns a string on success.
+ * @return non-falsy-string&lowercase-string Returns a string on success.
  * @throws StringsException
  *
  */
@@ -73,7 +73,7 @@ function md5_file(string $filename, bool $binary = false): string
  * @param string $filename The filename of the file to hash.
  * @param bool $binary When TRUE, returns the digest in raw binary format with a length of
  * 20.
- * @return string Returns a string on success.
+ * @return non-falsy-string&lowercase-string Returns a string on success.
  * @throws StringsException
  *
  */

--- a/generated/8.5/dir.php
+++ b/generated/8.5/dir.php
@@ -51,7 +51,7 @@ function chroot(string $directory): void
 /**
  * Gets the current working directory.
  *
- * @return string Returns the current working directory on success.
+ * @return non-empty-string Returns the current working directory on success.
  *
  * On some Unix variants, getcwd will return
  * FALSE if any one of the parent directories does not have the

--- a/generated/8.5/filesystem.php
+++ b/generated/8.5/filesystem.php
@@ -1357,7 +1357,7 @@ function readlink(string $path): string
  *
  * Whilst a path must be supplied, the value can be an empty string.
  * In this case, the value is interpreted as the current directory.
- * @return string Returns the canonicalized absolute pathname on success. The resulting path
+ * @return non-empty-string Returns the canonicalized absolute pathname on success. The resulting path
  * will have no symbolic link, /./ or /../ components. Trailing delimiters,
  * such as \ and /, are also removed.
  *
@@ -1488,7 +1488,7 @@ function symlink(string $target, string $link): void
  *
  * @param string $directory The directory where the temporary filename will be created.
  * @param string $prefix The prefix of the generated temporary filename.
- * @return string Returns the new temporary filename (with path).
+ * @return non-falsy-string Returns the new temporary filename (with path).
  * @throws FilesystemException
  *
  */

--- a/generated/8.5/info.php
+++ b/generated/8.5/info.php
@@ -319,7 +319,7 @@ function ini_set(string $option, string $value): string
 /**
  *
  *
- * @return string Returns the interface type, as a lowercase string.
+ * @return non-empty-string Returns the interface type, as a lowercase string.
  *
  * Although not exhaustive, the possible return values include
  * apache,

--- a/generated/8.5/json.php
+++ b/generated/8.5/json.php
@@ -43,7 +43,7 @@ use Safe\Exceptions\JsonException;
  * The behaviour of these constants is described on the
  * JSON constants page.
  * @param int $depth Set the maximum depth. Must be greater than zero.
- * @return string Returns a JSON encoded string on success.
+ * @return non-empty-string Returns a JSON encoded string on success.
  * @throws JsonException
  *
  */

--- a/generated/8.5/mbstring.php
+++ b/generated/8.5/mbstring.php
@@ -96,7 +96,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * For UTF-16, UTF-32,
  * UCS2 and UCS4, encoding
  * detection will fail always.
- * @return bool|string When setting the encoding detection order, TRUE is returned on success.
+ * @return array|bool When setting the encoding detection order, TRUE is returned on success.
  *
  * When getting the encoding detection order, an ordered array of the encodings is returned.
  * @throws MbstringException

--- a/generated/8.5/session.php
+++ b/generated/8.5/session.php
@@ -228,7 +228,7 @@ function session_module_name(?string $module = null): string
  *
  * The session name can't consist of digits only, at least one letter
  * must be present. Otherwise a new session id is generated every time.
- * @return string Returns the name of the current session. If name is given
+ * @return non-falsy-string Returns the name of the current session. If name is given
  * and function updates the session name, name of the old session
  * is returned.
  * @throws SessionException

--- a/generated/8.5/sodium.php
+++ b/generated/8.5/sodium.php
@@ -317,7 +317,7 @@ function sodium_crypto_secretbox_open(string $ciphertext, string $nonce, string 
  * Verify the signature attached to a message and return the message
  *
  * @param string $signed_message A message signed with sodium_crypto_sign
- * @param string $public_key An Ed25519 public key
+ * @param non-empty-string $public_key An Ed25519 public key
  * @return string Returns the original signed message on success.
  * @throws SodiumException
  *
@@ -336,9 +336,9 @@ function sodium_crypto_sign_open(string $signed_message, string $public_key): st
 /**
  * Verify signature for the message
  *
- * @param string $signature The cryptographic signature obtained from sodium_crypto_sign_detached
+ * @param non-empty-string $signature The cryptographic signature obtained from sodium_crypto_sign_detached
  * @param string $message The message being verified
- * @param string $public_key Ed25519 public key
+ * @param non-empty-string $public_key Ed25519 public key
  * @throws SodiumException
  *
  */

--- a/generated/8.5/strings.php
+++ b/generated/8.5/strings.php
@@ -52,7 +52,7 @@ function hex2bin(string $string): string
  * @param string $filename The filename
  * @param bool $binary When TRUE, returns the digest in raw binary format with a length of
  * 16.
- * @return string Returns a string on success.
+ * @return non-falsy-string&lowercase-string Returns a string on success.
  * @throws StringsException
  *
  */
@@ -73,7 +73,7 @@ function md5_file(string $filename, bool $binary = false): string
  * @param string $filename The filename of the file to hash.
  * @param bool $binary When TRUE, returns the digest in raw binary format with a length of
  * 20.
- * @return string Returns a string on success.
+ * @return non-falsy-string&lowercase-string Returns a string on success.
  * @throws StringsException
  *
  */

--- a/generator/src/PhpStanFunctions/PhpStanType.php
+++ b/generator/src/PhpStanFunctions/PhpStanType.php
@@ -83,14 +83,6 @@ class PhpStanType
             }
 
             // here we deal with some weird phpstan typings
-            if (str_contains($returnType, 'non-falsy-string')) {
-                $returnType = 'string';
-            }
-
-            if (str_contains($returnType, 'non-empty-string')) {
-                $returnType = 'string';
-            }
-
             if (str_contains($returnType, '__stringAndStringable')) {
                 $returnType = 'string';
             }
@@ -189,6 +181,10 @@ class PhpStanType
                 $type = ''; // null is a real typehint
             } elseif (str_contains($type, 'true')) {
                 $type = 'bool'; // php8.1 doesn't support "true" as a typehint
+            } elseif (str_contains($type, 'non-falsy-string')) {
+                $type = 'string'; // phpstan string type to generic string
+            } elseif (str_contains($type, 'non-empty-string')) {
+                $type = 'string';
             }
         }
 

--- a/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
@@ -172,7 +172,7 @@ class PhpStanTypeTest extends TestCase
     public function testNotEmptyStringBecomingString(): void
     {
         $param = new PhpStanType('non-empty-string|false');
-        $this->assertEquals('string', $param->getDocBlockType(Method::FALSY_TYPE));
+        $this->assertEquals('non-empty-string', $param->getDocBlockType(Method::FALSY_TYPE));
         $this->assertEquals('string', $param->getSignatureType(Method::FALSY_TYPE));
     }
 


### PR DESCRIPTION

(We still convert them to plain `string` for function signatures)
