### PR TITLE
Make _all_ return types alphabetical

### DIFF
--- a/generated/8.1/dir.php
+++ b/generated/8.1/dir.php
@@ -53,7 +53,7 @@ function chroot(string $directory): void
  * given directory is opened.
  *
  * @param string $directory Directory to open
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return \Directory Returns an instance of Directory, or FALSE in case of error.
  * @throws DirException
@@ -104,7 +104,7 @@ function getcwd(): string
  * rewinddir calls.
  *
  * @param string $directory The directory path that is to be opened
- * @param resource|null $context For a description of the context parameter,
+ * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return resource Returns a directory handle resource on success
@@ -136,7 +136,7 @@ function opendir(string $directory, $context = null)
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
  * SCANDIR_SORT_NONE then the result is unsorted.
- * @param resource|null $context For a description of the context parameter,
+ * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return array Returns an array of filenames on success. If directory is not a directory, then

--- a/generated/8.1/exec.php
+++ b/generated/8.1/exec.php
@@ -140,9 +140,9 @@ function proc_nice(int $priority): void
  * passing passphrases to programs like PGP, GPG and openssl in a more
  * secure manner. It is also useful for reading status information
  * provided by those programs on auxiliary file descriptors.
- * @param resource[]|null $pipes Will be set to an indexed array of file pointers that correspond to
+ * @param null|resource[] $pipes Will be set to an indexed array of file pointers that correspond to
  * PHP's end of any pipes that are created.
- * @param string|null $cwd The initial working dir for the command. This must be an
+ * @param null|string $cwd The initial working dir for the command. This must be an
  * absolute directory path, or NULL
  * if you want to use the default value (the working dir of the current
  * PHP process)
