### PR TITLE
add ob_get_clean in 8.1-8.3

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -568,6 +568,7 @@ return [
     'ob_end_clean',
     'ob_end_flush',
     'ob_flush',
+    'ob_get_clean',
     'ob_start',
     'oci_bind_array_by_name',
     'oci_bind_by_name',

--- a/generated/8.1/outcontrol.php
+++ b/generated/8.1/outcontrol.php
@@ -102,6 +102,34 @@ function ob_flush(): void
 
 
 /**
+ * Gets the current buffer contents and delete current output buffer.
+ *
+ * ob_get_clean essentially executes both
+ * ob_get_contents and
+ * ob_end_clean.
+ *
+ * The output buffer must be started by
+ * ob_start with PHP_OUTPUT_HANDLER_CLEANABLE
+ * and PHP_OUTPUT_HANDLER_REMOVABLE
+ * flags. Otherwise ob_get_clean will not work.
+ *
+ * @return string Returns the contents of the output buffer and end output buffering.
+ * If output buffering isn't active then FALSE is returned.
+ * @throws OutcontrolException
+ *
+ */
+function ob_get_clean(): string
+{
+    error_clear_last();
+    $safeResult = \ob_get_clean();
+    if ($safeResult === false) {
+        throw OutcontrolException::createFromPhpError();
+    }
+    return $safeResult;
+}
+
+
+/**
  * This function will turn output buffering on. While output buffering is
  * active no output is sent from the script (other than headers), instead the
  * output is stored in an internal buffer.

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -576,6 +576,7 @@ return static function (RectorConfig $rectorConfig): void {
             'ob_end_clean' => 'Safe\ob_end_clean',
             'ob_end_flush' => 'Safe\ob_end_flush',
             'ob_flush' => 'Safe\ob_flush',
+            'ob_get_clean' => 'Safe\ob_get_clean',
             'ob_start' => 'Safe\ob_start',
             'oci_bind_array_by_name' => 'Safe\oci_bind_array_by_name',
             'oci_bind_by_name' => 'Safe\oci_bind_by_name',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -564,6 +564,7 @@ return [
     'ob_end_clean',
     'ob_end_flush',
     'ob_flush',
+    'ob_get_clean',
     'ob_start',
     'oci_bind_array_by_name',
     'oci_bind_by_name',

--- a/generated/8.2/outcontrol.php
+++ b/generated/8.2/outcontrol.php
@@ -102,6 +102,34 @@ function ob_flush(): void
 
 
 /**
+ * Gets the current buffer contents and delete current output buffer.
+ *
+ * ob_get_clean essentially executes both
+ * ob_get_contents and
+ * ob_end_clean.
+ *
+ * The output buffer must be started by
+ * ob_start with PHP_OUTPUT_HANDLER_CLEANABLE
+ * and PHP_OUTPUT_HANDLER_REMOVABLE
+ * flags. Otherwise ob_get_clean will not work.
+ *
+ * @return string Returns the contents of the output buffer and end output buffering.
+ * If output buffering isn't active then FALSE is returned.
+ * @throws OutcontrolException
+ *
+ */
+function ob_get_clean(): string
+{
+    error_clear_last();
+    $safeResult = \ob_get_clean();
+    if ($safeResult === false) {
+        throw OutcontrolException::createFromPhpError();
+    }
+    return $safeResult;
+}
+
+
+/**
  * This function will turn output buffering on. While output buffering is
  * active no output is sent from the script (other than headers), instead the
  * output is stored in an internal buffer.

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -572,6 +572,7 @@ return static function (RectorConfig $rectorConfig): void {
             'ob_end_clean' => 'Safe\ob_end_clean',
             'ob_end_flush' => 'Safe\ob_end_flush',
             'ob_flush' => 'Safe\ob_flush',
+            'ob_get_clean' => 'Safe\ob_get_clean',
             'ob_start' => 'Safe\ob_start',
             'oci_bind_array_by_name' => 'Safe\oci_bind_array_by_name',
             'oci_bind_by_name' => 'Safe\oci_bind_by_name',

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -564,6 +564,7 @@ return [
     'ob_end_clean',
     'ob_end_flush',
     'ob_flush',
+    'ob_get_clean',
     'ob_start',
     'oci_bind_array_by_name',
     'oci_bind_by_name',

--- a/generated/8.3/outcontrol.php
+++ b/generated/8.3/outcontrol.php
@@ -102,6 +102,34 @@ function ob_flush(): void
 
 
 /**
+ * Gets the current buffer contents and delete current output buffer.
+ *
+ * ob_get_clean essentially executes both
+ * ob_get_contents and
+ * ob_end_clean.
+ *
+ * The output buffer must be started by
+ * ob_start with PHP_OUTPUT_HANDLER_CLEANABLE
+ * and PHP_OUTPUT_HANDLER_REMOVABLE
+ * flags. Otherwise ob_get_clean will not work.
+ *
+ * @return string Returns the contents of the output buffer and end output buffering.
+ * If output buffering isn't active then FALSE is returned.
+ * @throws OutcontrolException
+ *
+ */
+function ob_get_clean(): string
+{
+    error_clear_last();
+    $safeResult = \ob_get_clean();
+    if ($safeResult === false) {
+        throw OutcontrolException::createFromPhpError();
+    }
+    return $safeResult;
+}
+
+
+/**
  * This function will turn output buffering on. While output buffering is
  * active no output is sent from the script (other than headers), instead the
  * output is stored in an internal buffer.

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -572,6 +572,7 @@ return static function (RectorConfig $rectorConfig): void {
             'ob_end_clean' => 'Safe\ob_end_clean',
             'ob_end_flush' => 'Safe\ob_end_flush',
             'ob_flush' => 'Safe\ob_flush',
+            'ob_get_clean' => 'Safe\ob_get_clean',
             'ob_start' => 'Safe\ob_start',
             'oci_bind_array_by_name' => 'Safe\oci_bind_array_by_name',
             'oci_bind_by_name' => 'Safe\oci_bind_by_name',

--- a/generator/config/detectFalsyFunction.php
+++ b/generator/config/detectFalsyFunction.php
@@ -26,6 +26,7 @@ return function (string $text): bool {
         "/&false; if the pipe\s+cannot be established/m", // shell_exec
         "/&false; if an error occurs/m", // cfg_get_var
         "/On failure\s+returns &false;./m", // proc_open
+        "/If output buffering isn't active then &false; is returned./m", // ob_get_clean (8.1 - 8.3)
     ];
     foreach ($falsies as $falsie) {
         if (preg_match($falsie, $text)) {


### PR DESCRIPTION

The documentation changed in 8.4, and we were only detecting the new phrasing
