### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/.devcontainer export-ignore
 /.gitattributes export-ignore
 /.github export-ignore
 /.gitignore export-ignore


### PR DESCRIPTION
## Summary
Don't export `.devcontainer`, it's not needed for composer based installation
![image](https://github.com/user-attachments/assets/89b98b5b-0cac-4676-9f76-024ce4e2d0c3)