@@ -201,7 +201,7 @@ function proc_open(string $cmd, array $descriptorspec, ?array &$pipes, ?string $
  * This function is identical to the backtick operator.
  *
  * @param string $command The command that will be executed.
- * @return string|null A string containing the output from the executed command or NULL if an error occurs or the command produces no output.
+ * @return null|string A string containing the output from the executed command or NULL if an error occurs or the command produces no output.
  * @throws ExecException
  *
  */

--- a/generated/8.1/filesystem.php
+++ b/generated/8.1/filesystem.php
@@ -244,7 +244,7 @@ function fflush($stream): void
  * This is not possible if strict typing
  * is enabled, since FILE_USE_INCLUDE_PATH is an
  * int. Use TRUE instead.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create. If you don't need to use a
  * custom context, you can skip this parameter by NULL.
  * @param int $offset The offset where the reading starts on the original stream.
@@ -347,7 +347,7 @@ function file_get_contents(string $filename, bool $use_include_path = false, $co
  *
  *
  *
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create.
  * @return int This function returns the number of bytes that were written to the file.
  * @throws FilesystemException
@@ -852,7 +852,7 @@ function flock($stream, int $operation, ?int &$would_block = null): void
  * @param bool $use_include_path The optional third use_include_path parameter
  * can be set to '1' or TRUE if you want to search for the file in the
  * include_path, too.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return resource Returns a file pointer resource on success
  * @throws FilesystemException

--- a/generated/8.1/ftp.php
+++ b/generated/8.1/ftp.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\FtpException;
  *
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param int $size The number of bytes to allocate.
- * @param string|null $response A textual representation of the servers response will be returned by
+ * @param null|string $response A textual representation of the servers response will be returned by
  * reference in response if a variable is provided.
  * @throws FtpException
  *

--- a/generated/8.1/image.php
+++ b/generated/8.1/image.php
@@ -267,7 +267,7 @@ function imagearc(\GdImage $image, int $center_x, int $center_y, int $width, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst quality, smaller file)
  * to 100 (best quality, larger file).
  * If -1 is provided, the default value 30 is used.
@@ -300,7 +300,7 @@ function imageavif(\GdImage $image, $file = null, int $quality = -1, int $speed 
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  *
  * NULL is invalid if the compressed arguments is
  * not used.
@@ -1740,7 +1740,7 @@ function imagegammacorrect(\GdImage $image, float $input_gamma, float $output_ga
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
@@ -1763,7 +1763,7 @@ function imagegd(\GdImage $image, $file = null): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $chunk_size Chunk size.
  * @param int $mode Either IMG_GD2_RAW or
  * IMG_GD2_COMPRESSED. Default is
@@ -1803,7 +1803,7 @@ function imagegd2(\GdImage $image, $file = null, int $chunk_size = 128, int $mod
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
@@ -1865,7 +1865,7 @@ function imagegrabwindow(int $handle, bool $client_area = false): \GdImage
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst
  * quality, smaller file) to 100 (best quality, biggest file). The
  * default (-1) uses the default IJG quality value (about 75).
@@ -2049,7 +2049,7 @@ function imageloadfont(string $filename): int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  *
  * NULL is invalid if the quality and
  * filters arguments are not used.
@@ -2804,7 +2804,7 @@ function imagettftext(\GdImage $image, float $size, float $angle, int $x, int $y
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black.
@@ -2832,7 +2832,7 @@ function imagewbmp(\GdImage $image, $file = null, ?int $foreground_color = null)
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality ranges from 0 (worst
  * quality, smaller file) to 100 (best quality, biggest file).
  * @throws ImageException
@@ -2860,7 +2860,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
+ * @param null|resource|string $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
  *
  * The filename (without the .xbm extension) is also
  * used for the C identifiers of the XBM, whereby non

--- a/generated/8.1/imap.php
+++ b/generated/8.1/imap.php
@@ -1856,10 +1856,10 @@ function imap_renamemailbox(\IMAP\Connection $imap, string $from, string $to): v
 /**
  * Returns a properly formatted email address as defined in RFC2822 given the needed information.
  *
- * @param string|null $mailbox The mailbox name, see imap_open for more
+ * @param null|string $mailbox The mailbox name, see imap_open for more
  * information
- * @param string|null $hostname The email host part
- * @param string|null $personal The name of the account owner
+ * @param null|string $hostname The email host part
+ * @param null|string $personal The name of the account owner
  * @return string Returns a string properly formatted email address as defined in RFC2822.
  * @throws ImapException
  *

--- a/generated/8.1/ldap.php
+++ b/generated/8.1/ldap.php
@@ -65,8 +65,8 @@ function ldap_add(\LDAP\Connection $ldap, string $dn, array $entry, ?array $cont
  * Binds to the LDAP directory with specified RDN and password.
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
- * @param string|null $dn
- * @param string|null $password
+ * @param null|string $dn
+ * @param null|string $password
  * @throws LdapException
  *
  */
@@ -120,7 +120,7 @@ function ldap_compare(\LDAP\Connection $ldap, string $dn, string $attribute, str
  *
  * @param resource $link An LDAP resource, returned by ldap_connect.
  * @param resource $result
- * @param string|null $cookie An opaque structure sent by the server.
+ * @param null|string $cookie An opaque structure sent by the server.
  * @param int|null $estimated The estimated number of entries to retrieve.
  * @throws LdapException
  *
@@ -276,10 +276,10 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  * @param string $reqoid The extended operation request OID. You may use one of LDAP_EXOP_START_TLS, LDAP_EXOP_MODIFY_PASSWD, LDAP_EXOP_REFRESH, LDAP_EXOP_WHO_AM_I, LDAP_EXOP_TURN, or a string with the OID of the operation you want to send.
  * @param string $reqdata The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
  * @param array|null $serverctrls Array of LDAP Controls to send with the request.
- * @param string|null $retdata Will be filled with the extended operation response data if provided.
+ * @param null|string $retdata Will be filled with the extended operation response data if provided.
  * If not provided you may use ldap_parse_exop on the result object
  * later to get this data.
- * @param string|null $retoid Will be filled with the response OID if provided, usually equal to the request OID.
+ * @param null|string $retoid Will be filled with the response OID if provided, usually equal to the request OID.
  * @return bool|resource When used with retdata, returns TRUE on success.
  * When used without retdata, returns a result identifier.
  * @throws LdapException
@@ -960,8 +960,8 @@ function ldap_next_attribute(\LDAP\Connection $ldap, \LDAP\ResultEntry $entry): 
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param \LDAP\Result $result An LDAP\Result instance, returned by ldap_list or ldap_search.
- * @param string|null $response_data Will be filled by the response data.
- * @param string|null $response_oid Will be filled by the response OID.
+ * @param null|string $response_data Will be filled by the response data.
+ * @param null|string $response_oid Will be filled by the response OID.
  * @throws LdapException
  *
  */
@@ -982,9 +982,9 @@ function ldap_parse_exop(\LDAP\Connection $ldap, \LDAP\Result $result, ?string &
  * @param \LDAP\Result $result An LDAP\Result instance, returned by ldap_list or ldap_search.
  * @param int|null $error_code A reference to a variable that will be set to the LDAP error code in
  * the result, or 0 if no error occurred.
- * @param string|null $matched_dn A reference to a variable that will be set to a matched DN if one was
+ * @param null|string $matched_dn A reference to a variable that will be set to a matched DN if one was
  * recognised within the request, otherwise it will be set to NULL.
- * @param string|null $error_message A reference to a variable that will be set to the LDAP error message in
+ * @param null|string $error_message A reference to a variable that will be set to the LDAP error message in
  * the result, or an empty string if no error occurred.
  * @param array|null $referrals A reference to a variable that will be set to an array set
  * to all of the referral strings in the result, or an empty array if no
@@ -1073,7 +1073,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
 /**
  * Sets the value of the specified option to be value.
  *
- * @param resource|null $ldap An LDAP\Connection instance, returned by ldap_connect.
+ * @param null|resource $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param int $option The parameter option can be one of:
  *
  *

--- a/generated/8.1/mbstring.php
+++ b/generated/8.1/mbstring.php
@@ -161,7 +161,7 @@ function mb_encoding_aliases(string $encoding): array
  * not used anywhere else.
  * @param string $string The string being checked.
  * @param string $options The search option. See mb_regex_set_options for explanation.
- * @return string|null The resultant string on success.
+ * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
  * @throws MbstringException
@@ -191,7 +191,7 @@ function mb_ereg_replace_callback(string $pattern, callable $callback, string $s
  * @param string $replacement The replacement text.
  * @param string $string The string being checked.
  * @param string $options
- * @return string|null The resultant string on success.
+ * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
  * @throws MbstringException
@@ -520,7 +520,7 @@ function mb_regex_encoding(?string $encoding = null)
  * This parameter is not automatically encoded.
  * @param string $subject The subject of the mail.
  * @param string $message The message of the mail.
- * @param array|string|null $additional_headers String or array to be inserted at the end of the email header.
+ * @param array|null|string $additional_headers String or array to be inserted at the end of the email header.
  *
  * This is typically used to add extra headers (From, Cc, and Bcc).
  * Multiple extra headers should be separated with a CRLF (\r\n).

--- a/generated/8.1/network.php
+++ b/generated/8.1/network.php
@@ -289,7 +289,7 @@ function dns_get_record(string $hostname, int $type = DNS_ANY, ?array &$authorit
  * indication that the error occurred before the
  * connect() call. This is most likely due to a
  * problem initializing the socket.
- * @param string|null $error_message The error message as a string.
+ * @param null|string $error_message The error message as a string.
  * @param float $timeout The connection timeout, in seconds. When NULL, the
  * default_socket_timeout php.ini setting is used.
  *
@@ -642,7 +642,7 @@ function openlog(string $prefix, int $flags, int $facility): void
  * @param string $hostname
  * @param int $port
  * @param int|null $error_code
- * @param string|null $error_message
+ * @param null|string $error_message
  * @param float $timeout
  * @return resource pfsockopen returns a file pointer which may be used
  * together with the other file functions (such as

--- a/generated/8.1/openssl.php
+++ b/generated/8.1/openssl.php
@@ -29,7 +29,7 @@ function openssl_cipher_iv_length(string $cipher_algo): int
  * @param string $input_filename The name of a file containing encrypted content.
  * @param string $output_filename The name of the file to deposit the decrypted content.
  * @param \OpenSSLCertificate|string $certificate The name of the file containing a certificate of the recipient.
- * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key The name of the file containing a PKCS#8 key.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|null|string $private_key The name of the file containing a PKCS#8 key.
  * @param int $encoding The encoding of the input file. One of OPENSSL_CMS_SMIME,
  * OPENSLL_CMS_DER or OPENSSL_CMS_PEM.
  * @throws OpensslException
@@ -107,7 +107,7 @@ function openssl_cms_read(string $input_filename, array &$certificates): void
  * @param int $flags Flags to be passed to cms_sign.
  * @param int $encoding The encoding of the output file. One of OPENSSL_CMS_SMIME,
  * OPENSLL_CMS_DER or OPENSSL_CMS_PEM.
- * @param string|null $untrusted_certificates_filename Intermediate certificates to be included in the signature.
+ * @param null|string $untrusted_certificates_filename Intermediate certificates to be included in the signature.
  * @throws OpensslException
  *
  */
@@ -130,12 +130,12 @@ function openssl_cms_sign(string $input_filename, string $output_filename, $cert
  *
  * @param string $input_filename The input file.
  * @param int $flags Flags to pass to cms_verify.
- * @param string|null $certificates A file with the signer certificate and optionally intermediate certificates.
+ * @param null|string $certificates A file with the signer certificate and optionally intermediate certificates.
  * @param array $ca_info An array containing self-signed certificate authority certificates.
- * @param string|null $untrusted_certificates_filename A file containing additional intermediate certificates.
- * @param string|null $content A file pointing to the content when signatures are detached.
- * @param string|null $pk7
- * @param string|null $sigfile A file to save the signature to.
+ * @param null|string $untrusted_certificates_filename A file containing additional intermediate certificates.
+ * @param null|string $content A file pointing to the content when signatures are detached.
+ * @param null|string $pk7
+ * @param null|string $sigfile A file to save the signature to.
  * @param int $encoding The encoding of the input file. One of OPENSSL_CMS_SMIME,
  * OPENSLL_CMS_DER or OPENSSL_CMS_PEM.
  * @throws OpensslException
@@ -199,7 +199,7 @@ function openssl_csr_export_to_file($csr, string $output_filename, bool $no_text
  * reference.
  *
  * @param \OpenSSLCertificateSigningRequest|string $csr See CSR parameters for a list of valid values.
- * @param string|null $output on success, this string will contain the PEM encoded CSR
+ * @param null|string $output on success, this string will contain the PEM encoded CSR
  * @param bool $no_text
  * The optional parameter notext affects
  * the verbosity of the output; if it is FALSE, then additional human-readable
@@ -398,7 +398,7 @@ function openssl_csr_new(array $distinguished_names, \OpenSSLAsymmetricKey &$pri
  * It can also be the path to a PEM encoded CSR when specified as
  * file://path/to/csr or an exported string generated
  * by openssl_csr_export.
- * @param \OpenSSLCertificate|string|null $ca_certificate The generated certificate will be signed by ca_certificate.
+ * @param \OpenSSLCertificate|null|string $ca_certificate The generated certificate will be signed by ca_certificate.
  * If ca_certificate is NULL, the generated certificate
  * will be a self-signed certificate.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key is the private key that corresponds to
@@ -577,7 +577,7 @@ function openssl_get_curve_names(): array
  * openssl_seal for more information.
  *
  * @param string $data
- * @param string|null $output If the call is successful the opened data is returned in this
+ * @param null|string $output If the call is successful the opened data is returned in this
  * parameter.
  * @param string $encrypted_key
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key
@@ -681,7 +681,7 @@ function openssl_pkcs12_export_to_file($certificate, string $output_filename, $p
  * output in a PKCS#12 file format.
  *
  * @param \OpenSSLCertificate|string $certificate See Key/Certificate parameters for a list of valid values.
- * @param string|null $output On success, this will hold the PKCS#12.
+ * @param null|string $output On success, this will hold the PKCS#12.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key Private key component of PKCS#12 file.
  * See Public/Private Key parameters for a list of valid values.
  * @param string $passphrase Encryption password for unlocking the PKCS#12 file.
@@ -750,7 +750,7 @@ function openssl_pkcs12_read(string $pkcs12, ?array &$certificates, string $pass
  * @param string $output_filename The decrypted message is written to the file specified by
  * output_filename.
  * @param \OpenSSLCertificate|string $certificate
- * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|null|string $private_key
  * @throws OpensslException
  *
  */
@@ -887,7 +887,7 @@ function openssl_pkey_derive($public_key, $private_key, int $key_length = 0): st
  *
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param string $output_filename Path to the output file.
- * @param string|null $passphrase The key can be optionally protected by a
+ * @param null|string $passphrase The key can be optionally protected by a
  * passphrase.
  * @param array $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
@@ -918,8 +918,8 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * output (which is passed by reference).
  *
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
- * @param string|null $output
- * @param string|null $passphrase The key is optionally protected by passphrase.
+ * @param null|string $output
+ * @param null|string $passphrase The key is optionally protected by passphrase.
  * @param array $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file.  See openssl_csr_new for more
@@ -956,7 +956,7 @@ function openssl_pkey_export($key, ?string &$output, ?string $passphrase = null,
  *
  * A PEM formatted private key.
  *
- * @param string|null $passphrase The optional parameter passphrase must be used
+ * @param null|string $passphrase The optional parameter passphrase must be used
  * if the specified key is encrypted (protected by a passphrase).
  * @return \OpenSSLAsymmetricKey Returns an OpenSSLAsymmetricKey instance on success.
  * @throws OpensslException
@@ -1044,7 +1044,7 @@ function openssl_pkey_new(?array $options = null): \OpenSSLAsymmetricKey
  * You can use this function e.g. to decrypt data which is supposed to only be available to you.
  *
  * @param string $data
- * @param string|null $decrypted_data
+ * @param null|string $decrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key must be the private key corresponding that
  * was used to encrypt the data.
  * @param int $padding padding can be one of
@@ -1075,7 +1075,7 @@ function openssl_private_decrypt(string $data, ?string &$decrypted_data, $privat
  * is not written by someone else.
  *
  * @param string $data
- * @param string|null $encrypted_data
+ * @param null|string $encrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key
  * @param int $padding padding can be one of
  * OPENSSL_PKCS1_PADDING,
@@ -1103,7 +1103,7 @@ function openssl_private_encrypt(string $data, ?string &$encrypted_data, $privat
  * owner of the private key.
  *
  * @param string $data
- * @param string|null $decrypted_data
+ * @param null|string $decrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key public_key must be the public key corresponding that
  * was used to encrypt the data.
  * @param int $padding padding can be one of
@@ -1133,7 +1133,7 @@ function openssl_public_decrypt(string $data, ?string &$decrypted_data, $public_
  * in database.
  *
  * @param string $data
- * @param string|null $encrypted_data This will hold the result of the encryption.
+ * @param null|string $encrypted_data This will hold the result of the encryption.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key The public key.
  * @param int $padding padding can be one of
  * OPENSSL_PKCS1_PADDING,
@@ -1193,7 +1193,7 @@ function openssl_random_pseudo_bytes(int $length, ?bool &$strong_result = null):
  * the envelope key that was encrypted with the recipient's public key.
  *
  * @param string $data The data to seal.
- * @param string|null $sealed_data The sealed data.
+ * @param null|string $sealed_data The sealed data.
  * @param array|null $encrypted_keys Array of encrypted keys.
  * @param array $public_key Array of OpenSSLAsymmetricKey instances containing public keys.
  * @param string $cipher_algo The cipher method.
@@ -1203,7 +1203,7 @@ function openssl_random_pseudo_bytes(int $length, ?bool &$strong_result = null):
  * It is strongly recommended to explicitly specify a secure cipher method.
  *
  *
- * @param string|null $iv The initialization vector.
+ * @param null|string $iv The initialization vector.
  * @return int Returns the length of the sealed data on success.
  * If successful the sealed data is returned in
  * sealed_data, and the envelope keys in
@@ -1230,7 +1230,7 @@ function openssl_seal(string $data, ?string &$sealed_data, ?array &$encrypted_ke
  * not encrypted.
  *
  * @param string $data The string of data you wish to sign
- * @param string|null $signature If the call was successful the signature is returned in
+ * @param null|string $signature If the call was successful the signature is returned in
  * signature.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key OpenSSLAsymmetricKey - a key, returned by openssl_get_privatekey
  *
@@ -1255,7 +1255,7 @@ function openssl_sign(string $data, ?string &$signature, $private_key, $algorith
  * Exports challenge from encoded signed public key and challenge
  *
  * @param string $spki Expects a valid signed public key and challenge
- * @return string|null Returns the associated challenge string.
+ * @return null|string Returns the associated challenge string.
  * @throws OpensslException
  *
  */
@@ -1274,7 +1274,7 @@ function openssl_spki_export_challenge(string $spki): ?string
  * Exports PEM formatted public key from encoded signed public key and challenge
  *
  * @param string $spki Expects a valid signed public key and challenge
- * @return string|null Returns the associated PEM formatted public key.
+ * @return null|string Returns the associated PEM formatted public key.
  * @throws OpensslException
  *
  */
@@ -1299,7 +1299,7 @@ function openssl_spki_export(string $spki): ?string
  * CSR.
  * @param string $challenge The challenge associated to associate with the SPKAC
  * @param int $digest_algo The digest algorithm. See openssl_get_md_method().
- * @return string|null Returns a signed public key and challenge string.
+ * @return null|string Returns a signed public key and challenge string.
  * @throws OpensslException
  *
  */
@@ -1470,7 +1470,7 @@ function openssl_x509_export_to_file($certificate, string $output_filename, bool
  * output in a PEM encoded format.
  *
  * @param \OpenSSLCertificate|string $certificate See Key/Certificate parameters for a list of valid values.
- * @param string|null $output On success, this will hold the PEM.
+ * @param null|string $output On success, this will hold the PEM.
  * @param bool $no_text
  * The optional parameter notext affects
  * the verbosity of the output; if it is FALSE, then additional human-readable

--- a/generated/8.1/outcontrol.php
+++ b/generated/8.1/outcontrol.php
@@ -151,7 +151,7 @@ function ob_get_clean(): string
  * If output buffering is still active when the script ends, PHP outputs the
  * contents automatically.
  *
- * @param array|callable|string|null $callback An optional callback function may be
+ * @param array|callable|null|string $callback An optional callback function may be
  * specified. This function takes a string as a parameter and should
  * return a string. The function will be called when
  * the output buffer is flushed (sent) or cleaned (with

--- a/generated/8.1/pcre.php
+++ b/generated/8.1/pcre.php
@@ -390,7 +390,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  *
  * @param string $pattern The pattern to search for, as a string.
  * @param string $subject The input string.
- * @param string[]|null $matches If matches is provided, then it is filled with
+ * @param null|string[] $matches If matches is provided, then it is filled with
  * the results of search. $matches[0] will contain the
  * text that matched the full pattern, $matches[1]
  * will have the text that matched the first captured parenthesized

--- a/generated/8.1/pgsql.php
+++ b/generated/8.1/pgsql.php
@@ -1190,7 +1190,7 @@ function pg_query(?\PgSql\Connection $connection = null, ?string $query = null):
  * PGSQL_DIAG_CONTEXT, PGSQL_DIAG_SOURCE_FILE,
  * PGSQL_DIAG_SOURCE_LINE or
  * PGSQL_DIAG_SOURCE_FUNCTION.
- * @return string|null A string containing the contents of the error field, NULL if the field does not exist.
+ * @return null|string A string containing the contents of the error field, NULL if the field does not exist.
  * @throws PgsqlException
  *
  */

--- a/generated/8.1/sockets.php
+++ b/generated/8.1/sockets.php
@@ -355,7 +355,7 @@ function socket_get_option(\Socket $socket, int $level, int $option)
  *
  * @param \Socket $socket A Socket instance created with socket_create
  * or socket_accept.
- * @param string|null $address If the given socket is of type AF_INET or
+ * @param null|string $address If the given socket is of type AF_INET or
  * AF_INET6, socket_getpeername
  * will return the peers (remote) IP address in
  * appropriate notation (e.g. 127.0.0.1 or
@@ -387,7 +387,7 @@ function socket_getpeername(\Socket $socket, ?string &$address, ?int &$port = nu
  *
  * @param \Socket $socket A Socket instance created with socket_create
  * or socket_accept.
- * @param string|null $address If the given socket is of type AF_INET
+ * @param null|string $address If the given socket is of type AF_INET
  * or AF_INET6, socket_getsockname
  * will return the local IP address in appropriate notation (e.g.
  * 127.0.0.1 or fe80::1) in the

--- a/generated/8.1/sqlsrv.php
+++ b/generated/8.1/sqlsrv.php
@@ -283,7 +283,7 @@ function sqlsrv_fetch_array($stmt, ?int $fetchType = null, ?int $row = null, ?in
  * SQLSRV_SCROLL_ABSOLUTE or
  * SQLSRV_SCROLL_RELATIVE. Note that the first row in
  * a result set has index 0.
- * @return object|null Returns an object on success, NULL if there are no more rows to return,
+ * @return null|object Returns an object on success, NULL if there are no more rows to return,
  * and FALSE if an error occurs or if the specified class does not exist.
  * @throws SqlsrvException
  *

--- a/generated/8.1/stream.php
+++ b/generated/8.1/stream.php
@@ -362,7 +362,7 @@ function stream_set_timeout($stream, int $seconds, int $microseconds = 0): void
  * @param resource $server_socket The server socket to accept a connection from.
  * @param float $timeout Override the default socket accept timeout. Time should be given in
  * seconds.
- * @param string|null $peername Will be set to the name (address) of the client which connected, if
+ * @param null|string $peername Will be set to the name (address) of the client which connected, if
  * included and available from the selected transport.
  *
  * Can also be determined later using
@@ -401,7 +401,7 @@ function stream_socket_accept($server_socket, ?float $timeout = null, ?string &$
  *
  * @param string $remote_socket Address to the socket to connect to.
  * @param int|null $errno Will be set to the system level error number if connection fails.
- * @param string|null $errstr Will be set to the system level error message if the connection fails.
+ * @param null|string $errstr Will be set to the system level error message if the connection fails.
  * @param float $timeout Number of seconds until the connect() system call
  * should timeout.
  *
@@ -521,7 +521,7 @@ function stream_socket_pair(int $domain, int $type, int $protocol): array
  * call. This is most likely due to a problem initializing the socket.
  * Note that the errno and
  * errstr arguments will always be passed by reference.
- * @param string|null $errstr See errno description.
+ * @param null|string $errstr See errno description.
  * @param int $flags A bitmask field which may be set to any combination of socket creation
  * flags.
  *

--- a/generated/8.1/url.php
+++ b/generated/8.1/url.php
@@ -36,7 +36,7 @@ function base64_decode(string $string, bool $strict = false): string
  * @param bool $associative If the optional associative parameter is set to true,
  * get_headers parses the response and sets the
  * array's keys.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create.
  * @return array Returns an indexed or associative array with the headers.
  * @throws UrlException
@@ -125,7 +125,7 @@ function get_meta_tags(string $filename, bool $use_include_path = false): array
  * URL component as a string (except when
  * PHP_URL_PORT is given, in which case the return
  * value will be an int).
- * @return array|int|string|null On seriously malformed URLs, parse_url.
+ * @return array|int|null|string On seriously malformed URLs, parse_url.
  *
  * If the component parameter is omitted, an
  * associative array is returned. At least one element will be

--- a/generated/8.1/xdiff.php
+++ b/generated/8.1/xdiff.php
@@ -214,7 +214,7 @@ function xdiff_string_patch_binary(string $str, string $patch): string
  *
  * Starting from version 1.5.0, you can also use binary OR to enable
  * XDIFF_PATCH_IGNORESPACE flag.
- * @param string|null $error If provided then rejected parts are stored inside this variable.
+ * @param null|string $error If provided then rejected parts are stored inside this variable.
  * @return string Returns the patched string.
  * @throws XdiffException
  *

--- a/generated/8.2/dir.php
+++ b/generated/8.2/dir.php
@@ -53,7 +53,7 @@ function chroot(string $directory): void
  * given directory is opened.
  *
  * @param string $directory Directory to open
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return \Directory Returns an instance of Directory, or FALSE in case of error.
  * @throws DirException
@@ -104,7 +104,7 @@ function getcwd(): string
  * rewinddir calls.
  *
  * @param string $directory The directory path that is to be opened
- * @param resource|null $context For a description of the context parameter,
+ * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return resource Returns a directory handle resource on success
@@ -136,7 +136,7 @@ function opendir(string $directory, $context = null)
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
  * SCANDIR_SORT_NONE then the result is unsorted.
- * @param resource|null $context For a description of the context parameter,
+ * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return array Returns an array of filenames on success. If directory is not a directory, then

--- a/generated/8.2/exec.php
+++ b/generated/8.2/exec.php
@@ -170,9 +170,9 @@ function proc_nice(int $priority): void
  * passing passphrases to programs like PGP, GPG and openssl in a more
  * secure manner. It is also useful for reading status information
  * provided by those programs on auxiliary file descriptors.
- * @param resource[]|null $pipes Will be set to an indexed array of file pointers that correspond to
+ * @param null|resource[] $pipes Will be set to an indexed array of file pointers that correspond to
  * PHP's end of any pipes that are created.
- * @param string|null $cwd The initial working dir for the command. This must be an
+ * @param null|string $cwd The initial working dir for the command. This must be an
  * absolute directory path, or NULL
  * if you want to use the default value (the working dir of the current
  * PHP process)
@@ -231,7 +231,7 @@ function proc_open(string $command, array $descriptor_spec, ?array &$pipes, ?str
  * This function is identical to the backtick operator.
  *
  * @param string $command The command that will be executed.
- * @return string|null A string containing the output from the executed command or NULL if an error occurs or the command produces no output.
+ * @return null|string A string containing the output from the executed command or NULL if an error occurs or the command produces no output.
  * @throws ExecException
  *
  */

--- a/generated/8.2/filesystem.php
+++ b/generated/8.2/filesystem.php
@@ -100,7 +100,7 @@ function chown(string $filename, $user): void
  * existing files.
  *
  * If the destination file already exists, it will be overwritten.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create.
  * @throws FilesystemException
  *
@@ -244,7 +244,7 @@ function fflush($stream): void
  * This is not possible if strict typing
  * is enabled, since FILE_USE_INCLUDE_PATH is an
  * int. Use TRUE instead.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create. If you don't need to use a
  * custom context, you can skip this parameter by NULL.
  * @param int $offset The offset where the reading starts on the original stream.
@@ -347,7 +347,7 @@ function file_get_contents(string $filename, bool $use_include_path = false, $co
  *
  *
  *
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create.
  * @return int This function returns the number of bytes that were written to the file.
  * @throws FilesystemException
@@ -406,7 +406,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  *
  *
  *
- * @param resource|null $context
+ * @param null|resource $context
  * @return array Returns the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns FALSE.
@@ -852,7 +852,7 @@ function flock($stream, int $operation, ?int &$would_block = null): void
  * @param bool $use_include_path The optional third use_include_path parameter
  * can be set to '1' or TRUE if you want to search for the file in the
  * include_path, too.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return resource Returns a file pointer resource on success
  * @throws FilesystemException
@@ -1262,7 +1262,7 @@ function lstat(string $filename): array
  * umask.
  * @param bool $recursive If TRUE, then any parent directories to the directory specified will
  * also be created, with the same permissions.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1421,7 +1421,7 @@ function popen(string $command, string $mode)
  * @param string $filename The filename being read.
  * @param bool $use_include_path You can use the optional second parameter and set it to TRUE, if
  * you want to search for the file in the include_path, too.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return int Returns the number of bytes read from the file on success
  * @throws FilesystemException
@@ -1517,7 +1517,7 @@ function realpath(string $path): string
  * Otherwise rename fails and issues E_WARNING.
  *
  *
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1561,7 +1561,7 @@ function rewind($stream): void
  * A E_WARNING level error will be generated on failure.
  *
  * @param string $directory Path to the directory.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1692,7 +1692,7 @@ function touch(string $filename, ?int $mtime = null, ?int $atime = null): void
  *
  * If the file is a symlink, the symlink will be deleted. On Windows, to delete
  * a symlink to a directory, rmdir has to be used instead.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *

--- a/generated/8.2/ftp.php
+++ b/generated/8.2/ftp.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\FtpException;
  *
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param int $size The number of bytes to allocate.
- * @param string|null $response A textual representation of the servers response will be returned by
+ * @param null|string $response A textual representation of the servers response will be returned by
  * reference in response if a variable is provided.
  * @throws FtpException
  *

--- a/generated/8.2/image.php
+++ b/generated/8.2/image.php
@@ -267,7 +267,7 @@ function imagearc(\GdImage $image, int $center_x, int $center_y, int $width, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst quality, smaller file)
  * to 100 (best quality, larger file).
  * If -1 is provided, the default value 30 is used.
@@ -300,7 +300,7 @@ function imageavif(\GdImage $image, $file = null, int $quality = -1, int $speed 
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  *
  * NULL is invalid if the compressed arguments is
  * not used.
@@ -1713,7 +1713,7 @@ function imagegammacorrect(\GdImage $image, float $input_gamma, float $output_ga
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
@@ -1736,7 +1736,7 @@ function imagegd(\GdImage $image, $file = null): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $chunk_size Chunk size.
  * @param int $mode Either IMG_GD2_RAW or
  * IMG_GD2_COMPRESSED. Default is
@@ -1776,7 +1776,7 @@ function imagegd2(\GdImage $image, $file = null, int $chunk_size = 128, int $mod
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
@@ -1838,7 +1838,7 @@ function imagegrabwindow(int $handle, bool $client_area = false): \GdImage
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst
  * quality, smaller file) to 100 (best quality, biggest file). The
  * default (-1) uses the default IJG quality value (about 75).
@@ -2022,7 +2022,7 @@ function imageloadfont(string $filename): int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  *
  * NULL is invalid if the quality and
  * filters arguments are not used.
@@ -2789,7 +2789,7 @@ function imagettftext(\GdImage $image, float $size, float $angle, int $x, int $y
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black.
@@ -2817,7 +2817,7 @@ function imagewbmp(\GdImage $image, $file = null, ?int $foreground_color = null)
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality ranges from 0 (worst
  * quality, smaller file) to 100 (best quality, biggest file).
  * @throws ImageException
@@ -2845,7 +2845,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
+ * @param null|resource|string $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
  *
  * The filename (without the .xbm extension) is also
  * used for the C identifiers of the XBM, whereby non

--- a/generated/8.2/imap.php
+++ b/generated/8.2/imap.php
@@ -1860,10 +1860,10 @@ function imap_renamemailbox(\IMAP\Connection $imap, string $from, string $to): v
 /**
  * Returns a properly formatted email address as defined in RFC2822 given the needed information.
  *
- * @param string|null $mailbox The mailbox name, see imap_open for more
+ * @param null|string $mailbox The mailbox name, see imap_open for more
  * information
- * @param string|null $hostname The email host part
- * @param string|null $personal The name of the account owner
+ * @param null|string $hostname The email host part
+ * @param null|string $personal The name of the account owner
  * @return string Returns a string properly formatted email address as defined in RFC2822.
  * @throws ImapException
  *

--- a/generated/8.2/ldap.php
+++ b/generated/8.2/ldap.php
@@ -65,8 +65,8 @@ function ldap_add(\LDAP\Connection $ldap, string $dn, array $entry, ?array $cont
  * Binds to the LDAP directory with specified RDN and password.
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
- * @param string|null $dn
- * @param string|null $password
+ * @param null|string $dn
+ * @param null|string $password
  * @throws LdapException
  *
  */
@@ -120,7 +120,7 @@ function ldap_compare(\LDAP\Connection $ldap, string $dn, string $attribute, str
  *
  * @param resource $link An LDAP resource, returned by ldap_connect.
  * @param resource $result
- * @param string|null $cookie An opaque structure sent by the server.
+ * @param null|string $cookie An opaque structure sent by the server.
  * @param int|null $estimated The estimated number of entries to retrieve.
  * @throws LdapException
  *
@@ -276,10 +276,10 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  * @param string $request_oid The extended operation request OID. You may use one of LDAP_EXOP_START_TLS, LDAP_EXOP_MODIFY_PASSWD, LDAP_EXOP_REFRESH, LDAP_EXOP_WHO_AM_I, LDAP_EXOP_TURN, or a string with the OID of the operation you want to send.
  * @param string $request_data The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
  * @param array|null $controls Array of LDAP Controls to send with the request.
- * @param string|null $response_data Will be filled with the extended operation response data if provided.
+ * @param null|string $response_data Will be filled with the extended operation response data if provided.
  * If not provided you may use ldap_parse_exop on the result object
  * later to get this data.
- * @param string|null $response_oid Will be filled with the response OID if provided, usually equal to the request OID.
+ * @param null|string $response_oid Will be filled with the response OID if provided, usually equal to the request OID.
  * @return bool|resource When used with response_data, returns TRUE on success.
  * When used without response_data, returns a result identifier.
  * @throws LdapException
@@ -960,8 +960,8 @@ function ldap_next_attribute(\LDAP\Connection $ldap, \LDAP\ResultEntry $entry): 
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param \LDAP\Result $result An LDAP\Result instance, returned by ldap_list or ldap_search.
- * @param string|null $response_data Will be filled by the response data.
- * @param string|null $response_oid Will be filled by the response OID.
+ * @param null|string $response_data Will be filled by the response data.
+ * @param null|string $response_oid Will be filled by the response OID.
  * @throws LdapException
  *
  */
@@ -982,9 +982,9 @@ function ldap_parse_exop(\LDAP\Connection $ldap, \LDAP\Result $result, ?string &
  * @param \LDAP\Result $result An LDAP\Result instance, returned by ldap_list or ldap_search.
  * @param int|null $error_code A reference to a variable that will be set to the LDAP error code in
  * the result, or 0 if no error occurred.
- * @param string|null $matched_dn A reference to a variable that will be set to a matched DN if one was
+ * @param null|string $matched_dn A reference to a variable that will be set to a matched DN if one was
  * recognised within the request, otherwise it will be set to NULL.
- * @param string|null $error_message A reference to a variable that will be set to the LDAP error message in
+ * @param null|string $error_message A reference to a variable that will be set to the LDAP error message in
  * the result, or an empty string if no error occurred.
  * @param array|null $referrals A reference to a variable that will be set to an array set
  * to all of the referral strings in the result, or an empty array if no
@@ -1073,7 +1073,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
 /**
  * Sets the value of the specified option to be value.
  *
- * @param resource|null $ldap Either an LDAP\Connection instance, returned by
+ * @param null|resource $ldap Either an LDAP\Connection instance, returned by
  * ldap_connect, to set the option for that connection,
  * or NULL to set the option globally.
  * @param int $option The parameter option can be one of:

--- a/generated/8.2/mbstring.php
+++ b/generated/8.2/mbstring.php
@@ -164,7 +164,7 @@ function mb_encoding_aliases(string $encoding): array
  * not used anywhere else.
  * @param string $string The string being checked.
  * @param string $options The search option. See mb_regex_set_options for explanation.
- * @return string|null The resultant string on success.
+ * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
  * @throws MbstringException
@@ -194,7 +194,7 @@ function mb_ereg_replace_callback(string $pattern, callable $callback, string $s
  * @param string $replacement The replacement text.
  * @param string $string The string being checked.
  * @param string $options
- * @return string|null The resultant string on success.
+ * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
  * @throws MbstringException
@@ -523,7 +523,7 @@ function mb_regex_encoding(?string $encoding = null)
  * This parameter is not automatically encoded.
  * @param string $subject The subject of the mail.
  * @param string $message The message of the mail.
- * @param array|string|null $additional_headers String or array to be inserted at the end of the email header.
+ * @param array|null|string $additional_headers String or array to be inserted at the end of the email header.
  *
  * This is typically used to add extra headers (From, Cc, and Bcc).
  * Multiple extra headers should be separated with a CRLF (\r\n).

--- a/generated/8.2/network.php
+++ b/generated/8.2/network.php
@@ -289,7 +289,7 @@ function dns_get_record(string $hostname, int $type = DNS_ANY, ?array &$authorit
  * indication that the error occurred before the
  * connect() call. This is most likely due to a
  * problem initializing the socket.
- * @param string|null $error_message The error message as a string.
+ * @param null|string $error_message The error message as a string.
  * @param float $timeout The connection timeout, in seconds. When NULL, the
  * default_socket_timeout php.ini setting is used.
  *
@@ -747,7 +747,7 @@ function openlog(string $prefix, int $flags, int $facility): void
  * @param string $hostname
  * @param int $port
  * @param int|null $error_code
- * @param string|null $error_message
+ * @param null|string $error_message
  * @param float $timeout
  * @return resource pfsockopen returns a file pointer which may be used
  * together with the other file functions (such as

--- a/generated/8.2/openssl.php
+++ b/generated/8.2/openssl.php
@@ -48,7 +48,7 @@ function openssl_cipher_key_length(string $cipher_algo): int
  * @param string $input_filename The name of a file containing encrypted content.
  * @param string $output_filename The name of the file to deposit the decrypted content.
  * @param \OpenSSLCertificate|string $certificate The name of the file containing a certificate of the recipient.
- * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key The name of the file containing a PKCS#8 key.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|null|string $private_key The name of the file containing a PKCS#8 key.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
@@ -126,7 +126,7 @@ function openssl_cms_read(string $input_filename, array &$certificates): void
  * @param int $flags Flags to be passed to cms_sign.
  * @param int $encoding The encoding of the output file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
- * @param string|null $untrusted_certificates_filename Intermediate certificates to be included in the signature.
+ * @param null|string $untrusted_certificates_filename Intermediate certificates to be included in the signature.
  * @throws OpensslException
  *
  */
@@ -149,12 +149,12 @@ function openssl_cms_sign(string $input_filename, string $output_filename, $cert
  *
  * @param string $input_filename The input file.
  * @param int $flags Flags to pass to cms_verify.
- * @param string|null $certificates A file with the signer certificate and optionally intermediate certificates.
+ * @param null|string $certificates A file with the signer certificate and optionally intermediate certificates.
  * @param array $ca_info An array containing self-signed certificate authority certificates.
- * @param string|null $untrusted_certificates_filename A file containing additional intermediate certificates.
- * @param string|null $content A file pointing to the content when signatures are detached.
- * @param string|null $pk7
- * @param string|null $sigfile A file to save the signature to.
+ * @param null|string $untrusted_certificates_filename A file containing additional intermediate certificates.
+ * @param null|string $content A file pointing to the content when signatures are detached.
+ * @param null|string $pk7
+ * @param null|string $sigfile A file to save the signature to.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
@@ -218,7 +218,7 @@ function openssl_csr_export_to_file($csr, string $output_filename, bool $no_text
  * reference.
  *
  * @param \OpenSSLCertificateSigningRequest|string $csr See CSR parameters for a list of valid values.
- * @param string|null $output on success, this string will contain the PEM encoded CSR
+ * @param null|string $output on success, this string will contain the PEM encoded CSR
  * @param bool $no_text
  * The optional parameter notext affects
  * the verbosity of the output; if it is FALSE, then additional human-readable
@@ -417,7 +417,7 @@ function openssl_csr_new(array $distinguished_names, \OpenSSLAsymmetricKey &$pri
  * It can also be the path to a PEM encoded CSR when specified as
  * file://path/to/csr or an exported string generated
  * by openssl_csr_export.
- * @param \OpenSSLCertificate|string|null $ca_certificate The generated certificate will be signed by ca_certificate.
+ * @param \OpenSSLCertificate|null|string $ca_certificate The generated certificate will be signed by ca_certificate.
  * If ca_certificate is NULL, the generated certificate
  * will be a self-signed certificate.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key is the private key that corresponds to
@@ -602,7 +602,7 @@ function openssl_get_curve_names(): array
  * openssl_seal for more information.
  *
  * @param string $data
- * @param string|null $output If the call is successful the opened data is returned in this
+ * @param null|string $output If the call is successful the opened data is returned in this
  * parameter.
  * @param string $encrypted_key
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key
@@ -706,7 +706,7 @@ function openssl_pkcs12_export_to_file($certificate, string $output_filename, $p
  * output in a PKCS#12 file format.
  *
  * @param \OpenSSLCertificate|string $certificate See Key/Certificate parameters for a list of valid values.
- * @param string|null $output On success, this will hold the PKCS#12.
+ * @param null|string $output On success, this will hold the PKCS#12.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key Private key component of PKCS#12 file.
  * See Public/Private Key parameters for a list of valid values.
  * @param string $passphrase Encryption password for unlocking the PKCS#12 file.
@@ -775,7 +775,7 @@ function openssl_pkcs12_read(string $pkcs12, ?array &$certificates, string $pass
  * @param string $output_filename The decrypted message is written to the file specified by
  * output_filename.
  * @param \OpenSSLCertificate|string $certificate
- * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|null|string $private_key
  * @throws OpensslException
  *
  */
@@ -912,7 +912,7 @@ function openssl_pkey_derive($public_key, $private_key, int $key_length = 0): st
  *
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param string $output_filename Path to the output file.
- * @param string|null $passphrase The key can be optionally protected by a
+ * @param null|string $passphrase The key can be optionally protected by a
  * passphrase.
  * @param array $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
@@ -943,8 +943,8 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * output (which is passed by reference).
  *
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
- * @param string|null $output
- * @param string|null $passphrase The key is optionally protected by passphrase.
+ * @param null|string $output
+ * @param null|string $passphrase The key is optionally protected by passphrase.
  * @param array $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file.  See openssl_csr_new for more
@@ -981,7 +981,7 @@ function openssl_pkey_export($key, ?string &$output, ?string $passphrase = null,
  *
  * A PEM formatted private key.
  *
- * @param string|null $passphrase The optional parameter passphrase must be used
+ * @param null|string $passphrase The optional parameter passphrase must be used
  * if the specified key is encrypted (protected by a passphrase).
  * @return \OpenSSLAsymmetricKey Returns an OpenSSLAsymmetricKey instance on success.
  * @throws OpensslException
@@ -1069,7 +1069,7 @@ function openssl_pkey_new(?array $options = null): \OpenSSLAsymmetricKey
  * You can use this function e.g. to decrypt data which is supposed to only be available to you.
  *
  * @param string $data
- * @param string|null $decrypted_data
+ * @param null|string $decrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key must be the private key corresponding that
  * was used to encrypt the data.
  * @param int $padding padding can be one of
@@ -1100,7 +1100,7 @@ function openssl_private_decrypt(string $data, ?string &$decrypted_data, $privat
  * is not written by someone else.
  *
  * @param string $data
- * @param string|null $encrypted_data
+ * @param null|string $encrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key
  * @param int $padding padding can be one of
  * OPENSSL_PKCS1_PADDING,
@@ -1128,7 +1128,7 @@ function openssl_private_encrypt(string $data, ?string &$encrypted_data, $privat
  * owner of the private key.
  *
  * @param string $data
- * @param string|null $decrypted_data
+ * @param null|string $decrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key public_key must be the public key corresponding that
  * was used to encrypt the data.
  * @param int $padding padding can be one of
@@ -1158,7 +1158,7 @@ function openssl_public_decrypt(string $data, ?string &$decrypted_data, $public_
  * in database.
  *
  * @param string $data
- * @param string|null $encrypted_data This will hold the result of the encryption.
+ * @param null|string $encrypted_data This will hold the result of the encryption.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key The public key.
  * @param int $padding padding can be one of
  * OPENSSL_PKCS1_PADDING,
@@ -1190,7 +1190,7 @@ function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_
  * the envelope key that was encrypted with the recipient's public key.
  *
  * @param string $data The data to seal.
- * @param string|null $sealed_data The sealed data.
+ * @param null|string $sealed_data The sealed data.
  * @param array|null $encrypted_keys Array of encrypted keys.
  * @param array $public_key Array of OpenSSLAsymmetricKey instances containing public keys.
  * @param string $cipher_algo The cipher method.
@@ -1200,7 +1200,7 @@ function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_
  * It is strongly recommended to explicitly specify a secure cipher method.
  *
  *
- * @param string|null $iv The initialization vector.
+ * @param null|string $iv The initialization vector.
  * @return int Returns the length of the sealed data on success.
  * If successful the sealed data is returned in
  * sealed_data, and the envelope keys in
@@ -1227,7 +1227,7 @@ function openssl_seal(string $data, ?string &$sealed_data, ?array &$encrypted_ke
  * not encrypted.
  *
  * @param string $data The string of data you wish to sign
- * @param string|null $signature If the call was successful the signature is returned in
+ * @param null|string $signature If the call was successful the signature is returned in
  * signature.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key OpenSSLAsymmetricKey - a key, returned by openssl_get_privatekey
  *
@@ -1252,7 +1252,7 @@ function openssl_sign(string $data, ?string &$signature, $private_key, $algorith
  * Exports challenge from encoded signed public key and challenge
  *
  * @param string $spki Expects a valid signed public key and challenge
- * @return string|null Returns the associated challenge string.
+ * @return null|string Returns the associated challenge string.
  * @throws OpensslException
  *
  */
@@ -1271,7 +1271,7 @@ function openssl_spki_export_challenge(string $spki): ?string
  * Exports PEM formatted public key from encoded signed public key and challenge
  *
  * @param string $spki Expects a valid signed public key and challenge
- * @return string|null Returns the associated PEM formatted public key.
+ * @return null|string Returns the associated PEM formatted public key.
  * @throws OpensslException
  *
  */
@@ -1296,7 +1296,7 @@ function openssl_spki_export(string $spki): ?string
  * CSR.
  * @param string $challenge The challenge associated to associate with the SPKAC
  * @param int $digest_algo The digest algorithm. See openssl_get_md_method().
- * @return string|null Returns a signed public key and challenge string.
+ * @return null|string Returns a signed public key and challenge string.
  * @throws OpensslException
  *
  */
@@ -1467,7 +1467,7 @@ function openssl_x509_export_to_file($certificate, string $output_filename, bool
  * output in a PEM encoded format.
  *
  * @param \OpenSSLCertificate|string $certificate See Key/Certificate parameters for a list of valid values.
- * @param string|null $output On success, this will hold the PEM.
+ * @param null|string $output On success, this will hold the PEM.
  * @param bool $no_text
  * The optional parameter notext affects
  * the verbosity of the output; if it is FALSE, then additional human-readable

--- a/generated/8.2/outcontrol.php
+++ b/generated/8.2/outcontrol.php
@@ -151,7 +151,7 @@ function ob_get_clean(): string
  * If output buffering is still active when the script ends, PHP outputs the
  * contents automatically.
  *
- * @param array|callable|string|null $callback An optional callback function may be
+ * @param array|callable|null|string $callback An optional callback function may be
  * specified. This function takes a string as a parameter and should
  * return a string. The function will be called when
  * the output buffer is flushed (sent) or cleaned (with

--- a/generated/8.2/pcre.php
+++ b/generated/8.2/pcre.php
@@ -390,7 +390,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  *
  * @param string $pattern The pattern to search for, as a string.
  * @param string $subject The input string.
- * @param string[]|null $matches If matches is provided, then it is filled with
+ * @param null|string[] $matches If matches is provided, then it is filled with
  * the results of search. $matches[0] will contain the
  * text that matched the full pattern, $matches[1]
  * will have the text that matched the first captured parenthesized

--- a/generated/8.2/pgsql.php
+++ b/generated/8.2/pgsql.php
@@ -1192,7 +1192,7 @@ function pg_query(?\PgSql\Connection $connection = null, ?string $query = null):
  * PGSQL_DIAG_CONTEXT, PGSQL_DIAG_SOURCE_FILE,
  * PGSQL_DIAG_SOURCE_LINE or
  * PGSQL_DIAG_SOURCE_FUNCTION.
- * @return string|null A string containing the contents of the error field, NULL if the field does not exist.
+ * @return null|string A string containing the contents of the error field, NULL if the field does not exist.
  * @throws PgsqlException
  *
  */

--- a/generated/8.2/sockets.php
+++ b/generated/8.2/sockets.php
@@ -355,7 +355,7 @@ function socket_get_option(\Socket $socket, int $level, int $option)
  *
  * @param \Socket $socket A Socket instance created with socket_create
  * or socket_accept.
- * @param string|null $address If the given socket is of type AF_INET or
+ * @param null|string $address If the given socket is of type AF_INET or
  * AF_INET6, socket_getpeername
  * will return the peers (remote) IP address in
  * appropriate notation (e.g. 127.0.0.1 or
@@ -387,7 +387,7 @@ function socket_getpeername(\Socket $socket, ?string &$address, ?int &$port = nu
  *
  * @param \Socket $socket A Socket instance created with socket_create
  * or socket_accept.
- * @param string|null $address If the given socket is of type AF_INET
+ * @param null|string $address If the given socket is of type AF_INET
  * or AF_INET6, socket_getsockname
  * will return the local IP address in appropriate notation (e.g.
  * 127.0.0.1 or fe80::1) in the

--- a/generated/8.2/sqlsrv.php
+++ b/generated/8.2/sqlsrv.php
@@ -283,7 +283,7 @@ function sqlsrv_fetch_array($stmt, ?int $fetchType = null, ?int $row = null, ?in
  * SQLSRV_SCROLL_ABSOLUTE or
  * SQLSRV_SCROLL_RELATIVE. Note that the first row in
  * a result set has index 0.
- * @return object|null Returns an object on success, NULL if there are no more rows to return,
+ * @return null|object Returns an object on success, NULL if there are no more rows to return,
  * and FALSE if an error occurs or if the specified class does not exist.
  * @throws SqlsrvException
  *

--- a/generated/8.2/stream.php
+++ b/generated/8.2/stream.php
@@ -367,7 +367,7 @@ function stream_set_timeout($stream, int $seconds, int $microseconds = 0): void
  * @param float $timeout Override the default socket accept timeout. Time should be given in
  * seconds. By default, default_socket_timeout
  * is used.
- * @param string|null $peer_name Will be set to the name (address) of the client which connected, if
+ * @param null|string $peer_name Will be set to the name (address) of the client which connected, if
  * included and available from the selected transport.
  *
  * Can also be determined later using
@@ -406,7 +406,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  *
  * @param string $address Address to the socket to connect to.
  * @param int|null $error_code Will be set to the system level error number if connection fails.
- * @param string|null $error_message Will be set to the system level error message if the connection fails.
+ * @param null|string $error_message Will be set to the system level error message if the connection fails.
  * @param float $timeout Number of seconds until the connect() system call
  * should timeout. By default, default_socket_timeout
  * is used.
@@ -434,7 +434,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * STREAM_CLIENT_CONNECT (default),
  * STREAM_CLIENT_ASYNC_CONNECT and
  * STREAM_CLIENT_PERSISTENT.
- * @param resource|null $context A valid context resource created with stream_context_create.
+ * @param null|resource $context A valid context resource created with stream_context_create.
  * @return resource On success a stream resource is returned which may
  * be used together with the other file functions (such as
  * fgets, fgetss,
@@ -547,7 +547,7 @@ function stream_socket_pair(int $domain, int $type, int $protocol): array
  *
  *
  *
- * @param string|null $address If address is provided it will be populated with
+ * @param null|string $address If address is provided it will be populated with
  * the address of the remote socket.
  * @return string Returns the read data, as a string.
  * @throws StreamException
@@ -635,13 +635,13 @@ function stream_socket_sendto($socket, string $data, int $flags = 0, string $add
  * call. This is most likely due to a problem initializing the socket.
  * Note that the error_code and
  * error_message arguments will always be passed by reference.
- * @param string|null $error_message See error_code description.
+ * @param null|string $error_message See error_code description.
  * @param int $flags A bitmask field which may be set to any combination of socket creation
  * flags.
  *
  * For UDP sockets, you must use STREAM_SERVER_BIND as
  * the flags parameter.
- * @param resource|null $context
+ * @param null|resource $context
  * @return resource Returns the created stream.
  * @throws StreamException
  *

--- a/generated/8.2/url.php
+++ b/generated/8.2/url.php
@@ -36,7 +36,7 @@ function base64_decode(string $string, bool $strict = false): string
  * @param bool $associative If the optional associative parameter is set to true,
  * get_headers parses the response and sets the
  * array's keys.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create, or NULL to use the
  * default context.
  * @return array Returns an indexed or associative array with the headers.
@@ -124,7 +124,7 @@ function get_meta_tags(string $filename, bool $use_include_path = false): array
  * URL component as a string (except when
  * PHP_URL_PORT is given, in which case the return
  * value will be an int).
- * @return array|int|string|null On seriously malformed URLs, parse_url.
+ * @return array|int|null|string On seriously malformed URLs, parse_url.
  *
  * If the component parameter is omitted, an
  * associative array is returned. At least one element will be

--- a/generated/8.2/xdiff.php
+++ b/generated/8.2/xdiff.php
@@ -214,7 +214,7 @@ function xdiff_string_patch_binary(string $str, string $patch): string
  *
  * Starting from version 1.5.0, you can also use binary OR to enable
  * XDIFF_PATCH_IGNORESPACE flag.
- * @param string|null $error If provided then rejected parts are stored inside this variable.
+ * @param null|string $error If provided then rejected parts are stored inside this variable.
  * @return string Returns the patched string.
  * @throws XdiffException
  *

--- a/generated/8.3/dir.php
+++ b/generated/8.3/dir.php
@@ -53,7 +53,7 @@ function chroot(string $directory): void
  * given directory is opened.
  *
  * @param string $directory Directory to open
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return \Directory Returns an instance of Directory, or FALSE in case of error.
  * @throws DirException
@@ -104,7 +104,7 @@ function getcwd(): string
  * rewinddir calls.
  *
  * @param string $directory The directory path that is to be opened
- * @param resource|null $context For a description of the context parameter,
+ * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return resource Returns a directory handle resource on success
@@ -136,7 +136,7 @@ function opendir(string $directory, $context = null)
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
  * SCANDIR_SORT_NONE then the result is unsorted.
- * @param resource|null $context For a description of the context parameter,
+ * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return array Returns an array of filenames on success. If directory is not a directory, then

--- a/generated/8.3/exec.php
+++ b/generated/8.3/exec.php
@@ -170,9 +170,9 @@ function proc_nice(int $priority): void
  * passing passphrases to programs like PGP, GPG and openssl in a more
  * secure manner. It is also useful for reading status information
  * provided by those programs on auxiliary file descriptors.
- * @param resource[]|null $pipes Will be set to an indexed array of file pointers that correspond to
+ * @param null|resource[] $pipes Will be set to an indexed array of file pointers that correspond to
  * PHP's end of any pipes that are created.
- * @param string|null $cwd The initial working dir for the command. This must be an
+ * @param null|string $cwd The initial working dir for the command. This must be an
  * absolute directory path, or NULL
  * if you want to use the default value (the working dir of the current
  * PHP process)
@@ -231,7 +231,7 @@ function proc_open(string $command, array $descriptor_spec, ?array &$pipes, ?str
  * This function is identical to the backtick operator.
  *
  * @param string $command The command that will be executed.
- * @return string|null A string containing the output from the executed command or NULL if an error occurs or the command produces no output.
+ * @return null|string A string containing the output from the executed command or NULL if an error occurs or the command produces no output.
  * @throws ExecException
  *
  */

--- a/generated/8.3/filesystem.php
+++ b/generated/8.3/filesystem.php
@@ -100,7 +100,7 @@ function chown(string $filename, $user): void
  * existing files.
  *
  * If the destination file already exists, it will be overwritten.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create.
  * @throws FilesystemException
  *
@@ -244,7 +244,7 @@ function fflush($stream): void
  * This is not possible if strict typing
  * is enabled, since FILE_USE_INCLUDE_PATH is an
  * int. Use TRUE instead.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create. If you don't need to use a
  * custom context, you can skip this parameter by NULL.
  * @param int $offset The offset where the reading starts on the original stream.
@@ -347,7 +347,7 @@ function file_get_contents(string $filename, bool $use_include_path = false, $co
  *
  *
  *
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create.
  * @return int This function returns the number of bytes that were written to the file.
  * @throws FilesystemException
@@ -406,7 +406,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  *
  *
  *
- * @param resource|null $context
+ * @param null|resource $context
  * @return array Returns the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns FALSE.
@@ -852,7 +852,7 @@ function flock($stream, int $operation, ?int &$would_block = null): void
  * @param bool $use_include_path The optional third use_include_path parameter
  * can be set to '1' or TRUE if you want to search for the file in the
  * include_path, too.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return resource Returns a file pointer resource on success
  * @throws FilesystemException
@@ -1262,7 +1262,7 @@ function lstat(string $filename): array
  * umask.
  * @param bool $recursive If TRUE, then any parent directories to the directory specified will
  * also be created, with the same permissions.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1421,7 +1421,7 @@ function popen(string $command, string $mode)
  * @param string $filename The filename being read.
  * @param bool $use_include_path You can use the optional second parameter and set it to TRUE, if
  * you want to search for the file in the include_path, too.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return int Returns the number of bytes read from the file on success
  * @throws FilesystemException
@@ -1517,7 +1517,7 @@ function realpath(string $path): string
  * Otherwise rename fails and issues E_WARNING.
  *
  *
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1561,7 +1561,7 @@ function rewind($stream): void
  * A E_WARNING level error will be generated on failure.
  *
  * @param string $directory Path to the directory.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1692,7 +1692,7 @@ function touch(string $filename, ?int $mtime = null, ?int $atime = null): void
  *
  * If the file is a symlink, the symlink will be deleted. On Windows, to delete
  * a symlink to a directory, rmdir has to be used instead.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *

--- a/generated/8.3/ftp.php
+++ b/generated/8.3/ftp.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\FtpException;
  *
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param int $size The number of bytes to allocate.
- * @param string|null $response A textual representation of the servers response will be returned by
+ * @param null|string $response A textual representation of the servers response will be returned by
  * reference in response if a variable is provided.
  * @throws FtpException
  *

--- a/generated/8.3/image.php
+++ b/generated/8.3/image.php
@@ -267,7 +267,7 @@ function imagearc(\GdImage $image, int $center_x, int $center_y, int $width, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst quality, smaller file)
  * to 100 (best quality, larger file).
  * If -1 is provided, the default value 30 is used.
@@ -300,7 +300,7 @@ function imageavif(\GdImage $image, $file = null, int $quality = -1, int $speed 
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  *
  * NULL is invalid if the compressed arguments is
  * not used.
@@ -1713,7 +1713,7 @@ function imagegammacorrect(\GdImage $image, float $input_gamma, float $output_ga
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
@@ -1736,7 +1736,7 @@ function imagegd(\GdImage $image, $file = null): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $chunk_size Chunk size.
  * @param int $mode Either IMG_GD2_RAW or
  * IMG_GD2_COMPRESSED. Default is
@@ -1776,7 +1776,7 @@ function imagegd2(\GdImage $image, $file = null, int $chunk_size = 128, int $mod
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
@@ -1838,7 +1838,7 @@ function imagegrabwindow(int $handle, bool $client_area = false): \GdImage
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst
  * quality, smaller file) to 100 (best quality, biggest file). The
  * default (-1) uses the default IJG quality value (about 75).
@@ -2022,7 +2022,7 @@ function imageloadfont(string $filename): int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  *
  * NULL is invalid if the quality and
  * filters arguments are not used.
@@ -2777,7 +2777,7 @@ function imagettftext(\GdImage $image, float $size, float $angle, int $x, int $y
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black.
@@ -2805,7 +2805,7 @@ function imagewbmp(\GdImage $image, $file = null, ?int $foreground_color = null)
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality ranges from 0 (worst
  * quality, smaller file) to 100 (best quality, biggest file).
  * @throws ImageException
@@ -2833,7 +2833,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
+ * @param null|resource|string $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
  *
  * The filename (without the .xbm extension) is also
  * used for the C identifiers of the XBM, whereby non

--- a/generated/8.3/imap.php
+++ b/generated/8.3/imap.php
@@ -1860,10 +1860,10 @@ function imap_renamemailbox(\IMAP\Connection $imap, string $from, string $to): v
 /**
  * Returns a properly formatted email address as defined in RFC2822 given the needed information.
  *
- * @param string|null $mailbox The mailbox name, see imap_open for more
+ * @param null|string $mailbox The mailbox name, see imap_open for more
  * information
- * @param string|null $hostname The email host part
- * @param string|null $personal The name of the account owner
+ * @param null|string $hostname The email host part
+ * @param null|string $personal The name of the account owner
  * @return string Returns a string properly formatted email address as defined in RFC2822.
  * @throws ImapException
  *

--- a/generated/8.3/ldap.php
+++ b/generated/8.3/ldap.php
@@ -65,8 +65,8 @@ function ldap_add(\LDAP\Connection $ldap, string $dn, array $entry, ?array $cont
  * Binds to the LDAP directory with specified RDN and password.
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
- * @param string|null $dn
- * @param string|null $password
+ * @param null|string $dn
+ * @param null|string $password
  * @throws LdapException
  *
  */
@@ -120,7 +120,7 @@ function ldap_compare(\LDAP\Connection $ldap, string $dn, string $attribute, str
  *
  * @param resource $link An LDAP resource, returned by ldap_connect.
  * @param resource $result
- * @param string|null $cookie An opaque structure sent by the server.
+ * @param null|string $cookie An opaque structure sent by the server.
  * @param int|null $estimated The estimated number of entries to retrieve.
  * @throws LdapException
  *
@@ -276,10 +276,10 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  * @param string $request_oid The extended operation request OID. You may use one of LDAP_EXOP_START_TLS, LDAP_EXOP_MODIFY_PASSWD, LDAP_EXOP_REFRESH, LDAP_EXOP_WHO_AM_I, LDAP_EXOP_TURN, or a string with the OID of the operation you want to send.
  * @param string $request_data The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
  * @param array|null $controls Array of LDAP Controls to send with the request.
- * @param string|null $response_data Will be filled with the extended operation response data if provided.
+ * @param null|string $response_data Will be filled with the extended operation response data if provided.
  * If not provided you may use ldap_parse_exop on the result object
  * later to get this data.
- * @param string|null $response_oid Will be filled with the response OID if provided, usually equal to the request OID.
+ * @param null|string $response_oid Will be filled with the response OID if provided, usually equal to the request OID.
  * @return bool|resource When used with response_data, returns TRUE on success.
  * When used without response_data, returns a result identifier.
  * @throws LdapException
@@ -960,8 +960,8 @@ function ldap_next_attribute(\LDAP\Connection $ldap, \LDAP\ResultEntry $entry): 
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param \LDAP\Result $result An LDAP\Result instance, returned by ldap_list or ldap_search.
- * @param string|null $response_data Will be filled by the response data.
- * @param string|null $response_oid Will be filled by the response OID.
+ * @param null|string $response_data Will be filled by the response data.
+ * @param null|string $response_oid Will be filled by the response OID.
  * @throws LdapException
  *
  */
@@ -982,9 +982,9 @@ function ldap_parse_exop(\LDAP\Connection $ldap, \LDAP\Result $result, ?string &
  * @param \LDAP\Result $result An LDAP\Result instance, returned by ldap_list or ldap_search.
  * @param int|null $error_code A reference to a variable that will be set to the LDAP error code in
  * the result, or 0 if no error occurred.
- * @param string|null $matched_dn A reference to a variable that will be set to a matched DN if one was
+ * @param null|string $matched_dn A reference to a variable that will be set to a matched DN if one was
  * recognised within the request, otherwise it will be set to NULL.
- * @param string|null $error_message A reference to a variable that will be set to the LDAP error message in
+ * @param null|string $error_message A reference to a variable that will be set to the LDAP error message in
  * the result, or an empty string if no error occurred.
  * @param array|null $referrals A reference to a variable that will be set to an array set
  * to all of the referral strings in the result, or an empty array if no
@@ -1073,7 +1073,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
 /**
  * Sets the value of the specified option to be value.
  *
- * @param resource|null $ldap Either an LDAP\Connection instance, returned by
+ * @param null|resource $ldap Either an LDAP\Connection instance, returned by
  * ldap_connect, to set the option for that connection,
  * or NULL to set the option globally.
  * @param int $option The parameter option can be one of:

--- a/generated/8.3/mbstring.php
+++ b/generated/8.3/mbstring.php
@@ -164,7 +164,7 @@ function mb_encoding_aliases(string $encoding): array
  * not used anywhere else.
  * @param string $string The string being checked.
  * @param string $options The search option. See mb_regex_set_options for explanation.
- * @return string|null The resultant string on success.
+ * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
  * @throws MbstringException
@@ -194,7 +194,7 @@ function mb_ereg_replace_callback(string $pattern, callable $callback, string $s
  * @param string $replacement The replacement text.
  * @param string $string The string being checked.
  * @param string $options
- * @return string|null The resultant string on success.
+ * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
  * @throws MbstringException
@@ -523,7 +523,7 @@ function mb_regex_encoding(?string $encoding = null)
  * This parameter is not automatically encoded.
  * @param string $subject The subject of the mail.
  * @param string $message The message of the mail.
- * @param array|string|null $additional_headers String or array to be inserted at the end of the email header.
+ * @param array|null|string $additional_headers String or array to be inserted at the end of the email header.
  *
  * This is typically used to add extra headers (From, Cc, and Bcc).
  * Multiple extra headers should be separated with a CRLF (\r\n).

--- a/generated/8.3/network.php
+++ b/generated/8.3/network.php
@@ -289,7 +289,7 @@ function dns_get_record(string $hostname, int $type = DNS_ANY, ?array &$authorit
  * indication that the error occurred before the
  * connect() call. This is most likely due to a
  * problem initializing the socket.
- * @param string|null $error_message The error message as a string.
+ * @param null|string $error_message The error message as a string.
  * @param float $timeout The connection timeout, in seconds. When NULL, the
  * default_socket_timeout php.ini setting is used.
  *
@@ -747,7 +747,7 @@ function openlog(string $prefix, int $flags, int $facility): void
  * @param string $hostname
  * @param int $port
  * @param int|null $error_code
- * @param string|null $error_message
+ * @param null|string $error_message
  * @param float $timeout
  * @return resource pfsockopen returns a file pointer which may be used
  * together with the other file functions (such as

--- a/generated/8.3/openssl.php
+++ b/generated/8.3/openssl.php
@@ -48,7 +48,7 @@ function openssl_cipher_key_length(string $cipher_algo): int
  * @param string $input_filename The name of a file containing encrypted content.
  * @param string $output_filename The name of the file to deposit the decrypted content.
  * @param \OpenSSLCertificate|string $certificate The name of the file containing a certificate of the recipient.
- * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key The name of the file containing a PKCS#8 key.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|null|string $private_key The name of the file containing a PKCS#8 key.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
@@ -126,7 +126,7 @@ function openssl_cms_read(string $input_filename, array &$certificates): void
  * @param int $flags Flags to be passed to cms_sign.
  * @param int $encoding The encoding of the output file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
- * @param string|null $untrusted_certificates_filename Intermediate certificates to be included in the signature.
+ * @param null|string $untrusted_certificates_filename Intermediate certificates to be included in the signature.
  * @throws OpensslException
  *
  */
@@ -149,12 +149,12 @@ function openssl_cms_sign(string $input_filename, string $output_filename, $cert
  *
  * @param string $input_filename The input file.
  * @param int $flags Flags to pass to cms_verify.
- * @param string|null $certificates A file with the signer certificate and optionally intermediate certificates.
+ * @param null|string $certificates A file with the signer certificate and optionally intermediate certificates.
  * @param array $ca_info An array containing self-signed certificate authority certificates.
- * @param string|null $untrusted_certificates_filename A file containing additional intermediate certificates.
- * @param string|null $content A file pointing to the content when signatures are detached.
- * @param string|null $pk7
- * @param string|null $sigfile A file to save the signature to.
+ * @param null|string $untrusted_certificates_filename A file containing additional intermediate certificates.
+ * @param null|string $content A file pointing to the content when signatures are detached.
+ * @param null|string $pk7
+ * @param null|string $sigfile A file to save the signature to.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
@@ -218,7 +218,7 @@ function openssl_csr_export_to_file($csr, string $output_filename, bool $no_text
  * reference.
  *
  * @param \OpenSSLCertificateSigningRequest|string $csr See CSR parameters for a list of valid values.
- * @param string|null $output on success, this string will contain the PEM encoded CSR
+ * @param null|string $output on success, this string will contain the PEM encoded CSR
  * @param bool $no_text
  * The optional parameter notext affects
  * the verbosity of the output; if it is FALSE, then additional human-readable
@@ -417,7 +417,7 @@ function openssl_csr_new(array $distinguished_names, \OpenSSLAsymmetricKey &$pri
  * It can also be the path to a PEM encoded CSR when specified as
  * file://path/to/csr or an exported string generated
  * by openssl_csr_export.
- * @param \OpenSSLCertificate|string|null $ca_certificate The generated certificate will be signed by ca_certificate.
+ * @param \OpenSSLCertificate|null|string $ca_certificate The generated certificate will be signed by ca_certificate.
  * If ca_certificate is NULL, the generated certificate
  * will be a self-signed certificate.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key is the private key that corresponds to
@@ -602,7 +602,7 @@ function openssl_get_curve_names(): array
  * openssl_seal for more information.
  *
  * @param string $data
- * @param string|null $output If the call is successful the opened data is returned in this
+ * @param null|string $output If the call is successful the opened data is returned in this
  * parameter.
  * @param string $encrypted_key
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key
@@ -706,7 +706,7 @@ function openssl_pkcs12_export_to_file($certificate, string $output_filename, $p
  * output in a PKCS#12 file format.
  *
  * @param \OpenSSLCertificate|string $certificate See Key/Certificate parameters for a list of valid values.
- * @param string|null $output On success, this will hold the PKCS#12.
+ * @param null|string $output On success, this will hold the PKCS#12.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key Private key component of PKCS#12 file.
  * See Public/Private Key parameters for a list of valid values.
  * @param string $passphrase Encryption password for unlocking the PKCS#12 file.
@@ -775,7 +775,7 @@ function openssl_pkcs12_read(string $pkcs12, ?array &$certificates, string $pass
  * @param string $output_filename The decrypted message is written to the file specified by
  * output_filename.
  * @param \OpenSSLCertificate|string $certificate
- * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|null|string $private_key
  * @throws OpensslException
  *
  */
@@ -912,7 +912,7 @@ function openssl_pkey_derive($public_key, $private_key, int $key_length = 0): st
  *
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param string $output_filename Path to the output file.
- * @param string|null $passphrase The key can be optionally protected by a
+ * @param null|string $passphrase The key can be optionally protected by a
  * passphrase.
  * @param array $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
@@ -943,8 +943,8 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * output (which is passed by reference).
  *
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
- * @param string|null $output
- * @param string|null $passphrase The key is optionally protected by passphrase.
+ * @param null|string $output
+ * @param null|string $passphrase The key is optionally protected by passphrase.
  * @param array $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file.  See openssl_csr_new for more
@@ -981,7 +981,7 @@ function openssl_pkey_export($key, ?string &$output, ?string $passphrase = null,
  *
  * A PEM formatted private key.
  *
- * @param string|null $passphrase The optional parameter passphrase must be used
+ * @param null|string $passphrase The optional parameter passphrase must be used
  * if the specified key is encrypted (protected by a passphrase).
  * @return \OpenSSLAsymmetricKey Returns an OpenSSLAsymmetricKey instance on success.
  * @throws OpensslException
@@ -1069,7 +1069,7 @@ function openssl_pkey_new(?array $options = null): \OpenSSLAsymmetricKey
  * You can use this function e.g. to decrypt data which is supposed to only be available to you.
  *
  * @param string $data
- * @param string|null $decrypted_data
+ * @param null|string $decrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key must be the private key corresponding that
  * was used to encrypt the data.
  * @param int $padding padding can be one of
@@ -1100,7 +1100,7 @@ function openssl_private_decrypt(string $data, ?string &$decrypted_data, $privat
  * is not written by someone else.
  *
  * @param string $data
- * @param string|null $encrypted_data
+ * @param null|string $encrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key
  * @param int $padding padding can be one of
  * OPENSSL_PKCS1_PADDING,
@@ -1128,7 +1128,7 @@ function openssl_private_encrypt(string $data, ?string &$encrypted_data, $privat
  * owner of the private key.
  *
  * @param string $data
- * @param string|null $decrypted_data
+ * @param null|string $decrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key public_key must be the public key corresponding that
  * was used to encrypt the data.
  * @param int $padding padding can be one of
@@ -1158,7 +1158,7 @@ function openssl_public_decrypt(string $data, ?string &$decrypted_data, $public_
  * in database.
  *
  * @param string $data
- * @param string|null $encrypted_data This will hold the result of the encryption.
+ * @param null|string $encrypted_data This will hold the result of the encryption.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key The public key.
  * @param int $padding padding can be one of
  * OPENSSL_PKCS1_PADDING,
@@ -1190,7 +1190,7 @@ function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_
  * the envelope key that was encrypted with the recipient's public key.
  *
  * @param string $data The data to seal.
- * @param string|null $sealed_data The sealed data.
+ * @param null|string $sealed_data The sealed data.
  * @param array|null $encrypted_keys Array of encrypted keys.
  * @param array $public_key Array of OpenSSLAsymmetricKey instances containing public keys.
  * @param string $cipher_algo The cipher method.
@@ -1200,7 +1200,7 @@ function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_
  * It is strongly recommended to explicitly specify a secure cipher method.
  *
  *
- * @param string|null $iv The initialization vector.
+ * @param null|string $iv The initialization vector.
  * @return int Returns the length of the sealed data on success.
  * If successful the sealed data is returned in
  * sealed_data, and the envelope keys in
@@ -1227,7 +1227,7 @@ function openssl_seal(string $data, ?string &$sealed_data, ?array &$encrypted_ke
  * not encrypted.
  *
  * @param string $data The string of data you wish to sign
- * @param string|null $signature If the call was successful the signature is returned in
+ * @param null|string $signature If the call was successful the signature is returned in
  * signature.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key OpenSSLAsymmetricKey - a key, returned by openssl_get_privatekey
  *
@@ -1252,7 +1252,7 @@ function openssl_sign(string $data, ?string &$signature, $private_key, $algorith
  * Exports challenge from encoded signed public key and challenge
  *
  * @param string $spki Expects a valid signed public key and challenge
- * @return string|null Returns the associated challenge string.
+ * @return null|string Returns the associated challenge string.
  * @throws OpensslException
  *
  */
@@ -1271,7 +1271,7 @@ function openssl_spki_export_challenge(string $spki): ?string
  * Exports PEM formatted public key from encoded signed public key and challenge
  *
  * @param string $spki Expects a valid signed public key and challenge
- * @return string|null Returns the associated PEM formatted public key.
+ * @return null|string Returns the associated PEM formatted public key.
  * @throws OpensslException
  *
  */
@@ -1296,7 +1296,7 @@ function openssl_spki_export(string $spki): ?string
  * CSR.
  * @param string $challenge The challenge associated to associate with the SPKAC
  * @param int $digest_algo The digest algorithm. See openssl_get_md_method().
- * @return string|null Returns a signed public key and challenge string.
+ * @return null|string Returns a signed public key and challenge string.
  * @throws OpensslException
  *
  */
@@ -1467,7 +1467,7 @@ function openssl_x509_export_to_file($certificate, string $output_filename, bool
  * output in a PEM encoded format.
  *
  * @param \OpenSSLCertificate|string $certificate See Key/Certificate parameters for a list of valid values.
- * @param string|null $output On success, this will hold the PEM.
+ * @param null|string $output On success, this will hold the PEM.
  * @param bool $no_text
  * The optional parameter notext affects
  * the verbosity of the output; if it is FALSE, then additional human-readable

--- a/generated/8.3/outcontrol.php
+++ b/generated/8.3/outcontrol.php
@@ -151,7 +151,7 @@ function ob_get_clean(): string
  * If output buffering is still active when the script ends, PHP outputs the
  * contents automatically.
  *
- * @param array|callable|string|null $callback An optional callback function may be
+ * @param array|callable|null|string $callback An optional callback function may be
  * specified. This function takes a string as a parameter and should
  * return a string. The function will be called when
  * the output buffer is flushed (sent) or cleaned (with

--- a/generated/8.3/pcre.php
+++ b/generated/8.3/pcre.php
@@ -390,7 +390,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  *
  * @param string $pattern The pattern to search for, as a string.
  * @param string $subject The input string.
- * @param string[]|null $matches If matches is provided, then it is filled with
+ * @param null|string[] $matches If matches is provided, then it is filled with
  * the results of search. $matches[0] will contain the
  * text that matched the full pattern, $matches[1]
  * will have the text that matched the first captured parenthesized

--- a/generated/8.3/pgsql.php
+++ b/generated/8.3/pgsql.php
@@ -1192,7 +1192,7 @@ function pg_query(?\PgSql\Connection $connection = null, ?string $query = null):
  * PGSQL_DIAG_CONTEXT, PGSQL_DIAG_SOURCE_FILE,
  * PGSQL_DIAG_SOURCE_LINE or
  * PGSQL_DIAG_SOURCE_FUNCTION.
- * @return string|null A string containing the contents of the error field, NULL if the field does not exist.
+ * @return null|string A string containing the contents of the error field, NULL if the field does not exist.
  * @throws PgsqlException
  *
  */

--- a/generated/8.3/sockets.php
+++ b/generated/8.3/sockets.php
@@ -355,7 +355,7 @@ function socket_get_option(\Socket $socket, int $level, int $option)
  *
  * @param \Socket $socket A Socket instance created with socket_create
  * or socket_accept.
- * @param string|null $address If the given socket is of type AF_INET or
+ * @param null|string $address If the given socket is of type AF_INET or
  * AF_INET6, socket_getpeername
  * will return the peers (remote) IP address in
  * appropriate notation (e.g. 127.0.0.1 or
@@ -387,7 +387,7 @@ function socket_getpeername(\Socket $socket, ?string &$address, ?int &$port = nu
  *
  * @param \Socket $socket A Socket instance created with socket_create
  * or socket_accept.
- * @param string|null $address If the given socket is of type AF_INET
+ * @param null|string $address If the given socket is of type AF_INET
  * or AF_INET6, socket_getsockname
  * will return the local IP address in appropriate notation (e.g.
  * 127.0.0.1 or fe80::1) in the

--- a/generated/8.3/sqlsrv.php
+++ b/generated/8.3/sqlsrv.php
@@ -283,7 +283,7 @@ function sqlsrv_fetch_array($stmt, ?int $fetchType = null, ?int $row = null, ?in
  * SQLSRV_SCROLL_ABSOLUTE or
  * SQLSRV_SCROLL_RELATIVE. Note that the first row in
  * a result set has index 0.
- * @return object|null Returns an object on success, NULL if there are no more rows to return,
+ * @return null|object Returns an object on success, NULL if there are no more rows to return,
  * and FALSE if an error occurs or if the specified class does not exist.
  * @throws SqlsrvException
  *

--- a/generated/8.3/stream.php
+++ b/generated/8.3/stream.php
@@ -367,7 +367,7 @@ function stream_set_timeout($stream, int $seconds, int $microseconds = 0): void
  * @param float $timeout Override the default socket accept timeout. Time should be given in
  * seconds. By default, default_socket_timeout
  * is used.
- * @param string|null $peer_name Will be set to the name (address) of the client which connected, if
+ * @param null|string $peer_name Will be set to the name (address) of the client which connected, if
  * included and available from the selected transport.
  *
  * Can also be determined later using
@@ -406,7 +406,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  *
  * @param string $address Address to the socket to connect to.
  * @param int|null $error_code Will be set to the system level error number if connection fails.
- * @param string|null $error_message Will be set to the system level error message if the connection fails.
+ * @param null|string $error_message Will be set to the system level error message if the connection fails.
  * @param float $timeout Number of seconds until the connect() system call
  * should timeout. By default, default_socket_timeout
  * is used.
@@ -434,7 +434,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * STREAM_CLIENT_CONNECT (default),
  * STREAM_CLIENT_ASYNC_CONNECT and
  * STREAM_CLIENT_PERSISTENT.
- * @param resource|null $context A valid context resource created with stream_context_create.
+ * @param null|resource $context A valid context resource created with stream_context_create.
  * @return resource On success a stream resource is returned which may
  * be used together with the other file functions (such as
  * fgets, fgetss,
@@ -547,7 +547,7 @@ function stream_socket_pair(int $domain, int $type, int $protocol): array
  *
  *
  *
- * @param string|null $address If address is provided it will be populated with
+ * @param null|string $address If address is provided it will be populated with
  * the address of the remote socket.
  * @return string Returns the read data, as a string.
  * @throws StreamException
@@ -635,13 +635,13 @@ function stream_socket_sendto($socket, string $data, int $flags = 0, string $add
  * call. This is most likely due to a problem initializing the socket.
  * Note that the error_code and
  * error_message arguments will always be passed by reference.
- * @param string|null $error_message See error_code description.
+ * @param null|string $error_message See error_code description.
  * @param int $flags A bitmask field which may be set to any combination of socket creation
  * flags.
  *
  * For UDP sockets, you must use STREAM_SERVER_BIND as
  * the flags parameter.
- * @param resource|null $context
+ * @param null|resource $context
  * @return resource Returns the created stream.
  * @throws StreamException
  *

--- a/generated/8.3/url.php
+++ b/generated/8.3/url.php
@@ -36,7 +36,7 @@ function base64_decode(string $string, bool $strict = false): string
  * @param bool $associative If the optional associative parameter is set to true,
  * get_headers parses the response and sets the
  * array's keys.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create, or NULL to use the
  * default context.
  * @return array Returns an indexed or associative array with the headers.
@@ -124,7 +124,7 @@ function get_meta_tags(string $filename, bool $use_include_path = false): array
  * URL component as a string (except when
  * PHP_URL_PORT is given, in which case the return
  * value will be an int).
- * @return array|int|string|null On seriously malformed URLs, parse_url.
+ * @return array|int|null|string On seriously malformed URLs, parse_url.
  *
  * If the component parameter is omitted, an
  * associative array is returned. At least one element will be

--- a/generated/8.3/xdiff.php
+++ b/generated/8.3/xdiff.php
@@ -214,7 +214,7 @@ function xdiff_string_patch_binary(string $str, string $patch): string
  *
  * Starting from version 1.5.0, you can also use binary OR to enable
  * XDIFF_PATCH_IGNORESPACE flag.
- * @param string|null $error If provided then rejected parts are stored inside this variable.
+ * @param null|string $error If provided then rejected parts are stored inside this variable.
  * @return string Returns the patched string.
  * @throws XdiffException
  *

--- a/generated/8.4/datetime.php
+++ b/generated/8.4/datetime.php
@@ -41,7 +41,7 @@ function date_create_immutable(string $datetime = "now", ?\DateTimeZone $timezon
  * FALSE instead of an exception if the passed in
  * datetime string is invalid.
  *
- * @param string|null $datetime
+ * @param null|string $datetime
  * @param \DateTimeZone|null $timezone
  * @return \DateTime Returns a new DateTime instance
  * @throws DatetimeException

--- a/generated/8.4/dir.php
+++ b/generated/8.4/dir.php
@@ -53,7 +53,7 @@ function chroot(string $directory): void
  * given directory is opened.
  *
  * @param string $directory Directory to open
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return \Directory Returns an instance of Directory, or FALSE in case of error.
  * @throws DirException
@@ -104,7 +104,7 @@ function getcwd(): string
  * rewinddir calls.
  *
  * @param string $directory The directory path that is to be opened
- * @param resource|null $context For a description of the context parameter,
+ * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return resource Returns a directory handle resource on success
@@ -136,7 +136,7 @@ function opendir(string $directory, $context = null)
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
  * SCANDIR_SORT_NONE then the result is unsorted.
- * @param resource|null $context For a description of the context parameter,
+ * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return array Returns an array of filenames on success. If directory is not a directory, then

--- a/generated/8.4/exec.php
+++ b/generated/8.4/exec.php
@@ -170,9 +170,9 @@ function proc_nice(int $priority): void
  * passing passphrases to programs like PGP, GPG and openssl in a more
  * secure manner. It is also useful for reading status information
  * provided by those programs on auxiliary file descriptors.
- * @param resource[]|null $pipes Will be set to an indexed array of file pointers that correspond to
+ * @param null|resource[] $pipes Will be set to an indexed array of file pointers that correspond to
  * PHP's end of any pipes that are created.
- * @param string|null $cwd The initial working dir for the command. This must be an
+ * @param null|string $cwd The initial working dir for the command. This must be an
  * absolute directory path, or NULL
  * if you want to use the default value (the working dir of the current
  * PHP process)
@@ -231,7 +231,7 @@ function proc_open(string $command, array $descriptor_spec, ?array &$pipes, ?str
  * This function is identical to the backtick operator.
  *
  * @param string $command The command that will be executed.
- * @return string|null A string containing the output from the executed command or NULL if an error occurs or the command produces no output.
+ * @return null|string A string containing the output from the executed command or NULL if an error occurs or the command produces no output.
  * @throws ExecException
  *
  */

--- a/generated/8.4/filesystem.php
+++ b/generated/8.4/filesystem.php
@@ -100,7 +100,7 @@ function chown(string $filename, $user): void
  * existing files.
  *
  * If the destination file already exists, it will be overwritten.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create.
  * @throws FilesystemException
  *
@@ -244,7 +244,7 @@ function fflush($stream): void
  * This is not possible if strict typing
  * is enabled, since FILE_USE_INCLUDE_PATH is an
  * int. Use TRUE instead.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create. If you don't need to use a
  * custom context, you can skip this parameter by NULL.
  * @param int $offset The offset where the reading starts on the original stream.
@@ -347,7 +347,7 @@ function file_get_contents(string $filename, bool $use_include_path = false, $co
  *
  *
  *
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create.
  * @return int This function returns the number of bytes that were written to the file.
  * @throws FilesystemException
@@ -416,7 +416,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  *
  *
  *
- * @param resource|null $context
+ * @param null|resource $context
  * @return array Returns the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns FALSE.
@@ -862,7 +862,7 @@ function flock($stream, int $operation, ?int &$would_block = null): void
  * @param bool $use_include_path The optional third use_include_path parameter
  * can be set to TRUE if you want to search for the file in the
  * include_path, too.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return resource Returns a file pointer resource on success
  * @throws FilesystemException
@@ -1224,7 +1224,7 @@ function lstat(string $filename): array
  * umask.
  * @param bool $recursive If TRUE, then any parent directories to the directory specified will
  * also be created, with the same permissions.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1383,7 +1383,7 @@ function popen(string $command, string $mode)
  * @param string $filename The filename being read.
  * @param bool $use_include_path You can use the optional second parameter and set it to TRUE, if
  * you want to search for the file in the include_path, too.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return int Returns the number of bytes read from the file on success
  * @throws FilesystemException
@@ -1479,7 +1479,7 @@ function realpath(string $path): string
  * Otherwise rename fails and issues E_WARNING.
  *
  *
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1523,7 +1523,7 @@ function rewind($stream): void
  * A E_WARNING level error will be generated on failure.
  *
  * @param string $directory Path to the directory.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1654,7 +1654,7 @@ function touch(string $filename, ?int $mtime = null, ?int $atime = null): void
  *
  * If the file is a symlink, the symlink will be deleted. On Windows, to delete
  * a symlink to a directory, rmdir has to be used instead.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *

--- a/generated/8.4/ftp.php
+++ b/generated/8.4/ftp.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\FtpException;
  *
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param int $size The number of bytes to allocate.
- * @param string|null $response A textual representation of the servers response will be returned by
+ * @param null|string $response A textual representation of the servers response will be returned by
  * reference in response if a variable is provided.
  * @throws FtpException
  *

--- a/generated/8.4/image.php
+++ b/generated/8.4/image.php
@@ -267,7 +267,7 @@ function imagearc(\GdImage $image, int $center_x, int $center_y, int $width, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst quality, smaller file)
  * to 100 (best quality, larger file).
  * If -1 is provided, the default value 30 is used.
@@ -300,7 +300,7 @@ function imageavif(\GdImage $image, $file = null, int $quality = -1, int $speed 
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  *
  * NULL is invalid if the compressed arguments is
  * not used.
@@ -1713,7 +1713,7 @@ function imagegammacorrect(\GdImage $image, float $input_gamma, float $output_ga
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
@@ -1736,7 +1736,7 @@ function imagegd(\GdImage $image, $file = null): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $chunk_size Chunk size.
  * @param int $mode Either IMG_GD2_RAW or
  * IMG_GD2_COMPRESSED. Default is
@@ -1776,7 +1776,7 @@ function imagegd2(\GdImage $image, $file = null, int $chunk_size = 128, int $mod
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
@@ -1838,7 +1838,7 @@ function imagegrabwindow(int $handle, bool $client_area = false): \GdImage
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst
  * quality, smaller file) to 100 (best quality, biggest file). The
  * default (-1) uses the default IJG quality value (about 75).
@@ -2022,7 +2022,7 @@ function imageloadfont(string $filename): int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  *
  * NULL is invalid if the quality and
  * filters arguments are not used.
@@ -2748,7 +2748,7 @@ function imagettftext(\GdImage $image, float $size, float $angle, int $x, int $y
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black.
@@ -2776,7 +2776,7 @@ function imagewbmp(\GdImage $image, $file = null, ?int $foreground_color = null)
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality ranges from 0 (worst
  * quality, smaller file) to 100 (best quality, biggest file).
  * @throws ImageException
@@ -2804,7 +2804,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
+ * @param null|resource|string $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
  *
  * The filename (without the .xbm extension) is also
  * used for the C identifiers of the XBM, whereby non

--- a/generated/8.4/imap.php
+++ b/generated/8.4/imap.php
@@ -1720,10 +1720,10 @@ function imap_renamemailbox(\IMAP\Connection $imap, string $from, string $to): v
 /**
  * Returns a properly formatted email address as defined in RFC2822 given the needed information.
  *
- * @param string|null $mailbox The mailbox name, see imap_open for more
+ * @param null|string $mailbox The mailbox name, see imap_open for more
  * information
- * @param string|null $hostname The email host part
- * @param string|null $personal The name of the account owner
+ * @param null|string $hostname The email host part
+ * @param null|string $personal The name of the account owner
  * @return string Returns a string properly formatted email address as defined in RFC2822.
  * @throws ImapException
  *

--- a/generated/8.4/ldap.php
+++ b/generated/8.4/ldap.php
@@ -65,8 +65,8 @@ function ldap_add(\LDAP\Connection $ldap, string $dn, array $entry, ?array $cont
  * Binds to the LDAP directory with specified RDN and password.
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
- * @param string|null $dn
- * @param string|null $password
+ * @param null|string $dn
+ * @param null|string $password
  * @throws LdapException
  *
  */
@@ -120,7 +120,7 @@ function ldap_compare(\LDAP\Connection $ldap, string $dn, string $attribute, str
  *
  * @param resource $link An LDAP resource, returned by ldap_connect.
  * @param resource $result
- * @param string|null $cookie An opaque structure sent by the server.
+ * @param null|string $cookie An opaque structure sent by the server.
  * @param int|null $estimated The estimated number of entries to retrieve.
  * @throws LdapException
  *
@@ -276,10 +276,10 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  * @param string $request_oid The extended operation request OID. You may use one of LDAP_EXOP_START_TLS, LDAP_EXOP_MODIFY_PASSWD, LDAP_EXOP_REFRESH, LDAP_EXOP_WHO_AM_I, LDAP_EXOP_TURN, or a string with the OID of the operation you want to send.
  * @param string $request_data The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
  * @param array|null $controls Array of LDAP Controls to send with the request.
- * @param string|null $response_data Will be filled with the extended operation response data if provided.
+ * @param null|string $response_data Will be filled with the extended operation response data if provided.
  * If not provided you may use ldap_parse_exop on the result object
  * later to get this data.
- * @param string|null $response_oid Will be filled with the response OID if provided, usually equal to the request OID.
+ * @param null|string $response_oid Will be filled with the response OID if provided, usually equal to the request OID.
  * @return bool|resource When used with response_data, returns TRUE on success.
  * When used without response_data, returns a result identifier.
  * @throws LdapException
@@ -927,8 +927,8 @@ function ldap_next_attribute(\LDAP\Connection $ldap, \LDAP\ResultEntry $entry): 
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param \LDAP\Result $result An LDAP\Result instance, returned by ldap_list or ldap_search.
- * @param string|null $response_data Will be filled by the response data.
- * @param string|null $response_oid Will be filled by the response OID.
+ * @param null|string $response_data Will be filled by the response data.
+ * @param null|string $response_oid Will be filled by the response OID.
  * @throws LdapException
  *
  */
@@ -949,9 +949,9 @@ function ldap_parse_exop(\LDAP\Connection $ldap, \LDAP\Result $result, ?string &
  * @param \LDAP\Result $result An LDAP\Result instance, returned by ldap_list or ldap_search.
  * @param int|null $error_code A reference to a variable that will be set to the LDAP error code in
  * the result, or 0 if no error occurred.
- * @param string|null $matched_dn A reference to a variable that will be set to a matched DN if one was
+ * @param null|string $matched_dn A reference to a variable that will be set to a matched DN if one was
  * recognised within the request, otherwise it will be set to NULL.
- * @param string|null $error_message A reference to a variable that will be set to the LDAP error message in
+ * @param null|string $error_message A reference to a variable that will be set to the LDAP error message in
  * the result, or an empty string if no error occurred.
  * @param array|null $referrals A reference to a variable that will be set to an array set
  * to all of the referral strings in the result, or an empty array if no
@@ -1040,7 +1040,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
 /**
  * Sets the value of the specified option to be value.
  *
- * @param resource|null $ldap Either an LDAP\Connection instance, returned by
+ * @param null|resource $ldap Either an LDAP\Connection instance, returned by
  * ldap_connect, to set the option for that connection,
  * or NULL to set the option globally.
  * @param int $option The parameter option can be one of:

--- a/generated/8.4/mbstring.php
+++ b/generated/8.4/mbstring.php
@@ -145,7 +145,7 @@ function mb_detect_order($encoding = null)
  * not used anywhere else.
  * @param string $string The string being checked.
  * @param string $options The search option. See mb_regex_set_options for explanation.
- * @return string|null The resultant string on success.
+ * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
  * @throws MbstringException
@@ -175,7 +175,7 @@ function mb_ereg_replace_callback(string $pattern, callable $callback, string $s
  * @param string $replacement The replacement text.
  * @param string $string The string being checked.
  * @param string $options
- * @return string|null The resultant string on success.
+ * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
  * @throws MbstringException
@@ -504,7 +504,7 @@ function mb_regex_encoding(?string $encoding = null)
  * This parameter is not automatically encoded.
  * @param string $subject The subject of the mail.
  * @param string $message The message of the mail.
- * @param array|string|null $additional_headers String or array to be inserted at the end of the email header.
+ * @param array|null|string $additional_headers String or array to be inserted at the end of the email header.
  *
  * This is typically used to add extra headers (From, Cc, and Bcc).
  * Multiple extra headers should be separated with a CRLF (\r\n).

--- a/generated/8.4/network.php
+++ b/generated/8.4/network.php
@@ -257,7 +257,7 @@ function dns_get_record(string $hostname, int $type = DNS_ANY, ?array &$authorit
  * indication that the error occurred before the
  * connect() call. This is most likely due to a
  * problem initializing the socket.
- * @param string|null $error_message The error message as a string.
+ * @param null|string $error_message The error message as a string.
  * @param float $timeout The connection timeout, in seconds. When NULL, the
  * default_socket_timeout php.ini setting is used.
  *
@@ -552,7 +552,7 @@ function net_get_interfaces(): array
  * @param string $hostname
  * @param int $port
  * @param int|null $error_code
- * @param string|null $error_message
+ * @param null|string $error_message
  * @param float $timeout
  * @return resource pfsockopen returns a file pointer which may be used
  * together with the other file functions (such as

--- a/generated/8.4/openssl.php
+++ b/generated/8.4/openssl.php
@@ -48,7 +48,7 @@ function openssl_cipher_key_length(string $cipher_algo): int
  * @param string $input_filename The name of a file containing encrypted content.
  * @param string $output_filename The name of the file to deposit the decrypted content.
  * @param \OpenSSLCertificate|string $certificate The name of the file containing a certificate of the recipient.
- * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key The name of the file containing a PKCS#8 key.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|null|string $private_key The name of the file containing a PKCS#8 key.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
@@ -126,7 +126,7 @@ function openssl_cms_read(string $input_filename, array &$certificates): void
  * @param int $flags Flags to be passed to cms_sign.
  * @param int $encoding The encoding of the output file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
- * @param string|null $untrusted_certificates_filename Intermediate certificates to be included in the signature.
+ * @param null|string $untrusted_certificates_filename Intermediate certificates to be included in the signature.
  * @throws OpensslException
  *
  */
@@ -149,12 +149,12 @@ function openssl_cms_sign(string $input_filename, string $output_filename, $cert
  *
  * @param string $input_filename The input file.
  * @param int $flags Flags to pass to cms_verify.
- * @param string|null $certificates A file with the signer certificate and optionally intermediate certificates.
+ * @param null|string $certificates A file with the signer certificate and optionally intermediate certificates.
  * @param array $ca_info An array containing self-signed certificate authority certificates.
- * @param string|null $untrusted_certificates_filename A file containing additional intermediate certificates.
- * @param string|null $content A file pointing to the content when signatures are detached.
- * @param string|null $pk7
- * @param string|null $sigfile A file to save the signature to.
+ * @param null|string $untrusted_certificates_filename A file containing additional intermediate certificates.
+ * @param null|string $content A file pointing to the content when signatures are detached.
+ * @param null|string $pk7
+ * @param null|string $sigfile A file to save the signature to.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
@@ -219,7 +219,7 @@ function openssl_csr_export_to_file($csr, string $output_filename, bool $no_text
  * reference.
  *
  * @param \OpenSSLCertificateSigningRequest|string $csr See CSR parameters for a list of valid values.
- * @param string|null $output on success, this string will contain the PEM
+ * @param null|string $output on success, this string will contain the PEM
  * encoded CSR
  * @param bool $no_text
  * The optional parameter notext affects
@@ -422,7 +422,7 @@ function openssl_csr_new(array $distinguished_names, ?\OpenSSLAsymmetricKey &$pr
  * It can also be the path to a PEM encoded CSR when specified as
  * file://path/to/csr or an exported string generated
  * by openssl_csr_export.
- * @param \OpenSSLCertificate|string|null $ca_certificate The generated certificate will be signed by ca_certificate.
+ * @param \OpenSSLCertificate|null|string $ca_certificate The generated certificate will be signed by ca_certificate.
  * If ca_certificate is NULL, the generated certificate
  * will be a self-signed certificate.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key is the private key that corresponds to
@@ -434,7 +434,7 @@ function openssl_csr_new(array $distinguished_names, ?\OpenSSLAsymmetricKey &$pr
  * options.
  * @param int $serial An optional the serial number of issued certificate. If not specified
  * it will default to 0.
- * @param string|null $serial_hex
+ * @param null|string $serial_hex
  * @return \OpenSSLCertificate Returns an OpenSSLCertificate on success.
  * @throws OpensslException
  *
@@ -614,7 +614,7 @@ function openssl_get_curve_names(): array
  * associated with the private key. See openssl_seal for more information.
  *
  * @param string $data The sealed data.
- * @param string|null $output If the call is successful the opened data is returned in this parameter.
+ * @param null|string $output If the call is successful the opened data is returned in this parameter.
  * @param string $encrypted_key The encrypted symmetric key that can be decrypted using private_key.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key The private key used for decrypting encrypted_key.
  * @param string $cipher_algo The cipher method used for decryption of data.
@@ -723,7 +723,7 @@ function openssl_pkcs12_export_to_file($certificate, string $output_filename, $p
  * output in a PKCS#12 file format.
  *
  * @param \OpenSSLCertificate|string $certificate See Key/Certificate parameters for a list of valid values.
- * @param string|null $output On success, this will hold the PKCS#12.
+ * @param null|string $output On success, this will hold the PKCS#12.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key Private key component of PKCS#12 file.
  * See Public/Private Key parameters for a list of valid values.
  * @param string $passphrase Encryption password for unlocking the PKCS#12 file.
@@ -792,7 +792,7 @@ function openssl_pkcs12_read(string $pkcs12, ?array &$certificates, string $pass
  * @param string $output_filename The decrypted message is written to the file specified by
  * output_filename.
  * @param \OpenSSLCertificate|string $certificate
- * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|null|string $private_key
  * @throws OpensslException
  *
  */
@@ -929,7 +929,7 @@ function openssl_pkey_derive($public_key, $private_key, int $key_length = 0): st
  *
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param string $output_filename Path to the output file.
- * @param string|null $passphrase The key can be optionally protected by a
+ * @param null|string $passphrase The key can be optionally protected by a
  * passphrase.
  * @param array $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
@@ -960,8 +960,8 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * output (which is passed by reference).
  *
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
- * @param string|null $output
- * @param string|null $passphrase The key is optionally protected by passphrase.
+ * @param null|string $output
+ * @param null|string $passphrase The key is optionally protected by passphrase.
  * @param array $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file.  See openssl_csr_new for more
@@ -1027,7 +1027,7 @@ function openssl_pkey_get_details(\OpenSSLAsymmetricKey $key): array
  *
  * A PEM formatted private key.
  *
- * @param string|null $passphrase The optional parameter passphrase must be used
+ * @param null|string $passphrase The optional parameter passphrase must be used
  * if the specified key is encrypted (protected by a passphrase).
  * @return \OpenSSLAsymmetricKey Returns an OpenSSLAsymmetricKey instance on success.
  * @throws OpensslException
@@ -1116,7 +1116,7 @@ function openssl_pkey_new(?array $options = null): \OpenSSLAsymmetricKey
  * You can use this function e.g. to decrypt data which is supposed to only be available to you.
  *
  * @param string $data
- * @param string|null $decrypted_data
+ * @param null|string $decrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key must be the private key that corresponds
  * to the public key that was used to encrypt the data.
  * @param int $padding padding can be one of
@@ -1147,7 +1147,7 @@ function openssl_private_decrypt(string $data, ?string &$decrypted_data, $privat
  * is not written by someone else.
  *
  * @param string $data
- * @param string|null $encrypted_data
+ * @param null|string $encrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key must be the private key that corresponds
  * to the public key that will be used to decrypt the data.
  * @param int $padding padding can be one of
@@ -1176,7 +1176,7 @@ function openssl_private_encrypt(string $data, ?string &$encrypted_data, $privat
  * owner of the private key.
  *
  * @param string $data
- * @param string|null $decrypted_data
+ * @param null|string $decrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key public_key must be the public key that corresponds
  * to the private key that was used to encrypt the data.
  * @param int $padding padding can be one of
@@ -1206,7 +1206,7 @@ function openssl_public_decrypt(string $data, ?string &$decrypted_data, $public_
  * in database.
  *
  * @param string $data
- * @param string|null $encrypted_data This will hold the result of the encryption.
+ * @param null|string $encrypted_data This will hold the result of the encryption.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key public_key must be the public key that corresponds
  * to the private key that will be used to decrypt the data.
  * @param int $padding padding can be one of
@@ -1238,7 +1238,7 @@ function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_
  * iv.
  *
  * @param string $data The data to seal.
- * @param string|null $sealed_data The sealed data.
+ * @param null|string $sealed_data The sealed data.
  * @param array|null $encrypted_keys Array of encrypted keys.
  * @param array $public_key Array of OpenSSLAsymmetricKey instances containing public keys.
  * @param string $cipher_algo The cipher method.
@@ -1249,7 +1249,7 @@ function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_
  * method.
  *
  *
- * @param string|null $iv The initialization vector for decryption of data. It is required if
+ * @param null|string $iv The initialization vector for decryption of data. It is required if
  * the cipher method requires IV. This can be found out by calling
  * openssl_cipher_iv_length with cipher_algo.
  * @return int Returns the length of the sealed data on success.
@@ -1278,7 +1278,7 @@ function openssl_seal(string $data, ?string &$sealed_data, ?array &$encrypted_ke
  * not encrypted.
  *
  * @param string $data The string of data you wish to sign
- * @param string|null $signature If the call was successful the signature is returned in
+ * @param null|string $signature If the call was successful the signature is returned in
  * signature.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key OpenSSLAsymmetricKey - a key, returned by openssl_get_privatekey
  *
@@ -1303,7 +1303,7 @@ function openssl_sign(string $data, ?string &$signature, $private_key, $algorith
  * Exports challenge from encoded signed public key and challenge
  *
  * @param string $spki Expects a valid signed public key and challenge
- * @return string|null Returns the associated challenge string.
+ * @return null|string Returns the associated challenge string.
  * @throws OpensslException
  *
  */
@@ -1322,7 +1322,7 @@ function openssl_spki_export_challenge(string $spki): ?string
  * Exports PEM formatted public key from encoded signed public key and challenge
  *
  * @param string $spki Expects a valid signed public key and challenge
- * @return string|null Returns the associated PEM formatted public key.
+ * @return null|string Returns the associated PEM formatted public key.
  * @throws OpensslException
  *
  */
@@ -1347,7 +1347,7 @@ function openssl_spki_export(string $spki): ?string
  * CSR.
  * @param string $challenge The challenge associated to associate with the SPKAC
  * @param int $digest_algo The digest algorithm. See openssl_get_md_method().
- * @return string|null Returns a signed public key and challenge string.
+ * @return null|string Returns a signed public key and challenge string.
  * @throws OpensslException
  *
  */
@@ -1518,7 +1518,7 @@ function openssl_x509_export_to_file($certificate, string $output_filename, bool
  * output in a PEM encoded format.
  *
  * @param \OpenSSLCertificate|string $certificate See Key/Certificate parameters for a list of valid values.
- * @param string|null $output On success, this will hold the PEM.
+ * @param null|string $output On success, this will hold the PEM.
  * @param bool $no_text
  * The optional parameter notext affects
  * the verbosity of the output; if it is FALSE, then additional human-readable

--- a/generated/8.4/outcontrol.php
+++ b/generated/8.4/outcontrol.php
@@ -195,7 +195,7 @@ function ob_get_flush(): string
  * See
  * for a detailed description of output buffers.
  *
- * @param array|callable|string|null $callback An optional callback callable may be
+ * @param array|callable|null|string $callback An optional callback callable may be
  * specified. It can also be bypassed by passing NULL.
  *
  * callback is invoked when the output buffer is

--- a/generated/8.4/pcre.php
+++ b/generated/8.4/pcre.php
@@ -390,7 +390,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  *
  * @param string $pattern The pattern to search for, as a string.
  * @param string $subject The input string.
- * @param string[]|null $matches If matches is provided, then it is filled with
+ * @param null|string[] $matches If matches is provided, then it is filled with
  * the results of search. $matches[0] will contain the
  * text that matched the full pattern, $matches[1]
  * will have the text that matched the first captured parenthesized

--- a/generated/8.4/pgsql.php
+++ b/generated/8.4/pgsql.php
@@ -1193,7 +1193,7 @@ function pg_query(?\PgSql\Connection $connection = null, ?string $query = null):
  * PGSQL_DIAG_CONTEXT, PGSQL_DIAG_SOURCE_FILE,
  * PGSQL_DIAG_SOURCE_LINE or
  * PGSQL_DIAG_SOURCE_FUNCTION.
- * @return string|null A string containing the contents of the error field, NULL if the field does not exist.
+ * @return null|string A string containing the contents of the error field, NULL if the field does not exist.
  * @throws PgsqlException
  *
  */

--- a/generated/8.4/sockets.php
+++ b/generated/8.4/sockets.php
@@ -373,7 +373,7 @@ function socket_get_option(\Socket $socket, int $level, int $option)
  *
  * @param \Socket $socket A Socket instance created with socket_create
  * or socket_accept.
- * @param string|null $address If the given socket is of type AF_INET or
+ * @param null|string $address If the given socket is of type AF_INET or
  * AF_INET6, socket_getpeername
  * will return the peers (remote) IP address in
  * appropriate notation (e.g. 127.0.0.1 or
@@ -405,7 +405,7 @@ function socket_getpeername(\Socket $socket, ?string &$address, ?int &$port = nu
  *
  * @param \Socket $socket A Socket instance created with socket_create
  * or socket_accept.
- * @param string|null $address If the given socket is of type AF_INET
+ * @param null|string $address If the given socket is of type AF_INET
  * or AF_INET6, socket_getsockname
  * will return the local IP address in appropriate notation (e.g.
  * 127.0.0.1 or fe80::1) in the

--- a/generated/8.4/sqlsrv.php
+++ b/generated/8.4/sqlsrv.php
@@ -283,7 +283,7 @@ function sqlsrv_fetch_array($stmt, ?int $fetchType = null, ?int $row = null, ?in
  * SQLSRV_SCROLL_ABSOLUTE or
  * SQLSRV_SCROLL_RELATIVE. Note that the first row in
  * a result set has index 0.
- * @return object|null Returns an object on success, NULL if there are no more rows to return,
+ * @return null|object Returns an object on success, NULL if there are no more rows to return,
  * and FALSE if an error occurs or if the specified class does not exist.
  * @throws SqlsrvException
  *

--- a/generated/8.4/stream.php
+++ b/generated/8.4/stream.php
@@ -393,7 +393,7 @@ function stream_set_timeout($stream, int $seconds, int $microseconds = 0): void
  * @param float $timeout Override the default socket accept timeout. Time should be given in
  * seconds. By default, default_socket_timeout
  * is used.
- * @param string|null $peer_name Will be set to the name (address) of the client which connected, if
+ * @param null|string $peer_name Will be set to the name (address) of the client which connected, if
  * included and available from the selected transport.
  *
  * Can also be determined later using
@@ -432,7 +432,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  *
  * @param string $address Address to the socket to connect to.
  * @param int|null $error_code Will be set to the system level error number if connection fails.
- * @param string|null $error_message Will be set to the system level error message if the connection fails.
+ * @param null|string $error_message Will be set to the system level error message if the connection fails.
  * @param float $timeout Number of seconds until the connect() system call
  * should timeout. By default, default_socket_timeout
  * is used.
@@ -460,7 +460,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * STREAM_CLIENT_CONNECT (default),
  * STREAM_CLIENT_ASYNC_CONNECT and
  * STREAM_CLIENT_PERSISTENT.
- * @param resource|null $context A valid context resource created with stream_context_create.
+ * @param null|resource $context A valid context resource created with stream_context_create.
  * @return resource On success a stream resource is returned which may
  * be used together with the other file functions (such as
  * fgets, fgetss,
@@ -573,7 +573,7 @@ function stream_socket_pair(int $domain, int $type, int $protocol): array
  *
  *
  *
- * @param string|null $address If address is provided it will be populated with
+ * @param null|string $address If address is provided it will be populated with
  * the address of the remote socket.
  * @return string Returns the read data, as a string.
  * @throws StreamException
@@ -661,13 +661,13 @@ function stream_socket_sendto($socket, string $data, int $flags = 0, string $add
  * call. This is most likely due to a problem initializing the socket.
  * Note that the error_code and
  * error_message arguments will always be passed by reference.
- * @param string|null $error_message See error_code description.
+ * @param null|string $error_message See error_code description.
  * @param int $flags A bitmask field which may be set to any combination of socket creation
  * flags.
  *
  * For UDP sockets, you must use STREAM_SERVER_BIND as
  * the flags parameter.
- * @param resource|null $context
+ * @param null|resource $context
  * @return resource Returns the created stream.
  * @throws StreamException
  *

--- a/generated/8.4/url.php
+++ b/generated/8.4/url.php
@@ -36,7 +36,7 @@ function base64_decode(string $string, bool $strict = false): string
  * @param bool $associative If the optional associative parameter is set to true,
  * get_headers parses the response and sets the
  * array's keys.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create, or NULL to use the
  * default context.
  * @return array Returns an indexed or associative array with the headers.
@@ -124,7 +124,7 @@ function get_meta_tags(string $filename, bool $use_include_path = false): array
  * URL component as a string (except when
  * PHP_URL_PORT is given, in which case the return
  * value will be an int).
- * @return array|int|string|null On seriously malformed URLs, parse_url.
+ * @return array|int|null|string On seriously malformed URLs, parse_url.
  *
  * If the component parameter is omitted, an
  * associative array is returned. At least one element will be

--- a/generated/8.4/xdiff.php
+++ b/generated/8.4/xdiff.php
@@ -214,7 +214,7 @@ function xdiff_string_patch_binary(string $str, string $patch): string
  *
  * Starting from version 1.5.0, you can also use binary OR to enable
  * XDIFF_PATCH_IGNORESPACE flag.
- * @param string|null $error If provided then rejected parts are stored inside this variable.
+ * @param null|string $error If provided then rejected parts are stored inside this variable.
  * @return string Returns the patched string.
  * @throws XdiffException
  *

--- a/generated/8.5/datetime.php
+++ b/generated/8.5/datetime.php
@@ -41,7 +41,7 @@ function date_create_immutable(string $datetime = "now", ?\DateTimeZone $timezon
  * FALSE instead of an exception if the passed in
  * datetime string is invalid.
  *
- * @param string|null $datetime
+ * @param null|string $datetime
  * @param \DateTimeZone|null $timezone
  * @return \DateTime Returns a new DateTime instance
  * @throws DatetimeException

--- a/generated/8.5/dir.php
+++ b/generated/8.5/dir.php
@@ -53,7 +53,7 @@ function chroot(string $directory): void
  * given directory is opened.
  *
  * @param string $directory Directory to open
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return \Directory Returns an instance of Directory, or FALSE in case of error.
  * @throws DirException
@@ -104,7 +104,7 @@ function getcwd(): string
  * rewinddir calls.
  *
  * @param string $directory The directory path that is to be opened
- * @param resource|null $context For a description of the context parameter,
+ * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return resource Returns a directory handle resource on success
@@ -136,7 +136,7 @@ function opendir(string $directory, $context = null)
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
  * SCANDIR_SORT_NONE then the result is unsorted.
- * @param resource|null $context For a description of the context parameter,
+ * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
  * @return array Returns an array of filenames on success. If directory is not a directory, then

--- a/generated/8.5/exec.php
+++ b/generated/8.5/exec.php
@@ -170,9 +170,9 @@ function proc_nice(int $priority): void
  * passing passphrases to programs like PGP, GPG and openssl in a more
  * secure manner. It is also useful for reading status information
  * provided by those programs on auxiliary file descriptors.
- * @param resource[]|null $pipes Will be set to an indexed array of file pointers that correspond to
+ * @param null|resource[] $pipes Will be set to an indexed array of file pointers that correspond to
  * PHP's end of any pipes that are created.
- * @param string|null $cwd The initial working dir for the command. This must be an
+ * @param null|string $cwd The initial working dir for the command. This must be an
  * absolute directory path, or NULL
  * if you want to use the default value (the working dir of the current
  * PHP process)
@@ -231,7 +231,7 @@ function proc_open(string $command, array $descriptor_spec, ?array &$pipes, ?str
  * This function is identical to the backtick operator.
  *
  * @param string $command The command that will be executed.
- * @return string|null A string containing the output from the executed command or NULL if an error occurs or the command produces no output.
+ * @return null|string A string containing the output from the executed command or NULL if an error occurs or the command produces no output.
  * @throws ExecException
  *
  */

--- a/generated/8.5/filesystem.php
+++ b/generated/8.5/filesystem.php
@@ -100,7 +100,7 @@ function chown(string $filename, $user): void
  * existing files.
  *
  * If the destination file already exists, it will be overwritten.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create.
  * @throws FilesystemException
  *
@@ -244,7 +244,7 @@ function fflush($stream): void
  * This is not possible if strict typing
  * is enabled, since FILE_USE_INCLUDE_PATH is an
  * int. Use TRUE instead.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create. If you don't need to use a
  * custom context, you can skip this parameter by NULL.
  * @param int $offset The offset where the reading starts on the original stream.
@@ -347,7 +347,7 @@ function file_get_contents(string $filename, bool $use_include_path = false, $co
  *
  *
  *
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create.
  * @return int This function returns the number of bytes that were written to the file.
  * @throws FilesystemException
@@ -416,7 +416,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  *
  *
  *
- * @param resource|null $context
+ * @param null|resource $context
  * @return array Returns the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns FALSE.
@@ -862,7 +862,7 @@ function flock($stream, int $operation, ?int &$would_block = null): void
  * @param bool $use_include_path The optional third use_include_path parameter
  * can be set to TRUE if you want to search for the file in the
  * include_path, too.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return resource Returns a file pointer resource on success
  * @throws FilesystemException
@@ -1224,7 +1224,7 @@ function lstat(string $filename): array
  * umask.
  * @param bool $recursive If TRUE, then any parent directories to the directory specified will
  * also be created, with the same permissions.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1383,7 +1383,7 @@ function popen(string $command, string $mode)
  * @param string $filename The filename being read.
  * @param bool $use_include_path You can use the optional second parameter and set it to TRUE, if
  * you want to search for the file in the include_path, too.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @return int Returns the number of bytes read from the file on success
  * @throws FilesystemException
@@ -1479,7 +1479,7 @@ function realpath(string $path): string
  * Otherwise rename fails and issues E_WARNING.
  *
  *
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1523,7 +1523,7 @@ function rewind($stream): void
  * A E_WARNING level error will be generated on failure.
  *
  * @param string $directory Path to the directory.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *
@@ -1654,7 +1654,7 @@ function touch(string $filename, ?int $mtime = null, ?int $atime = null): void
  *
  * If the file is a symlink, the symlink will be deleted. On Windows, to delete
  * a symlink to a directory, rmdir has to be used instead.
- * @param resource|null $context A context stream
+ * @param null|resource $context A context stream
  * resource.
  * @throws FilesystemException
  *

--- a/generated/8.5/ftp.php
+++ b/generated/8.5/ftp.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\FtpException;
  *
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param int $size The number of bytes to allocate.
- * @param string|null $response A textual representation of the servers response will be returned by
+ * @param null|string $response A textual representation of the servers response will be returned by
  * reference in response if a variable is provided.
  * @throws FtpException
  *

--- a/generated/8.5/image.php
+++ b/generated/8.5/image.php
@@ -267,7 +267,7 @@ function imagearc(\GdImage $image, int $center_x, int $center_y, int $width, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst quality, smaller file)
  * to 100 (best quality, larger file).
  * If -1 is provided, the default value 30 is used.
@@ -300,7 +300,7 @@ function imageavif(\GdImage $image, $file = null, int $quality = -1, int $speed 
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  *
  * NULL is invalid if the compressed arguments is
  * not used.
@@ -1715,7 +1715,7 @@ function imagegammacorrect(\GdImage $image, float $input_gamma, float $output_ga
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
@@ -1738,7 +1738,7 @@ function imagegd(\GdImage $image, $file = null): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $chunk_size Chunk size.
  * @param int $mode Either IMG_GD2_RAW or
  * IMG_GD2_COMPRESSED. Default is
@@ -1778,7 +1778,7 @@ function imagegd2(\GdImage $image, $file = null, int $chunk_size = 128, int $mod
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @throws ImageException
  *
  */
@@ -1840,7 +1840,7 @@ function imagegrabwindow(int $handle, bool $client_area = false): \GdImage
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality is optional, and ranges from 0 (worst
  * quality, smaller file) to 100 (best quality, biggest file). The
  * default (-1) uses the default IJG quality value (about 75).
@@ -2024,7 +2024,7 @@ function imageloadfont(string $filename): int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  *
  * NULL is invalid if the quality and
  * filters arguments are not used.
@@ -2750,7 +2750,7 @@ function imagettftext(\GdImage $image, float $size, float $angle, int $x, int $y
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black.
@@ -2778,7 +2778,7 @@ function imagewbmp(\GdImage $image, $file = null, ?int $foreground_color = null)
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
+ * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
  * @param int $quality quality ranges from 0 (worst
  * quality, smaller file) to 100 (best quality, biggest file).
  * @throws ImageException
@@ -2806,7 +2806,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param resource|string|null $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
+ * @param null|resource|string $filename The path to save the file to, given as string. If NULL, the raw image stream will be output directly.
  *
  * The filename (without the .xbm extension) is also
  * used for the C identifiers of the XBM, whereby non

--- a/generated/8.5/imap.php
+++ b/generated/8.5/imap.php
@@ -1720,10 +1720,10 @@ function imap_renamemailbox(\IMAP\Connection $imap, string $from, string $to): v
 /**
  * Returns a properly formatted email address as defined in RFC2822 given the needed information.
  *
- * @param string|null $mailbox The mailbox name, see imap_open for more
+ * @param null|string $mailbox The mailbox name, see imap_open for more
  * information
- * @param string|null $hostname The email host part
- * @param string|null $personal The name of the account owner
+ * @param null|string $hostname The email host part
+ * @param null|string $personal The name of the account owner
  * @return string Returns a string properly formatted email address as defined in RFC2822.
  * @throws ImapException
  *

--- a/generated/8.5/ldap.php
+++ b/generated/8.5/ldap.php
@@ -65,8 +65,8 @@ function ldap_add(\LDAP\Connection $ldap, string $dn, array $entry, ?array $cont
  * Binds to the LDAP directory with specified RDN and password.
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
- * @param string|null $dn
- * @param string|null $password
+ * @param null|string $dn
+ * @param null|string $password
  * @throws LdapException
  *
  */
@@ -120,7 +120,7 @@ function ldap_compare(\LDAP\Connection $ldap, string $dn, string $attribute, str
  *
  * @param resource $link An LDAP resource, returned by ldap_connect.
  * @param resource $result
- * @param string|null $cookie An opaque structure sent by the server.
+ * @param null|string $cookie An opaque structure sent by the server.
  * @param int|null $estimated The estimated number of entries to retrieve.
  * @throws LdapException
  *
@@ -276,10 +276,10 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  * @param string $request_oid The extended operation request OID. You may use one of LDAP_EXOP_START_TLS, LDAP_EXOP_MODIFY_PASSWD, LDAP_EXOP_REFRESH, LDAP_EXOP_WHO_AM_I, LDAP_EXOP_TURN, or a string with the OID of the operation you want to send.
  * @param string $request_data The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
  * @param array|null $controls Array of LDAP Controls to send with the request.
- * @param string|null $response_data Will be filled with the extended operation response data if provided.
+ * @param null|string $response_data Will be filled with the extended operation response data if provided.
  * If not provided you may use ldap_parse_exop on the result object
  * later to get this data.
- * @param string|null $response_oid Will be filled with the response OID if provided, usually equal to the request OID.
+ * @param null|string $response_oid Will be filled with the response OID if provided, usually equal to the request OID.
  * @return bool|resource When used with response_data, returns TRUE on success.
  * When used without response_data, returns a result identifier.
  * @throws LdapException
@@ -927,8 +927,8 @@ function ldap_next_attribute(\LDAP\Connection $ldap, \LDAP\ResultEntry $entry): 
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param \LDAP\Result $result An LDAP\Result instance, returned by ldap_list or ldap_search.
- * @param string|null $response_data Will be filled by the response data.
- * @param string|null $response_oid Will be filled by the response OID.
+ * @param null|string $response_data Will be filled by the response data.
+ * @param null|string $response_oid Will be filled by the response OID.
  * @throws LdapException
  *
  */
@@ -949,9 +949,9 @@ function ldap_parse_exop(\LDAP\Connection $ldap, \LDAP\Result $result, ?string &
  * @param \LDAP\Result $result An LDAP\Result instance, returned by ldap_list or ldap_search.
  * @param int|null $error_code A reference to a variable that will be set to the LDAP error code in
  * the result, or 0 if no error occurred.
- * @param string|null $matched_dn A reference to a variable that will be set to a matched DN if one was
+ * @param null|string $matched_dn A reference to a variable that will be set to a matched DN if one was
  * recognised within the request, otherwise it will be set to NULL.
- * @param string|null $error_message A reference to a variable that will be set to the LDAP error message in
+ * @param null|string $error_message A reference to a variable that will be set to the LDAP error message in
  * the result, or an empty string if no error occurred.
  * @param array|null $referrals A reference to a variable that will be set to an array set
  * to all of the referral strings in the result, or an empty array if no
@@ -1040,7 +1040,7 @@ function ldap_sasl_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $pas
 /**
  * Sets the value of the specified option to be value.
  *
- * @param resource|null $ldap Either an LDAP\Connection instance, returned by
+ * @param null|resource $ldap Either an LDAP\Connection instance, returned by
  * ldap_connect, to set the option for that connection,
  * or NULL to set the option globally.
  * @param int $option The parameter option can be one of:

--- a/generated/8.5/mbstring.php
+++ b/generated/8.5/mbstring.php
@@ -145,7 +145,7 @@ function mb_detect_order($encoding = null)
  * not used anywhere else.
  * @param string $string The string being checked.
  * @param string $options The search option. See mb_regex_set_options for explanation.
- * @return string|null The resultant string on success.
+ * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
  * @throws MbstringException
@@ -175,7 +175,7 @@ function mb_ereg_replace_callback(string $pattern, callable $callback, string $s
  * @param string $replacement The replacement text.
  * @param string $string The string being checked.
  * @param string $options
- * @return string|null The resultant string on success.
+ * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
  * @throws MbstringException
@@ -504,7 +504,7 @@ function mb_regex_encoding(?string $encoding = null)
  * This parameter is not automatically encoded.
  * @param string $subject The subject of the mail.
  * @param string $message The message of the mail.
- * @param array|string|null $additional_headers String or array to be inserted at the end of the email header.
+ * @param array|null|string $additional_headers String or array to be inserted at the end of the email header.
  *
  * This is typically used to add extra headers (From, Cc, and Bcc).
  * Multiple extra headers should be separated with a CRLF (\r\n).

--- a/generated/8.5/network.php
+++ b/generated/8.5/network.php
@@ -257,7 +257,7 @@ function dns_get_record(string $hostname, int $type = DNS_ANY, ?array &$authorit
  * indication that the error occurred before the
  * connect() call. This is most likely due to a
  * problem initializing the socket.
- * @param string|null $error_message The error message as a string.
+ * @param null|string $error_message The error message as a string.
  * @param float $timeout The connection timeout, in seconds. When NULL, the
  * default_socket_timeout php.ini setting is used.
  *
@@ -552,7 +552,7 @@ function net_get_interfaces(): array
  * @param string $hostname
  * @param int $port
  * @param int|null $error_code
- * @param string|null $error_message
+ * @param null|string $error_message
  * @param float $timeout
  * @return resource pfsockopen returns a file pointer which may be used
  * together with the other file functions (such as

--- a/generated/8.5/openssl.php
+++ b/generated/8.5/openssl.php
@@ -48,7 +48,7 @@ function openssl_cipher_key_length(string $cipher_algo): int
  * @param string $input_filename The name of a file containing encrypted content.
  * @param string $output_filename The name of the file to deposit the decrypted content.
  * @param \OpenSSLCertificate|string $certificate The name of the file containing a certificate of the recipient.
- * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key The name of the file containing a PKCS#8 key.
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|null|string $private_key The name of the file containing a PKCS#8 key.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
@@ -126,7 +126,7 @@ function openssl_cms_read(string $input_filename, array &$certificates): void
  * @param int $flags Flags to be passed to cms_sign.
  * @param int $encoding The encoding of the output file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
- * @param string|null $untrusted_certificates_filename Intermediate certificates to be included in the signature.
+ * @param null|string $untrusted_certificates_filename Intermediate certificates to be included in the signature.
  * @throws OpensslException
  *
  */
@@ -149,12 +149,12 @@ function openssl_cms_sign(string $input_filename, string $output_filename, $cert
  *
  * @param string $input_filename The input file.
  * @param int $flags Flags to pass to cms_verify.
- * @param string|null $certificates A file with the signer certificate and optionally intermediate certificates.
+ * @param null|string $certificates A file with the signer certificate and optionally intermediate certificates.
  * @param array $ca_info An array containing self-signed certificate authority certificates.
- * @param string|null $untrusted_certificates_filename A file containing additional intermediate certificates.
- * @param string|null $content A file pointing to the content when signatures are detached.
- * @param string|null $pk7
- * @param string|null $sigfile A file to save the signature to.
+ * @param null|string $untrusted_certificates_filename A file containing additional intermediate certificates.
+ * @param null|string $content A file pointing to the content when signatures are detached.
+ * @param null|string $pk7
+ * @param null|string $sigfile A file to save the signature to.
  * @param int $encoding The encoding of the input file. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
  * @throws OpensslException
@@ -219,7 +219,7 @@ function openssl_csr_export_to_file($csr, string $output_filename, bool $no_text
  * reference.
  *
  * @param \OpenSSLCertificateSigningRequest|string $csr See CSR parameters for a list of valid values.
- * @param string|null $output on success, this string will contain the PEM
+ * @param null|string $output on success, this string will contain the PEM
  * encoded CSR
  * @param bool $no_text
  * The optional parameter notext affects
@@ -426,7 +426,7 @@ function openssl_csr_new(array $distinguished_names, ?\OpenSSLAsymmetricKey &$pr
  * It can also be the path to a PEM encoded CSR when specified as
  * file://path/to/csr or an exported string generated
  * by openssl_csr_export.
- * @param \OpenSSLCertificate|string|null $ca_certificate The generated certificate will be signed by ca_certificate.
+ * @param \OpenSSLCertificate|null|string $ca_certificate The generated certificate will be signed by ca_certificate.
  * If ca_certificate is NULL, the generated certificate
  * will be a self-signed certificate.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key is the private key that corresponds to
@@ -438,7 +438,7 @@ function openssl_csr_new(array $distinguished_names, ?\OpenSSLAsymmetricKey &$pr
  * options.
  * @param int $serial An optional the serial number of issued certificate. If not specified
  * it will default to 0.
- * @param string|null $serial_hex An optional hexadecimal string representing the serial number of the
+ * @param null|string $serial_hex An optional hexadecimal string representing the serial number of the
  * issued certificate. If set, it takes precedence over the
  * serial parameter value. If not specified or set
  * to NULL, the serial parameter value is used
@@ -622,7 +622,7 @@ function openssl_get_curve_names(): array
  * associated with the private key. See openssl_seal for more information.
  *
  * @param string $data The sealed data.
- * @param string|null $output If the call is successful the opened data is returned in this parameter.
+ * @param null|string $output If the call is successful the opened data is returned in this parameter.
  * @param string $encrypted_key The encrypted symmetric key that can be decrypted using private_key.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key The private key used for decrypting encrypted_key.
  * @param string $cipher_algo The cipher method used for decryption of data.
@@ -731,7 +731,7 @@ function openssl_pkcs12_export_to_file($certificate, string $output_filename, $p
  * output in a PKCS#12 file format.
  *
  * @param \OpenSSLCertificate|string $certificate See Key/Certificate parameters for a list of valid values.
- * @param string|null $output On success, this will hold the PKCS#12.
+ * @param null|string $output On success, this will hold the PKCS#12.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key Private key component of PKCS#12 file.
  * See Public/Private Key parameters for a list of valid values.
  * @param string $passphrase Encryption password for unlocking the PKCS#12 file.
@@ -800,7 +800,7 @@ function openssl_pkcs12_read(string $pkcs12, ?array &$certificates, string $pass
  * @param string $output_filename The decrypted message is written to the file specified by
  * output_filename.
  * @param \OpenSSLCertificate|string $certificate
- * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string|null $private_key
+ * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|null|string $private_key
  * @throws OpensslException
  *
  */
@@ -937,7 +937,7 @@ function openssl_pkey_derive($public_key, $private_key, int $key_length = 0): st
  *
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param string $output_filename Path to the output file.
- * @param string|null $passphrase The key can be optionally protected by a
+ * @param null|string $passphrase The key can be optionally protected by a
  * passphrase.
  * @param array $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
@@ -968,8 +968,8 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * output (which is passed by reference).
  *
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
- * @param string|null $output
- * @param string|null $passphrase The key is optionally protected by passphrase.
+ * @param null|string $output
+ * @param null|string $passphrase The key is optionally protected by passphrase.
  * @param array $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file.  See openssl_csr_new for more
@@ -1040,7 +1040,7 @@ function openssl_pkey_get_details(\OpenSSLAsymmetricKey $key): array
  *
  * A PEM formatted private key.
  *
- * @param string|null $passphrase The optional parameter passphrase must be used
+ * @param null|string $passphrase The optional parameter passphrase must be used
  * if the specified key is encrypted (protected by a passphrase).
  * @return \OpenSSLAsymmetricKey Returns an OpenSSLAsymmetricKey instance on success.
  * @throws OpensslException
@@ -1463,7 +1463,7 @@ function openssl_pkey_new(?array $options = null): \OpenSSLAsymmetricKey
  * You can use this function e.g. to decrypt data which is supposed to only be available to you.
  *
  * @param string $data
- * @param string|null $decrypted_data
+ * @param null|string $decrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key must be the private key that corresponds
  * to the public key that was used to encrypt the data.
  * @param int $padding padding can be one of
@@ -1494,7 +1494,7 @@ function openssl_private_decrypt(string $data, ?string &$decrypted_data, $privat
  * is not written by someone else.
  *
  * @param string $data
- * @param string|null $encrypted_data
+ * @param null|string $encrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key private_key must be the private key that corresponds
  * to the public key that will be used to decrypt the data.
  * @param int $padding padding can be one of
@@ -1523,7 +1523,7 @@ function openssl_private_encrypt(string $data, ?string &$encrypted_data, $privat
  * owner of the private key.
  *
  * @param string $data
- * @param string|null $decrypted_data
+ * @param null|string $decrypted_data
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key public_key must be the public key that corresponds
  * to the private key that was used to encrypt the data.
  * @param int $padding padding can be one of
@@ -1553,7 +1553,7 @@ function openssl_public_decrypt(string $data, ?string &$decrypted_data, $public_
  * in database.
  *
  * @param string $data
- * @param string|null $encrypted_data This will hold the result of the encryption.
+ * @param null|string $encrypted_data This will hold the result of the encryption.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $public_key public_key must be the public key that corresponds
  * to the private key that will be used to decrypt the data.
  * @param int $padding padding can be one of
@@ -1585,7 +1585,7 @@ function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_
  * iv.
  *
  * @param string $data The data to seal.
- * @param string|null $sealed_data The sealed data.
+ * @param null|string $sealed_data The sealed data.
  * @param array|null $encrypted_keys Array of encrypted keys.
  * @param array $public_key Array of OpenSSLAsymmetricKey instances containing public keys.
  * @param string $cipher_algo The cipher method.
@@ -1596,7 +1596,7 @@ function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_
  * method.
  *
  *
- * @param string|null $iv The initialization vector for decryption of data. It is required if
+ * @param null|string $iv The initialization vector for decryption of data. It is required if
  * the cipher method requires IV. This can be found out by calling
  * openssl_cipher_iv_length with cipher_algo.
  * @return int Returns the length of the sealed data on success.
@@ -1625,7 +1625,7 @@ function openssl_seal(string $data, ?string &$sealed_data, ?array &$encrypted_ke
  * not encrypted.
  *
  * @param string $data The string of data you wish to sign
- * @param string|null $signature If the call was successful the signature is returned in
+ * @param null|string $signature If the call was successful the signature is returned in
  * signature.
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key OpenSSLAsymmetricKey - a key, returned by openssl_get_privatekey
  *
@@ -1650,7 +1650,7 @@ function openssl_sign(string $data, ?string &$signature, $private_key, $algorith
  * Exports challenge from encoded signed public key and challenge
  *
  * @param string $spki Expects a valid signed public key and challenge
- * @return string|null Returns the associated challenge string.
+ * @return null|string Returns the associated challenge string.
  * @throws OpensslException
  *
  */
@@ -1669,7 +1669,7 @@ function openssl_spki_export_challenge(string $spki): ?string
  * Exports PEM formatted public key from encoded signed public key and challenge
  *
  * @param string $spki Expects a valid signed public key and challenge
- * @return string|null Returns the associated PEM formatted public key.
+ * @return null|string Returns the associated PEM formatted public key.
  * @throws OpensslException
  *
  */
@@ -1694,7 +1694,7 @@ function openssl_spki_export(string $spki): ?string
  * CSR.
  * @param string $challenge The challenge associated to associate with the SPKAC
  * @param int $digest_algo The digest algorithm. See openssl_get_md_method().
- * @return string|null Returns a signed public key and challenge string.
+ * @return null|string Returns a signed public key and challenge string.
  * @throws OpensslException
  *
  */
@@ -1865,7 +1865,7 @@ function openssl_x509_export_to_file($certificate, string $output_filename, bool
  * output in a PEM encoded format.
  *
  * @param \OpenSSLCertificate|string $certificate See Key/Certificate parameters for a list of valid values.
- * @param string|null $output On success, this will hold the PEM.
+ * @param null|string $output On success, this will hold the PEM.
  * @param bool $no_text
  * The optional parameter notext affects
  * the verbosity of the output; if it is FALSE, then additional human-readable

--- a/generated/8.5/outcontrol.php
+++ b/generated/8.5/outcontrol.php
@@ -195,7 +195,7 @@ function ob_get_flush(): string
  * See
  * for a detailed description of output buffers.
  *
- * @param array|callable|string|null $callback An optional callback callable may be
+ * @param array|callable|null|string $callback An optional callback callable may be
  * specified. It can also be bypassed by passing NULL.
  *
  * callback is invoked when the output buffer is

--- a/generated/8.5/pcre.php
+++ b/generated/8.5/pcre.php
@@ -390,7 +390,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  *
  * @param string $pattern The pattern to search for, as a string.
  * @param string $subject The input string.
- * @param string[]|null $matches If matches is provided, then it is filled with
+ * @param null|string[] $matches If matches is provided, then it is filled with
  * the results of search. $matches[0] will contain the
  * text that matched the full pattern, $matches[1]
  * will have the text that matched the first captured parenthesized

--- a/generated/8.5/pgsql.php
+++ b/generated/8.5/pgsql.php
@@ -1196,7 +1196,7 @@ function pg_query(?\PgSql\Connection $connection = null, ?string $query = null):
  * PGSQL_DIAG_CONTEXT, PGSQL_DIAG_SOURCE_FILE,
  * PGSQL_DIAG_SOURCE_LINE or
  * PGSQL_DIAG_SOURCE_FUNCTION.
- * @return string|null A string containing the contents of the error field, NULL if the field does not exist.
+ * @return null|string A string containing the contents of the error field, NULL if the field does not exist.
  * @throws PgsqlException
  *
  */

--- a/generated/8.5/sockets.php
+++ b/generated/8.5/sockets.php
@@ -373,7 +373,7 @@ function socket_get_option(\Socket $socket, int $level, int $option)
  *
  * @param \Socket $socket A Socket instance created with socket_create
  * or socket_accept.
- * @param string|null $address If the given socket is of type AF_INET or
+ * @param null|string $address If the given socket is of type AF_INET or
  * AF_INET6, socket_getpeername
  * will return the peers (remote) IP address in
  * appropriate notation (e.g. 127.0.0.1 or
@@ -405,7 +405,7 @@ function socket_getpeername(\Socket $socket, ?string &$address, ?int &$port = nu
  *
  * @param \Socket $socket A Socket instance created with socket_create
  * or socket_accept.
- * @param string|null $address If the given socket is of type AF_INET
+ * @param null|string $address If the given socket is of type AF_INET
  * or AF_INET6, socket_getsockname
  * will return the local IP address in appropriate notation (e.g.
  * 127.0.0.1 or fe80::1) in the

--- a/generated/8.5/sqlsrv.php
+++ b/generated/8.5/sqlsrv.php
@@ -283,7 +283,7 @@ function sqlsrv_fetch_array($stmt, ?int $fetchType = null, ?int $row = null, ?in
  * SQLSRV_SCROLL_ABSOLUTE or
  * SQLSRV_SCROLL_RELATIVE. Note that the first row in
  * a result set has index 0.
- * @return object|null Returns an object on success, NULL if there are no more rows to return,
+ * @return null|object Returns an object on success, NULL if there are no more rows to return,
  * and FALSE if an error occurs or if the specified class does not exist.
  * @throws SqlsrvException
  *

--- a/generated/8.5/stream.php
+++ b/generated/8.5/stream.php
@@ -393,7 +393,7 @@ function stream_set_timeout($stream, int $seconds, int $microseconds = 0): void
  * @param float $timeout Override the default socket accept timeout. Time should be given in
  * seconds. By default, default_socket_timeout
  * is used.
- * @param string|null $peer_name Will be set to the name (address) of the client which connected, if
+ * @param null|string $peer_name Will be set to the name (address) of the client which connected, if
  * included and available from the selected transport.
  *
  * Can also be determined later using
@@ -432,7 +432,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  *
  * @param string $address Address to the socket to connect to.
  * @param int|null $error_code Will be set to the system level error number if connection fails.
- * @param string|null $error_message Will be set to the system level error message if the connection fails.
+ * @param null|string $error_message Will be set to the system level error message if the connection fails.
  * @param float $timeout Number of seconds until the connect() system call
  * should timeout. By default, default_socket_timeout
  * is used.
@@ -460,7 +460,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * STREAM_CLIENT_CONNECT (default),
  * STREAM_CLIENT_ASYNC_CONNECT and
  * STREAM_CLIENT_PERSISTENT.
- * @param resource|null $context A valid context resource created with stream_context_create.
+ * @param null|resource $context A valid context resource created with stream_context_create.
  * @return resource On success a stream resource is returned which may
  * be used together with the other file functions (such as
  * fgets, fgetss,
@@ -573,7 +573,7 @@ function stream_socket_pair(int $domain, int $type, int $protocol): array
  *
  *
  *
- * @param string|null $address If address is provided it will be populated with
+ * @param null|string $address If address is provided it will be populated with
  * the address of the remote socket.
  * @return string Returns the read data, as a string.
  * @throws StreamException
@@ -661,13 +661,13 @@ function stream_socket_sendto($socket, string $data, int $flags = 0, string $add
  * call. This is most likely due to a problem initializing the socket.
  * Note that the error_code and
  * error_message arguments will always be passed by reference.
- * @param string|null $error_message See error_code description.
+ * @param null|string $error_message See error_code description.
  * @param int $flags A bitmask field which may be set to any combination of socket creation
  * flags.
  *
  * For UDP sockets, you must use STREAM_SERVER_BIND as
  * the flags parameter.
- * @param resource|null $context
+ * @param null|resource $context
  * @return resource Returns the created stream.
  * @throws StreamException
  *

--- a/generated/8.5/url.php
+++ b/generated/8.5/url.php
@@ -36,7 +36,7 @@ function base64_decode(string $string, bool $strict = false): string
  * @param bool $associative If the optional associative parameter is set to true,
  * get_headers parses the response and sets the
  * array's keys.
- * @param resource|null $context A valid context resource created with
+ * @param null|resource $context A valid context resource created with
  * stream_context_create, or NULL to use the
  * default context.
  * @return array Returns an indexed or associative array with the headers.
@@ -124,7 +124,7 @@ function get_meta_tags(string $filename, bool $use_include_path = false): array
  * URL component as a string (except when
  * PHP_URL_PORT is given, in which case the return
  * value will be an int).
- * @return array|int|string|null On seriously malformed URLs, parse_url.
+ * @return array|int|null|string On seriously malformed URLs, parse_url.
  *
  * If the component parameter is omitted, an
  * associative array is returned. At least one element will be

--- a/generated/8.5/xdiff.php
+++ b/generated/8.5/xdiff.php
@@ -214,7 +214,7 @@ function xdiff_string_patch_binary(string $str, string $patch): string
  *
  * Starting from version 1.5.0, you can also use binary OR to enable
  * XDIFF_PATCH_IGNORESPACE flag.
- * @param string|null $error If provided then rejected parts are stored inside this variable.
+ * @param null|string $error If provided then rejected parts are stored inside this variable.
  * @return string Returns the patched string.
  * @throws XdiffException
  *

--- a/generator/src/PhpStanFunctions/PhpStanType.php
+++ b/generator/src/PhpStanFunctions/PhpStanType.php
@@ -104,7 +104,6 @@ class PhpStanType
 
             $returnType = Type::toRootNamespace($returnType);
         }
-        sort($returnTypes);
         $this->types = array_unique($returnTypes);
         $this->nullable = $nullable;
         $this->falsable = $falsable;
@@ -150,6 +149,7 @@ class PhpStanType
         } elseif ($this->nullable && $errorType !== ErrorType::NULLSY) {
             $returnTypes[] = 'null';
         }
+        sort($returnTypes);
         $type = join('|', $returnTypes);
         if ($type === 'bool' && !$this->nullable && $errorType === ErrorType::FALSY) {
             // If the function only returns a boolean, since false is for error, true is for success.
@@ -189,6 +189,7 @@ class PhpStanType
                 $type = 'string';
             }
         }
+        sort($types);
 
         //if there are several distinct types, no typehint (we use distinct in case doc block contains several times the same type, for example array<int>|array<string>)
         if (count(array_unique($types)) > 1) {

--- a/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
@@ -63,12 +63,12 @@ class PhpStanTypeTest extends TestCase
 
         $param = new PhpStanType('?int|?string');
         $this->assertEquals(true, $param->isNullable());
-        $this->assertEquals('int|string|null', $param->getDocBlockType());
+        $this->assertEquals('int|null|string', $param->getDocBlockType());
         $this->assertEquals('', $param->getSignatureType());
 
         $param = new PhpStanType('?string');
         $this->assertEquals(true, $param->isNullable());
-        $this->assertEquals('string|null', $param->getDocBlockType());
+        $this->assertEquals('null|string', $param->getDocBlockType());
         $this->assertEquals('?string', $param->getSignatureType());
 
         $param = new PhpStanType('?HashContext');
@@ -81,14 +81,14 @@ class PhpStanTypeTest extends TestCase
     {
         $param = new PhpStanType('(?int)|(?string)');
         $this->assertEquals(true, $param->isNullable());
-        $this->assertEquals('int|string|null', $param->getDocBlockType());
+        $this->assertEquals('int|null|string', $param->getDocBlockType());
         $this->assertEquals('', $param->getSignatureType());
     }
 
     public function testFalsable(): void
     {
         $param = new PhpStanType('string|false');
-        $this->assertEquals('string|false', $param->getDocBlockType());
+        $this->assertEquals('false|string', $param->getDocBlockType());
         $this->assertEquals('string', $param->getSignatureType());
     }
 

--- a/generator/tests/XmlDocParser/MethodTest.php
+++ b/generator/tests/XmlDocParser/MethodTest.php
@@ -55,7 +55,7 @@ class MethodTest extends TestCase
         $params = $method->getParams();
         $this->assertEquals('string', $params[0]->getDocBlockType());
         $this->assertEquals('string', $params[0]->getSignatureType());
-        $this->assertEquals('bool|float|int|string|null', $params[1]->getDocBlockType());
+        $this->assertEquals('bool|float|int|null|string', $params[1]->getDocBlockType());
         $this->assertTrue($params[1]->isVariadic());
         $this->assertEquals('', $params[1]->getSignatureType());
 


### PR DESCRIPTION

Currently we're treating `null` and `false` as special cases, adding and removing them at various points in the process; this results in the return type list being `sorted(types-except-null) + null`. I want to remove the special-case magic, which will have the side effect of changing the return type to `sorted(types)`. I'm pulling that out into a separate PR because it makes the future PR easier to understand, and I also think it's valid to do this by itself
