### PR TITLE
[generator] make ErrorType into an actual type

### DIFF
--- a/generator/src/Generator/WritePhpFunction.php
+++ b/generator/src/Generator/WritePhpFunction.php
@@ -6,6 +6,7 @@ namespace Safe\Generator;
 
 use Safe\XmlDocParser\Method;
 use Safe\XmlDocParser\Parameter;
+use Safe\XmlDocParser\ErrorType;
 
 class WritePhpFunction
 {
@@ -97,9 +98,9 @@ class WritePhpFunction
     private function generateExceptionCode(string $moduleName, Method $method) : string
     {
         $errorValue = match ($method->getErrorType()) {
-            Method::FALSY_TYPE => 'false',
-            Method::NULLSY_TYPE => 'null',
-            Method::EMPTY_TYPE => "''",
+            ErrorType::FALSY => 'false',
+            ErrorType::NULLSY => 'null',
+            ErrorType::EMPTY => "''",
             default => throw new \LogicException("Method doesn't have an error type"),
         };
 

--- a/generator/src/XmlDocParser/DocPage.php
+++ b/generator/src/XmlDocParser/DocPage.php
@@ -47,18 +47,18 @@ class DocPage
         return false;
     }
 
-    public function getErrorType(): int
+    public function getErrorType(): ErrorType
     {
         if ($this->detectFalsyFunction()) {
-            return Method::FALSY_TYPE;
+            return ErrorType::FALSY;
         }
         if ($this->detectNullsyFunction()) {
-            return Method::NULLSY_TYPE;
+            return ErrorType::NULLSY;
         }
         if ($this->detectEmptyFunction()) {
-            return Method::EMPTY_TYPE;
+            return ErrorType::EMPTY;
         }
-        return Method::UNKNOWN_TYPE;
+        return ErrorType::UNKNOWN;
     }
 
     /*

--- a/generator/src/XmlDocParser/ErrorType.php
+++ b/generator/src/XmlDocParser/ErrorType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Safe\XmlDocParser;
+
+enum ErrorType
+{
+    case UNKNOWN;
+    case FALSY;
+    case NULLSY;
+    case EMPTY;
+}

--- a/generator/src/XmlDocParser/Method.php
+++ b/generator/src/XmlDocParser/Method.php
@@ -11,10 +11,6 @@ use Safe\Generator\FileCreator;
 
 class Method
 {
-    const UNKNOWN_TYPE = 0;
-    const FALSY_TYPE = 1;
-    const NULLSY_TYPE = 2;
-    const EMPTY_TYPE = 3;
     /**
      * @var Parameter[]|null
      */
@@ -30,7 +26,7 @@ class Method
         private \SimpleXMLElement $rootEntity,
         private string $moduleName,
         PhpStanFunctionMapReader $phpStanFunctionMapReader,
-        private int $errorType
+        private ErrorType $errorType
     ) {
         $this->phpstanSignature = $phpStanFunctionMapReader->getFunction($this->getFunctionName());
         $this->returnType = PhpStanType::selectMostUsefulType(
@@ -59,7 +55,7 @@ class Method
             $data .= "    Safe:    " . $param->getDocBlockType() . "\n";
         }
         $data .= "\n";
-        $data .= "Error type: " . [0=>"unknown", 1=>"false", 2=>"null", 3=>"empty"][$this->errorType] . "\n";
+        $data .= "Error type: " . $this->errorType->name . "\n";
         $data .= "\n";
         $data .= "Return type:\n";
         $phpStanType = $this->phpstanSignature ? $this->phpstanSignature->getReturnType() : null;
@@ -75,7 +71,7 @@ class Method
         return $this->functionObject->methodname->__toString();
     }
 
-    public function getErrorType(): int
+    public function getErrorType(): ErrorType
     {
         return $this->errorType;
     }
