### PR TITLE
`finfo`, despite being lowercase, is a class

### DIFF
--- a/generated/8.1/fileinfo.php
+++ b/generated/8.1/fileinfo.php
@@ -7,11 +7,11 @@ use Safe\Exceptions\FileinfoException;
 /**
  * This function closes the instance opened by finfo_open.
  *
- * @param finfo $finfo An finfo instance, returned by finfo_open.
+ * @param \finfo $finfo An finfo instance, returned by finfo_open.
  * @throws FileinfoException
  *
  */
-function finfo_close(finfo $finfo): void
+function finfo_close(\finfo $finfo): void
 {
     error_clear_last();
     $safeResult = \finfo_close($finfo);
@@ -38,12 +38,12 @@ function finfo_close(finfo $finfo): void
  *
  * Passing NULL or an empty string will be equivalent to the default
  * value.
- * @return finfo (Procedural style only)
+ * @return \finfo (Procedural style only)
  * Returns an finfo instance on success.
  * @throws FileinfoException
  *
  */
-function finfo_open(int $flags = FILEINFO_NONE, ?string $magic_database = null): finfo
+function finfo_open(int $flags = FILEINFO_NONE, ?string $magic_database = null): \finfo
 {
     error_clear_last();
     if ($magic_database !== null) {

--- a/generated/8.2/fileinfo.php
+++ b/generated/8.2/fileinfo.php
@@ -7,11 +7,11 @@ use Safe\Exceptions\FileinfoException;
 /**
  * This function closes the instance opened by finfo_open.
  *
- * @param finfo $finfo An finfo instance, returned by finfo_open.
+ * @param \finfo $finfo An finfo instance, returned by finfo_open.
  * @throws FileinfoException
  *
  */
-function finfo_close(finfo $finfo): void
+function finfo_close(\finfo $finfo): void
 {
     error_clear_last();
     $safeResult = \finfo_close($finfo);
@@ -38,12 +38,12 @@ function finfo_close(finfo $finfo): void
  *
  * Passing NULL or an empty string will be equivalent to the default
  * value.
- * @return finfo (Procedural style only)
+ * @return \finfo (Procedural style only)
  * Returns an finfo instance on success.
  * @throws FileinfoException
  *
  */
-function finfo_open(int $flags = FILEINFO_NONE, ?string $magic_database = null): finfo
+function finfo_open(int $flags = FILEINFO_NONE, ?string $magic_database = null): \finfo
 {
     error_clear_last();
     if ($magic_database !== null) {

--- a/generated/8.3/fileinfo.php
+++ b/generated/8.3/fileinfo.php
@@ -7,11 +7,11 @@ use Safe\Exceptions\FileinfoException;
 /**
  * This function closes the instance opened by finfo_open.
  *
- * @param finfo $finfo An finfo instance, returned by finfo_open.
+ * @param \finfo $finfo An finfo instance, returned by finfo_open.
  * @throws FileinfoException
  *
  */
-function finfo_close(finfo $finfo): void
+function finfo_close(\finfo $finfo): void
 {
     error_clear_last();
     $safeResult = \finfo_close($finfo);
@@ -38,12 +38,12 @@ function finfo_close(finfo $finfo): void
  *
  * Passing NULL or an empty string will be equivalent to the default
  * value.
- * @return finfo (Procedural style only)
+ * @return \finfo (Procedural style only)
  * Returns an finfo instance on success.
  * @throws FileinfoException
  *
  */
-function finfo_open(int $flags = FILEINFO_NONE, ?string $magic_database = null): finfo
+function finfo_open(int $flags = FILEINFO_NONE, ?string $magic_database = null): \finfo
 {
     error_clear_last();
     if ($magic_database !== null) {

--- a/generated/8.4/fileinfo.php
+++ b/generated/8.4/fileinfo.php
@@ -7,11 +7,11 @@ use Safe\Exceptions\FileinfoException;
 /**
  * This function closes the instance opened by finfo_open.
  *
- * @param finfo $finfo An finfo instance, returned by finfo_open.
+ * @param \finfo $finfo An finfo instance, returned by finfo_open.
  * @throws FileinfoException
  *
  */
-function finfo_close(finfo $finfo): void
+function finfo_close(\finfo $finfo): void
 {
     error_clear_last();
     $safeResult = \finfo_close($finfo);
@@ -38,12 +38,12 @@ function finfo_close(finfo $finfo): void
  *
  * Passing NULL or an empty string will be equivalent to the default
  * value.
- * @return finfo (Procedural style only)
+ * @return \finfo (Procedural style only)
  * Returns an finfo instance on success.
  * @throws FileinfoException
  *
  */
-function finfo_open(int $flags = FILEINFO_NONE, ?string $magic_database = null): finfo
+function finfo_open(int $flags = FILEINFO_NONE, ?string $magic_database = null): \finfo
 {
     error_clear_last();
     if ($magic_database !== null) {

--- a/generated/8.5/fileinfo.php
+++ b/generated/8.5/fileinfo.php
@@ -7,11 +7,11 @@ use Safe\Exceptions\FileinfoException;
 /**
  * This function closes the instance opened by finfo_open.
  *
- * @param finfo $finfo An finfo instance, returned by finfo_open.
+ * @param \finfo $finfo An finfo instance, returned by finfo_open.
  * @throws FileinfoException
  *
  */
-function finfo_close(finfo $finfo): void
+function finfo_close(\finfo $finfo): void
 {
     error_clear_last();
     $safeResult = \finfo_close($finfo);
@@ -38,12 +38,12 @@ function finfo_close(finfo $finfo): void
  *
  * Passing NULL or an empty string will be equivalent to the default
  * value.
- * @return finfo (Procedural style only)
+ * @return \finfo (Procedural style only)
  * Returns an finfo instance on success.
  * @throws FileinfoException
  *
  */
-function finfo_open(int $flags = FILEINFO_NONE, ?string $magic_database = null): finfo
+function finfo_open(int $flags = FILEINFO_NONE, ?string $magic_database = null): \finfo
 {
     error_clear_last();
     if ($magic_database !== null) {

--- a/generator/src/XmlDocParser/Type.php
+++ b/generator/src/XmlDocParser/Type.php
@@ -14,9 +14,12 @@ class Type
         if ($type === '') {
             return false;
         }
-        if ($type === 'stdClass') {
+
+        // Non-standard lowercase classes
+        if (in_array($type, ['stdClass', 'finfo'])) {
             return true;
         }
+
         // Classes start with uppercase letters. Otherwise, it's most likely a scalar.
         if ($type[0] === strtoupper($type[0])) {
             return true;


### PR DESCRIPTION

grepping for "all the return typehints in `generated/`", it appears that this and `stdClass` are the only lowercase classes:

```
sl grep '^function' | cut -d: -f3 | sort | uniq
```
