### PR TITLE
turn foo[] into array rather than iterable, fixes #582

### DIFF
--- a/generated/8.1/exec.php
+++ b/generated/8.1/exec.php
@@ -151,7 +151,7 @@ function proc_nice(int $priority): void
  * @throws ExecException
  *
  */
-function proc_open(string $cmd, array $descriptorspec, ?iterable &$pipes, ?string $cwd = null, ?array $env = null, ?array $other_options = null)
+function proc_open(string $cmd, array $descriptorspec, ?array &$pipes, ?string $cwd = null, ?array $env = null, ?array $other_options = null)
 {
     error_clear_last();
     if ($other_options !== null) {

--- a/generated/8.1/pcre.php
+++ b/generated/8.1/pcre.php
@@ -610,7 +610,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  * @throws PcreException
  *
  */
-function preg_match(string $pattern, string $subject, ?iterable &$matches = null, int $flags = 0, int $offset = 0): int
+function preg_match(string $pattern, string $subject, ?array &$matches = null, int $flags = 0, int $offset = 0): int
 {
     error_clear_last();
     $safeResult = \preg_match($pattern, $subject, $matches, $flags, $offset);

--- a/generated/8.1/sockets.php
+++ b/generated/8.1/sockets.php
@@ -99,7 +99,7 @@ function socket_addrinfo_connect(\AddressInfo $address): \Socket
  * @throws SocketsException
  *
  */
-function socket_addrinfo_lookup(string $host, $service = null, array $hints = []): iterable
+function socket_addrinfo_lookup(string $host, $service = null, array $hints = []): array
 {
     error_clear_last();
     if ($hints !== []) {
@@ -239,7 +239,7 @@ function socket_create_listen(int $port, int $backlog = 128): \Socket
  * @throws SocketsException
  *
  */
-function socket_create_pair(int $domain, int $type, int $protocol, ?iterable &$pair): void
+function socket_create_pair(int $domain, int $type, int $protocol, ?array &$pair): void
 {
     error_clear_last();
     $safeResult = \socket_create_pair($domain, $type, $protocol, $pair);

--- a/generated/8.1/stream.php
+++ b/generated/8.1/stream.php
@@ -443,7 +443,7 @@ function stream_socket_client(string $remote_socket, ?int &$errno = null, ?strin
  * @throws StreamException
  *
  */
-function stream_socket_pair(int $domain, int $type, int $protocol): iterable
+function stream_socket_pair(int $domain, int $type, int $protocol): array
 {
     error_clear_last();
     $safeResult = \stream_socket_pair($domain, $type, $protocol);

--- a/generated/8.2/exec.php
+++ b/generated/8.2/exec.php
@@ -181,7 +181,7 @@ function proc_nice(int $priority): void
  * @throws ExecException
  *
  */
-function proc_open(string $command, array $descriptor_spec, ?iterable &$pipes, ?string $cwd = null, ?array $env_vars = null, ?array $options = null)
+function proc_open(string $command, array $descriptor_spec, ?array &$pipes, ?string $cwd = null, ?array $env_vars = null, ?array $options = null)
 {
     error_clear_last();
     if ($options !== null) {

--- a/generated/8.2/pcre.php
+++ b/generated/8.2/pcre.php
@@ -610,7 +610,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  * @throws PcreException
  *
  */
-function preg_match(string $pattern, string $subject, ?iterable &$matches = null, int $flags = 0, int $offset = 0): int
+function preg_match(string $pattern, string $subject, ?array &$matches = null, int $flags = 0, int $offset = 0): int
 {
     error_clear_last();
     $safeResult = \preg_match($pattern, $subject, $matches, $flags, $offset);

--- a/generated/8.2/sockets.php
+++ b/generated/8.2/sockets.php
@@ -99,7 +99,7 @@ function socket_addrinfo_connect(\AddressInfo $address): \Socket
  * @throws SocketsException
  *
  */
-function socket_addrinfo_lookup(string $host, $service = null, array $hints = []): iterable
+function socket_addrinfo_lookup(string $host, $service = null, array $hints = []): array
 {
     error_clear_last();
     if ($hints !== []) {
@@ -239,7 +239,7 @@ function socket_create_listen(int $port, int $backlog = 128): \Socket
  * @throws SocketsException
  *
  */
-function socket_create_pair(int $domain, int $type, int $protocol, ?iterable &$pair): void
+function socket_create_pair(int $domain, int $type, int $protocol, ?array &$pair): void
 {
     error_clear_last();
     $safeResult = \socket_create_pair($domain, $type, $protocol, $pair);

--- a/generated/8.2/stream.php
+++ b/generated/8.2/stream.php
@@ -506,7 +506,7 @@ function stream_socket_get_name($socket, bool $remote): string
  * @throws StreamException
  *
  */
-function stream_socket_pair(int $domain, int $type, int $protocol): iterable
+function stream_socket_pair(int $domain, int $type, int $protocol): array
 {
     error_clear_last();
     $safeResult = \stream_socket_pair($domain, $type, $protocol);

--- a/generated/8.3/exec.php
+++ b/generated/8.3/exec.php
@@ -181,7 +181,7 @@ function proc_nice(int $priority): void
  * @throws ExecException
  *
  */
-function proc_open(string $command, array $descriptor_spec, ?iterable &$pipes, ?string $cwd = null, ?array $env_vars = null, ?array $options = null)
+function proc_open(string $command, array $descriptor_spec, ?array &$pipes, ?string $cwd = null, ?array $env_vars = null, ?array $options = null)
 {
     error_clear_last();
     if ($options !== null) {

--- a/generated/8.3/pcre.php
+++ b/generated/8.3/pcre.php
@@ -610,7 +610,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  * @throws PcreException
  *
  */
-function preg_match(string $pattern, string $subject, ?iterable &$matches = null, int $flags = 0, int $offset = 0): int
+function preg_match(string $pattern, string $subject, ?array &$matches = null, int $flags = 0, int $offset = 0): int
 {
     error_clear_last();
     $safeResult = \preg_match($pattern, $subject, $matches, $flags, $offset);

--- a/generated/8.3/sockets.php
+++ b/generated/8.3/sockets.php
@@ -99,7 +99,7 @@ function socket_addrinfo_connect(\AddressInfo $address): \Socket
  * @throws SocketsException
  *
  */
-function socket_addrinfo_lookup(string $host, $service = null, array $hints = []): iterable
+function socket_addrinfo_lookup(string $host, $service = null, array $hints = []): array
 {
     error_clear_last();
     if ($hints !== []) {
@@ -239,7 +239,7 @@ function socket_create_listen(int $port, int $backlog = 128): \Socket
  * @throws SocketsException
  *
  */
-function socket_create_pair(int $domain, int $type, int $protocol, ?iterable &$pair): void
+function socket_create_pair(int $domain, int $type, int $protocol, ?array &$pair): void
 {
     error_clear_last();
     $safeResult = \socket_create_pair($domain, $type, $protocol, $pair);

--- a/generated/8.3/stream.php
+++ b/generated/8.3/stream.php
@@ -506,7 +506,7 @@ function stream_socket_get_name($socket, bool $remote): string
  * @throws StreamException
  *
  */
-function stream_socket_pair(int $domain, int $type, int $protocol): iterable
+function stream_socket_pair(int $domain, int $type, int $protocol): array
 {
     error_clear_last();
     $safeResult = \stream_socket_pair($domain, $type, $protocol);

--- a/generated/8.4/exec.php
+++ b/generated/8.4/exec.php
@@ -181,7 +181,7 @@ function proc_nice(int $priority): void
  * @throws ExecException
  *
  */
-function proc_open(string $command, array $descriptor_spec, ?iterable &$pipes, ?string $cwd = null, ?array $env_vars = null, ?array $options = null)
+function proc_open(string $command, array $descriptor_spec, ?array &$pipes, ?string $cwd = null, ?array $env_vars = null, ?array $options = null)
 {
     error_clear_last();
     if ($options !== null) {

--- a/generated/8.4/pcre.php
+++ b/generated/8.4/pcre.php
@@ -610,7 +610,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  * @throws PcreException
  *
  */
-function preg_match(string $pattern, string $subject, ?iterable &$matches = null, int $flags = 0, int $offset = 0): int
+function preg_match(string $pattern, string $subject, ?array &$matches = null, int $flags = 0, int $offset = 0): int
 {
     error_clear_last();
     $safeResult = \preg_match($pattern, $subject, $matches, $flags, $offset);

--- a/generated/8.4/sockets.php
+++ b/generated/8.4/sockets.php
@@ -100,7 +100,7 @@ function socket_addrinfo_connect(\AddressInfo $address): \Socket
  * @throws SocketsException
  *
  */
-function socket_addrinfo_lookup(string $host, $service = null, array $hints = []): iterable
+function socket_addrinfo_lookup(string $host, $service = null, array $hints = []): array
 {
     error_clear_last();
     if ($hints !== []) {
@@ -257,7 +257,7 @@ function socket_create_listen(int $port, int $backlog = SOMAXCONN): \Socket
  * @throws SocketsException
  *
  */
-function socket_create_pair(int $domain, int $type, int $protocol, ?iterable &$pair): void
+function socket_create_pair(int $domain, int $type, int $protocol, ?array &$pair): void
 {
     error_clear_last();
     $safeResult = \socket_create_pair($domain, $type, $protocol, $pair);

--- a/generated/8.4/stream.php
+++ b/generated/8.4/stream.php
@@ -532,7 +532,7 @@ function stream_socket_get_name($socket, bool $remote): string
  * @throws StreamException
  *
  */
-function stream_socket_pair(int $domain, int $type, int $protocol): iterable
+function stream_socket_pair(int $domain, int $type, int $protocol): array
 {
     error_clear_last();
     $safeResult = \stream_socket_pair($domain, $type, $protocol);

--- a/generated/8.5/exec.php
+++ b/generated/8.5/exec.php
@@ -181,7 +181,7 @@ function proc_nice(int $priority): void
  * @throws ExecException
  *
  */
-function proc_open(string $command, array $descriptor_spec, ?iterable &$pipes, ?string $cwd = null, ?array $env_vars = null, ?array $options = null)
+function proc_open(string $command, array $descriptor_spec, ?array &$pipes, ?string $cwd = null, ?array $env_vars = null, ?array $options = null)
 {
     error_clear_last();
     if ($options !== null) {

--- a/generated/8.5/pcre.php
+++ b/generated/8.5/pcre.php
@@ -610,7 +610,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  * @throws PcreException
  *
  */
-function preg_match(string $pattern, string $subject, ?iterable &$matches = null, int $flags = 0, int $offset = 0): int
+function preg_match(string $pattern, string $subject, ?array &$matches = null, int $flags = 0, int $offset = 0): int
 {
     error_clear_last();
     $safeResult = \preg_match($pattern, $subject, $matches, $flags, $offset);

--- a/generated/8.5/sockets.php
+++ b/generated/8.5/sockets.php
@@ -100,7 +100,7 @@ function socket_addrinfo_connect(\AddressInfo $address): \Socket
  * @throws SocketsException
  *
  */
-function socket_addrinfo_lookup(string $host, $service = null, array $hints = []): iterable
+function socket_addrinfo_lookup(string $host, $service = null, array $hints = []): array
 {
     error_clear_last();
     if ($hints !== []) {
@@ -257,7 +257,7 @@ function socket_create_listen(int $port, int $backlog = SOMAXCONN): \Socket
  * @throws SocketsException
  *
  */
-function socket_create_pair(int $domain, int $type, int $protocol, ?iterable &$pair): void
+function socket_create_pair(int $domain, int $type, int $protocol, ?array &$pair): void
 {
     error_clear_last();
     $safeResult = \socket_create_pair($domain, $type, $protocol, $pair);

--- a/generated/8.5/stream.php
+++ b/generated/8.5/stream.php
@@ -532,7 +532,7 @@ function stream_socket_get_name($socket, bool $remote): string
  * @throws StreamException
  *
  */
-function stream_socket_pair(int $domain, int $type, int $protocol): iterable
+function stream_socket_pair(int $domain, int $type, int $protocol): array
 {
     error_clear_last();
     $safeResult = \stream_socket_pair($domain, $type, $protocol);

--- a/generator/src/PhpStanFunctions/PhpStanType.php
+++ b/generator/src/PhpStanFunctions/PhpStanType.php
@@ -174,7 +174,7 @@ class PhpStanType
             } elseif (str_contains($type, 'array<') || str_contains($type, 'array{')) {
                 $type = 'array'; //typed array has to be untyped
             } elseif (str_contains($type, '[]')) {
-                $type = 'iterable'; //generics cannot be typehinted and have to be turned into iterable
+                $type = 'array'; //generics cannot be typehinted
             } elseif (str_contains($type, 'resource')) {
                 $type = ''; // resource cant be typehinted
             } elseif (str_contains($type, 'null')) {

--- a/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
@@ -27,11 +27,11 @@ class PhpStanTypeTest extends TestCase
     {
         $param = new PhpStanType('string[]');
         $this->assertEquals('string[]', $param->getDocBlockType());
-        $this->assertEquals('iterable', $param->getSignatureType());
+        $this->assertEquals('array', $param->getSignatureType());
 
         $param = new PhpStanType('int[]');
         $this->assertEquals('int[]', $param->getDocBlockType());
-        $this->assertEquals('iterable', $param->getSignatureType());
+        $this->assertEquals('array', $param->getSignatureType());
 
         $param = new PhpStanType('array<string,mixed>');
         $this->assertEquals('array<string,mixed>', $param->getDocBlockType());


### PR DESCRIPTION

This was specifically requested for `preg_match`, but looking at all the other instances which get changed, I believe they are all either unaffecte or improved by this change