@@ -163,16 +159,16 @@ class Method
     {
         $string = \strip_tags($string);
         switch ($this->errorType) {
-            case self::UNKNOWN_TYPE:
+            case ErrorType::UNKNOWN:
                 break;
 
-            case self::NULLSY_TYPE:
+            case ErrorType::NULLSY:
                 $string = $this->removeString($string, ', or NULL if an error occurs');
                 $string = $this->removeString($string, ' and NULL on failure');
                 $string = $this->removeString($string, ' or NULL on failure');
                 break;
 
-            case self::FALSY_TYPE:
+            case ErrorType::FALSY:
                 $string = $this->removeString($string, 'or FALSE on failure');
                 $string = $this->removeString($string, ', FALSE on failure');
                 $string = $this->removeString($string, ', FALSE on errors');
@@ -189,7 +185,7 @@ class Method
                 $string = $this->removeString($string, ', FALSE if the pipe cannot be established');
                 break;
 
-            case self::EMPTY_TYPE:
+            case ErrorType::EMPTY:
                 $string = $this->removeString($string, ' or an empty string on error');
                 break;
 

--- a/generator/src/XmlDocParser/Scanner.php
+++ b/generator/src/XmlDocParser/Scanner.php
@@ -108,7 +108,7 @@ class Scanner
 
             $docPage = new DocPage($path->getPathname());
             $errorType = $docPage->getErrorType();
-            if ($errorType !== Method::UNKNOWN_TYPE) {
+            if ($errorType !== ErrorType::UNKNOWN) {
                 $functionObjects = $docPage->getMethodSynopsis();
                 if (count($functionObjects) > 1) {
                     $overloadedFunctions = array_merge($overloadedFunctions, \array_map(function ($functionObject) {

--- a/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Safe\PhpStanFunctions;
 
 use PHPUnit\Framework\TestCase;
-use Safe\XmlDocParser\Method;
+use Safe\XmlDocParser\ErrorType;
 
 class PhpStanTypeTest extends TestCase
 {
@@ -137,22 +137,22 @@ class PhpStanTypeTest extends TestCase
     {
         //bool => void if the method is falsy
         $param = new PhpStanType('bool');
-        $this->assertEquals('void', $param->getDocBlockType(Method::FALSY_TYPE));
-        $this->assertEquals('void', $param->getSignatureType(Method::FALSY_TYPE));
+        $this->assertEquals('void', $param->getDocBlockType(ErrorType::FALSY));
+        $this->assertEquals('void', $param->getSignatureType(ErrorType::FALSY));
 
         //int|false => int if the method is falsy
         $param = new PhpStanType('int|false');
-        $this->assertEquals('int', $param->getDocBlockType(Method::FALSY_TYPE));
-        $this->assertEquals('int', $param->getSignatureType(Method::FALSY_TYPE));
+        $this->assertEquals('int', $param->getDocBlockType(ErrorType::FALSY));
+        $this->assertEquals('int', $param->getSignatureType(ErrorType::FALSY));
 
         //int|null => int if the method is nullsy
         $param = new PhpStanType('int|null');
-        $this->assertEquals('int', $param->getDocBlockType(Method::NULLSY_TYPE));
-        $this->assertEquals('int', $param->getSignatureType(Method::NULLSY_TYPE));
+        $this->assertEquals('int', $param->getDocBlockType(ErrorType::NULLSY));
+        $this->assertEquals('int', $param->getSignatureType(ErrorType::NULLSY));
 
         $param = new PhpStanType('array|false|null');
-        $this->assertEquals('array|null', $param->getDocBlockType(Method::FALSY_TYPE));
-        $this->assertEquals('?array', $param->getSignatureType(Method::FALSY_TYPE));
+        $this->assertEquals('array|null', $param->getDocBlockType(ErrorType::FALSY));
+        $this->assertEquals('?array', $param->getSignatureType(ErrorType::FALSY));
     }
 
     public function testDuplicateType(): void
@@ -165,15 +165,15 @@ class PhpStanTypeTest extends TestCase
     public function testNullOrFalseBecomingNull(): void
     {
         $param = new PhpStanType('null|false');
-        $this->assertEquals('null', $param->getDocBlockType(Method::FALSY_TYPE));
-        $this->assertEquals('', $param->getSignatureType(Method::FALSY_TYPE));
+        $this->assertEquals('null', $param->getDocBlockType(ErrorType::FALSY));
+        $this->assertEquals('', $param->getSignatureType(ErrorType::FALSY));
     }
 
     public function testNotEmptyStringBecomingString(): void
     {
         $param = new PhpStanType('non-empty-string|false');
-        $this->assertEquals('non-empty-string', $param->getDocBlockType(Method::FALSY_TYPE));
-        $this->assertEquals('string', $param->getSignatureType(Method::FALSY_TYPE));
+        $this->assertEquals('non-empty-string', $param->getDocBlockType(ErrorType::FALSY));
+        $this->assertEquals('string', $param->getSignatureType(ErrorType::FALSY));
     }
 
     public function testPositiveIntBecomingInt(): void
@@ -186,8 +186,8 @@ class PhpStanTypeTest extends TestCase
     public function testListBecomingArray(): void
     {
         $param = new PhpStanType('list<string>|false');
-        $this->assertEquals('array<string>', $param->getDocBlockType(Method::FALSY_TYPE));
-        $this->assertEquals('array', $param->getSignatureType(Method::FALSY_TYPE));
+        $this->assertEquals('array<string>', $param->getDocBlockType(ErrorType::FALSY));
+        $this->assertEquals('array', $param->getSignatureType(ErrorType::FALSY));
     }
 
     public function testNumbersAreRemoved(): void
@@ -200,8 +200,8 @@ class PhpStanTypeTest extends TestCase
     public function testIgnoreBenevolence(): void
     {
         $param = new PhpStanType('__benevolent<string|false>');
-        $this->assertEquals('string', $param->getDocBlockType(Method::FALSY_TYPE));
-        $this->assertEquals('string', $param->getSignatureType(Method::FALSY_TYPE));
+        $this->assertEquals('string', $param->getDocBlockType(ErrorType::FALSY));
+        $this->assertEquals('string', $param->getSignatureType(ErrorType::FALSY));
     }
 
     public function testTypeFromXML(): void

--- a/generator/tests/XmlDocParser/MethodTest.php
+++ b/generator/tests/XmlDocParser/MethodTest.php
@@ -13,7 +13,7 @@ class MethodTest extends TestCase
     {
         $docPage = new DocPage(DocPage::findReferenceDir() . '/pcre/functions/preg-match.xml');
         $xmlObject = $docPage->getMethodSynopsis();
-        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), ErrorType::FALSY);
         $name = $method->getFunctionName();
         $this->assertEquals('preg_match', $name);
     }
@@ -22,7 +22,7 @@ class MethodTest extends TestCase
     {
         $docPage = new DocPage(DocPage::findReferenceDir() . '/pcre/functions/preg-match.xml');
         $xmlObject = $docPage->getMethodSynopsis();
-        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), ErrorType::FALSY);
         $type = $method->getSignatureReturnType();
         $this->assertEquals('int', $type);
     }
@@ -31,7 +31,7 @@ class MethodTest extends TestCase
     {
         $docPage = new DocPage(DocPage::findReferenceDir() . '/pcre/functions/preg-match.xml');
         $xmlObject = $docPage->getMethodSynopsis();
-        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), ErrorType::FALSY);
         $params = $method->getParams();
         $this->assertEquals('string', $params[0]->getSignatureType());
         $this->assertEquals('pattern', $params[0]->getParameterName());
@@ -41,7 +41,7 @@ class MethodTest extends TestCase
     {
         $docPage = new DocPage(DocPage::findReferenceDir() . '/strings/functions/sprintf.xml');
         $xmlObject = $docPage->getMethodSynopsis();
-        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), ErrorType::FALSY);
         $params = $method->getParams();
         $this->assertEquals('string', $params[0]->getDocBlockType());
         $this->assertEquals('string', $params[0]->getSignatureType());
@@ -51,7 +51,7 @@ class MethodTest extends TestCase
 
         $docPage = new DocPage(DocPage::findReferenceDir() . '/mbstring/functions/mb-ereg-replace-callback.xml');
         $xmlObject = $docPage->getMethodSynopsis();
-        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), ErrorType::FALSY);
         $params = $method->getParams();
         $this->assertEquals('string', $params[0]->getDocBlockType());
         $this->assertEquals('callable(array<int|string, string>):string', $params[1]->getDocBlockType());
@@ -61,7 +61,7 @@ class MethodTest extends TestCase
 
         $docPage = new DocPage(DocPage::findReferenceDir() . '/gmp/functions/gmp-export.xml');
         $xmlObject = $docPage->getMethodSynopsis();
-        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), ErrorType::FALSY);
         $params = $method->getParams();
         $this->assertEquals('\GMP|int|string', $params[0]->getDocBlockType());
         $this->assertEquals('', $params[0]->getSignatureType());
