### PR TITLE
Make function-info 4000x faster

### DIFF
--- a/generator/src/Commands/FunctionInfoCommand.php
+++ b/generator/src/Commands/FunctionInfoCommand.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Safe\Commands;
 
-use Safe\XmlDocParser\Scanner;
+use Safe\XmlDocParser\Method;
 use Safe\XmlDocParser\DocPage;
+use Safe\PhpStanFunctions\PhpStanFunctionMapReader;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
 
 class FunctionInfoCommand extends Command
 {
@@ -24,14 +26,26 @@ class FunctionInfoCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $scanner = new Scanner(DocPage::findReferenceDir());
-        $res = $scanner->getMethods($scanner->getFunctionsPaths(), $output);
+        $target = $input->getArgument("function");
+        $targetFilename = str_replace("_", "-", $target) . ".xml";
 
-        foreach ($res->methods as $function) {
-            $name = $function->getFunctionName();
-            if ($name == $input->getArgument("function")) {
+        $phpStanFunctionMapReader = new PhpStanFunctionMapReader();
+
+        $finder = new Finder();
+        $finder->in(DocPage::findReferenceDir())->name($targetFilename)->sortByName();
+
+        foreach ($finder as $file) {
+            $docPage = new DocPage($file->getPathname());
+            $isFalsy = $docPage->detectFalsyFunction();
+            $isNullsy = $docPage->detectNullsyFunction();
+            $isEmpty = $docPage->detectEmptyFunction();
+            $errorType = $isFalsy ? Method::FALSY_TYPE : ($isNullsy ? Method::NULLSY_TYPE : Method::EMPTY_TYPE);
+
+            $functionObjects = $docPage->getMethodSynopsis();
+            $rootEntity = $docPage->loadAndResolveFile();
+            foreach ($functionObjects as $functionObject) {
+                $function = new Method($functionObject, $rootEntity, $docPage->getModule(), $phpStanFunctionMapReader, $errorType);
                 $output->writeln((string)$function);
-                break;
             }
         }
 


### PR DESCRIPTION
We don't need to load all 4000 xml files - we can just search for a file whose name matches the function name, and open that one

This also happens to mean that we can load _any_ xml file, including those for functions we consider invalid, which helps to debug _why_ we consider them invalid
