### PR TITLE
Drop dependency on thecodingmachine/phpstan-strict-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,6 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^1",
-        "thecodingmachine/phpstan-strict-rules": "^1.0",
         "squizlabs/php_codesniffer": "^3.2",
         "phpunit/phpunit": "^10",
         "php-parallel-lint/php-parallel-lint": "^1.4"

--- a/generator/composer.json
+++ b/generator/composer.json
@@ -18,7 +18,6 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^12",
-    "thecodingmachine/phpstan-strict-rules": "^1.0",
     "squizlabs/php_codesniffer": "^3.2",
     "php-coveralls/php-coveralls": "^2.1",
     "php-parallel-lint/php-parallel-lint": "^1.4"

--- a/generator/composer.lock
+++ b/generator/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c89649abb189f4fdc34a252e3b05e0d",
+    "content-hash": "44aff98f8f128d2d44649cb48ba083f9",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -3494,61 +3494,6 @@
                 }
             ],
             "time": "2025-01-07T12:55:42+00:00"
-        },
-        {
-            "name": "thecodingmachine/phpstan-strict-rules",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thecodingmachine/phpstan-strict-rules.git",
-                "reference": "2ba8fa8b328c45f3b149c05def5bf96793c594b6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thecodingmachine/phpstan-strict-rules/zipball/2ba8fa8b328c45f3b149c05def5bf96793c594b6",
-                "reference": "2ba8fa8b328c45f3b149c05def5bf96793c594b6",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1|^8.0",
-                "phpstan/phpstan": "^1.0"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^7.1"
-            },
-            "type": "phpstan-extension",
-            "extra": {
-                "phpstan": {
-                    "includes": [
-                        "phpstan-strict-rules.neon"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "TheCodingMachine\\PHPStan\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "David Négrier",
-                    "email": "d.negrier@thecodingmachine.com"
-                }
-            ],
-            "description": "A set of additional rules for PHPStan based on best practices followed at TheCodingMachine",
-            "support": {
-                "issues": "https://github.com/thecodingmachine/phpstan-strict-rules/issues",
-                "source": "https://github.com/thecodingmachine/phpstan-strict-rules/tree/v1.0.0"
-            },
-            "time": "2021-11-08T09:10:49+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/generator/phpstan.neon
+++ b/generator/phpstan.neon
@@ -1,5 +1,7 @@
 includes:
-    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+    # TODO: re-enable these rules once they are compatible with modern phpstan
+	# https://github.com/thecodingmachine/phpstan-strict-rules/issues/66
+    # - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
     - phar://phpstan.phar/conf/bleedingEdge.neon
 
 parameters:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,7 @@
 includes:
-    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+    # TODO: re-enable these rules once they are compatible with modern phpstan
+	# https://github.com/thecodingmachine/phpstan-strict-rules/issues/66
+    # - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
     - phar://phpstan.phar/conf/bleedingEdge.neon
 
 parameters:


### PR DESCRIPTION

These are unmaintained and block us from upgrading phpstan