@@ -70,7 +70,7 @@ class MethodTest extends TestCase
 
         $docPage = new DocPage(DocPage::findReferenceDir() . '/hash/functions/hash-update.xml');
         $xmlObject = $docPage->getMethodSynopsis();
-        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), ErrorType::FALSY);
         $params = $method->getParams();
         $this->assertEquals('\HashContext', $params[0]->getDocBlockType());
         $this->assertEquals('\HashContext', $params[0]->getSignatureType());
@@ -80,7 +80,7 @@ class MethodTest extends TestCase
     {
         $docPage = new DocPage(DocPage::findReferenceDir() . '/imap/functions/imap-open.xml');
         $xmlObject = $docPage->getMethodSynopsis();
-        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), ErrorType::FALSY);
         $params = $method->getParams();
         $this->assertEquals('array', $params[5]->getDocBlockType());
         $this->assertEquals('array', $params[5]->getSignatureType());
@@ -90,7 +90,7 @@ class MethodTest extends TestCase
     {
         $docPage = new DocPage(DocPage::findReferenceDir() . '/apache/functions/apache-getenv.xml');
         $xmlObject = $docPage->getMethodSynopsis();
-        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), ErrorType::FALSY);
 
         $params = $method->getParams();
         $this->assertEquals('', $params[0]->getDefaultValue());
