### PR TITLE
[ci] fail workflow if we can't fetch input data

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           path: "generator/doc/doc-en"
           key: php-doc-${{ needs.fetch_defs.outputs.date }}
+          fail-on-cache-miss: true
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v4"
         with:
@@ -91,7 +92,6 @@ jobs:
   generated_tests:
     name: "Generated Tests"
     runs-on: "ubuntu-24.04"
-    needs: "fetch_defs"
     strategy:
       fail-fast: false
       matrix:
@@ -108,12 +108,6 @@ jobs:
         with:
           coverage: "pcov"
           php-version: "${{ matrix.php-version }}"
-      - name: "Fetch cached docs"
-        id: cache-php-doc
-        uses: "actions/cache@v4"
-        with:
-          path: "generator/doc/doc-en"
-          key: php-doc-${{ needs.fetch_defs.outputs.date }}
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v4"
         with:
@@ -151,6 +145,7 @@ jobs:
         with:
           path: "generator/doc/doc-en"
           key: php-doc-${{ needs.fetch_defs.outputs.date }}
+          fail-on-cache-miss: true
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v4"
         with:


### PR DESCRIPTION

Github caching API is having issues and making our workflows fail, there doesn't appear to be any "fail workflow if cache save fails", but there is "fail workflow if cache restore fails"...

Also: we don't need xml docs to run generated-file tests, only generator tests