@@ -101,18 +101,18 @@ class MethodTest extends TestCase
     {
         $docPage = new DocPage(DocPage::findReferenceDir() . '/array/functions/array-replace.xml');
         $xmlObject = $docPage->getMethodSynopsis();
-        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::NULLSY_TYPE);
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), ErrorType::NULLSY);
         $this->assertEquals("@return array Returns an array.\n", $method->getReturnDocBlock());
 
         $docPage = new DocPage(DocPage::findReferenceDir() . '/shmop/functions/shmop-delete.xml');
         $xmlObject = $docPage->getMethodSynopsis();
-        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), ErrorType::FALSY);
         $this->assertEquals('', $method->getReturnDocBlock());
         $this->assertEquals('void', $method->getSignatureReturnType());
 
         $docPage = new DocPage(DocPage::findReferenceDir() . '/sqlsrv/functions/sqlsrv-next-result.xml');
         $xmlObject = $docPage->getMethodSynopsis();
-        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), ErrorType::FALSY);
         $this->assertEquals("@return bool|null Returns TRUE if the next result was successfully retrieved, FALSE if an error \n   occurred, and NULL if there are no more results to retrieve.\n", $method->getReturnDocBlock());
         $this->assertEquals('?bool', $method->getSignatureReturnType());
     }
@@ -121,7 +121,7 @@ class MethodTest extends TestCase
     {
         $docPage = new DocPage(DocPage::findReferenceDir() . '/openssl/functions/openssl-cipher-key-length.xml');
         $xmlObject = $docPage->getMethodSynopsis();
-        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), Method::FALSY_TYPE);
+        $method = new Method($xmlObject[0], $docPage->loadAndResolveFile(), $docPage->getModule(), new PhpStanFunctionMapReader(), ErrorType::FALSY);
         $this->assertEquals("@return int Returns the cipher length on success.\n", $method->getReturnDocBlock());
     }
 }


### PR DESCRIPTION

Enums have been supported since php 8.1, we don't need to be passing primitives around any more \o/
