### PR TITLE
More thorough nullability detection

### DIFF
--- a/generated/8.1/bzip2.php
+++ b/generated/8.1/bzip2.php
@@ -98,7 +98,7 @@ function bzread($bz, int $length = 1024): string
  * @param resource $bz The file pointer. It must be valid and must point to a file
  * successfully opened by bzopen.
  * @param string $data The written data.
- * @param int $length If supplied, writing will stop after length
+ * @param int|null $length If supplied, writing will stop after length
  * (uncompressed) bytes have been written or the end of
  * data is reached, whichever comes first.
  * @return int Returns the number of bytes written.

--- a/generated/8.1/calendar.php
+++ b/generated/8.1/calendar.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\CalendarException;
  * timestamp is given. Either way, the time is regarded
  * as local time (not UTC).
  *
- * @param int $timestamp A unix timestamp to convert.
+ * @param int|null $timestamp A unix timestamp to convert.
  * @return int A julian day number as integer.
  * @throws CalendarException
  *

--- a/generated/8.1/com.php
+++ b/generated/8.1/com.php
@@ -132,7 +132,7 @@ function com_load_typelib(string $typelib, bool $case_insensitive = true): void
  * @param object $variant variant should be either an instance of a COM
  * object, or be the name of a typelibrary (which will be resolved according
  * to the rules set out in com_load_typelib).
- * @param string $dispatch_interface The name of an IDispatch descendant interface that you want to display.
+ * @param null|string $dispatch_interface The name of an IDispatch descendant interface that you want to display.
  * @param bool $display_sink If set to TRUE, the corresponding sink interface will be displayed
  * instead.
  * @throws ComException

--- a/generated/8.1/curl.php
+++ b/generated/8.1/curl.php
@@ -75,7 +75,7 @@ function curl_exec(\CurlHandle $handle)
  *
  * @param \CurlHandle $handle A cURL handle returned by
  * curl_init.
- * @param int $option This may be one of the following constants:
+ * @param int|null $option This may be one of the following constants:
  *
  *
  *
@@ -552,7 +552,7 @@ function curl_getinfo(\CurlHandle $handle, ?int $option = null)
  * curl_setopt, curl_exec,
  * and curl_close functions.
  *
- * @param string $url If provided, the CURLOPT_URL option will be set
+ * @param null|string $url If provided, the CURLOPT_URL option will be set
  * to its value. You can manually set this using the
  * curl_setopt function.
  *

--- a/generated/8.1/datetime.php
+++ b/generated/8.1/datetime.php
@@ -186,11 +186,11 @@ function date_sun_info(int $timestamp, float $latitude, float $longitude): array
  *
  *
  *
- * @param float $latitude Defaults to North, pass in a negative value for South.
+ * @param float|null $latitude Defaults to North, pass in a negative value for South.
  * See also: date.default_latitude
- * @param float $longitude Defaults to East, pass in a negative value for West.
+ * @param float|null $longitude Defaults to East, pass in a negative value for West.
  * See also: date.default_longitude
- * @param float $zenith zenith is the angle between the center of the sun
+ * @param float|null $zenith zenith is the angle between the center of the sun
  * and a line perpendicular to earth's surface. It defaults to
  * date.sunrise_zenith
  *
@@ -222,7 +222,7 @@ function date_sun_info(int $timestamp, float $latitude, float $longitude): array
  *
  *
  *
- * @param float $utcOffset Specified in hours.
+ * @param float|null $utcOffset Specified in hours.
  * The utcOffset is ignored, if
  * returnFormat is
  * SUNFUNCS_RET_TIMESTAMP.
@@ -289,11 +289,11 @@ function date_sunrise(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?
  *
  *
  *
- * @param float $latitude Defaults to North, pass in a negative value for South.
+ * @param float|null $latitude Defaults to North, pass in a negative value for South.
  * See also: date.default_latitude
- * @param float $longitude Defaults to East, pass in a negative value for West.
+ * @param float|null $longitude Defaults to East, pass in a negative value for West.
  * See also: date.default_longitude
- * @param float $zenith zenith is the angle between the center of the sun
+ * @param float|null $zenith zenith is the angle between the center of the sun
  * and a line perpendicular to earth's surface. It defaults to
  * date.sunset_zenith
  *
@@ -325,7 +325,7 @@ function date_sunrise(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?
  *
  *
  *
- * @param float $utcOffset Specified in hours.
+ * @param float|null $utcOffset Specified in hours.
  * The utcOffset is ignored, if
  * returnFormat is
  * SUNFUNCS_RET_TIMESTAMP.
@@ -364,7 +364,7 @@ function date_sunset(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?f
  * is optional and defaults to the value of time.
  *
  * @param string $format Format accepted by DateTimeInterface::format.
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -402,21 +402,21 @@ function date(string $format, ?int $timestamp = null): string
  * month, day and year.
  * Negative values reference the hour before midnight of the day in question.
  * Values greater than 23 reference the appropriate hour in the following day(s).
- * @param int $minute The number of the minute relative to the start of the hour.
+ * @param int|null $minute The number of the minute relative to the start of the hour.
  * Negative values reference the minute in the previous hour.
  * Values greater than 59 reference the appropriate minute in the following hour(s).
- * @param int $second The number of seconds relative to the start of the minute.
+ * @param int|null $second The number of seconds relative to the start of the minute.
  * Negative values reference the second in the previous minute.
  * Values greater than 59 reference the appropriate second in the following minute(s).
- * @param int $month The number of the month relative to the end of the previous year.
+ * @param int|null $month The number of the month relative to the end of the previous year.
  * Values 1 to 12 reference the normal calendar months of the year in question.
  * Values less than 1 (including negative values) reference the months in the previous year in reverse order, so 0 is December, -1 is November, etc.
  * Values greater than 12 reference the appropriate month in the following year(s).
- * @param int $day The number of the day relative to the end of the previous month.
+ * @param int|null $day The number of the day relative to the end of the previous month.
  * Values 1 to 28, 29, 30 or 31 (depending upon the month) reference the normal days in the relevant month.
  * Values less than 1 (including negative values) reference the days in the previous month, so 0 is the last day of the previous month, -1 is the day before that, etc.
  * Values greater than the number of days in the relevant month reference the appropriate day in the following month(s).
- * @param int $year The year
+ * @param int|null $year The year
  * @return int Returns a int Unix timestamp on success.
  * @throws DatetimeException
  *
@@ -452,7 +452,7 @@ function gmmktime(int $hour, ?int $minute = null, ?int $second = null, ?int $mon
  * 01:00:00".
  *
  * @param string $format See description in strftime.
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -575,7 +575,7 @@ function gmstrftime(string $format, ?int $timestamp = null): string
  *
  *
  *
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -616,21 +616,21 @@ function idate(string $format, ?int $timestamp = null): int
  * month, day and year.
  * Negative values reference the hour before midnight of the day in question.
  * Values greater than 23 reference the appropriate hour in the following day(s).
- * @param int $minute The number of the minute relative to the start of the hour.
+ * @param int|null $minute The number of the minute relative to the start of the hour.
  * Negative values reference the minute in the previous hour.
  * Values greater than 59 reference the appropriate minute in the following hour(s).
- * @param int $second The number of seconds relative to the start of the minute.
+ * @param int|null $second The number of seconds relative to the start of the minute.
  * Negative values reference the second in the previous minute.
  * Values greater than 59 reference the appropriate second in the following minute(s).
- * @param int $month The number of the month relative to the end of the previous year.
+ * @param int|null $month The number of the month relative to the end of the previous year.
  * Values 1 to 12 reference the normal calendar months of the year in question.
  * Values less than 1 (including negative values) reference the months in the previous year in reverse order, so 0 is December, -1 is November, etc.
  * Values greater than 12 reference the appropriate month in the following year(s).
- * @param int $day The number of the day relative to the end of the previous month.
+ * @param int|null $day The number of the day relative to the end of the previous month.
  * Values 1 to 28, 29, 30 or 31 (depending upon the month) reference the normal days in the relevant month.
  * Values less than 1 (including negative values) reference the days in the previous month, so 0 is the last day of the previous month, -1 is the day before that, etc.
  * Values greater than the number of days in the relevant month reference the appropriate day in the following month(s).
- * @param int $year The number of the year, may be a two or four digit value,
+ * @param int|null $year The number of the year, may be a two or four digit value,
  * with values between 0-69 mapping to 2000-2069 and 70-100 to
  * 1970-2000. On systems where time_t is a 32bit signed integer, as
  * most common today, the valid range for year
@@ -957,7 +957,7 @@ function mktime(int $hour, ?int $minute = null, ?int $second = null, ?int $month
  *
  * The %z and %Z modifiers both
  * return the time zone name instead of the offset or abbreviation.
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -1078,7 +1078,7 @@ function strptime(string $timestamp, string $format): array
  * ways to define the default time zone.
  *
  * @param string $datetime A date/time string. Valid formats are explained in Date and Time Formats.
- * @param int $baseTimestamp The timestamp which is used as a base for the calculation of relative
+ * @param int|null $baseTimestamp The timestamp which is used as a base for the calculation of relative
  * dates.
  * @return int Returns a timestamp on success.
  * @throws DatetimeException

--- a/generated/8.1/eio.php
+++ b/generated/8.1/eio.php
@@ -13,7 +13,7 @@ use Safe\Exceptions\EioException;
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback This callback is called when all the group requests are done.
+ * @param callable|null $callback This callback is called when all the group requests are done.
  * @param mixed $data Arbitrary variable passed to callback.
  * @return resource eio_busy returns request resource on success.
  * @throws EioException
@@ -41,7 +41,7 @@ function eio_busy(int $delay, int $pri = EIO_PRI_DEFAULT, ?callable $callback = 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -93,7 +93,7 @@ function eio_chmod(string $path, int $mode, int $pri = EIO_PRI_DEFAULT, ?callabl
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -142,7 +142,7 @@ function eio_chown(string $path, int $uid, int $gid = -1, int $pri = EIO_PRI_DEF
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -250,7 +250,7 @@ function eio_custom(callable $execute, int $pri, callable $callback, $data = nul
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -322,7 +322,7 @@ function eio_event_loop(): void
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -372,7 +372,7 @@ function eio_fallocate($fd, int $mode, int $offset, int $length, int $pri = EIO_
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -423,7 +423,7 @@ function eio_fchmod($fd, int $mode, int $pri = EIO_PRI_DEFAULT, ?callable $callb
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -471,7 +471,7 @@ function eio_fchown($fd, int $uid, int $gid = -1, int $pri = EIO_PRI_DEFAULT, ?c
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -625,7 +625,7 @@ function eio_fstatvfs($fd, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -676,7 +676,7 @@ function eio_fsync($fd, int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -727,7 +727,7 @@ function eio_ftruncate($fd, int $offset = 0, int $pri = EIO_PRI_DEFAULT, ?callab
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -796,7 +796,7 @@ function eio_futime($fd, float $atime, float $mtime, int $pri = EIO_PRI_DEFAULT,
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_grp returns request group resource on success.
  * @throws EioException
  *
@@ -870,7 +870,7 @@ function eio_lstat(string $path, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -935,7 +935,7 @@ function eio_mkdir(string $path, int $mode, int $pri = EIO_PRI_DEFAULT, ?callabl
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -983,7 +983,7 @@ function eio_mknod(string $path, int $mode, int $dev, int $pri = EIO_PRI_DEFAULT
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1034,7 +1034,7 @@ function eio_nop(int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, $data =
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1111,7 +1111,7 @@ function eio_readahead($fd, int $offset, int $length, int $pri = EIO_PRI_DEFAULT
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_readdir returns request resource on success.
  * Sets result argument of
  * callback function according to
@@ -1411,7 +1411,7 @@ function eio_readdir(string $path, int $flags, int $pri, callable $callback, ?st
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_readlink returns request resource on success.
  * @throws EioException
  *
@@ -1435,7 +1435,7 @@ function eio_readlink(string $path, int $pri, callable $callback, ?string $data 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1483,7 +1483,7 @@ function eio_rename(string $path, string $new_path, int $pri = EIO_PRI_DEFAULT, 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1539,7 +1539,7 @@ function eio_rmdir(string $path, int $pri = EIO_PRI_DEFAULT, ?callable $callback
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1754,7 +1754,7 @@ function eio_statvfs(string $path, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1813,7 +1813,7 @@ function eio_symlink(string $path, string $new_path, int $pri = EIO_PRI_DEFAULT,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1858,7 +1858,7 @@ function eio_sync_file_range($fd, int $offset, int $nbytes, int $flags, int $pri
  *
  *
  * @param int $pri
- * @param callable $callback
+ * @param callable|null $callback
  * @param mixed $data
  * @return resource eio_sync returns request resource on success.
  * @throws EioException
@@ -1882,7 +1882,7 @@ function eio_sync(int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, $data 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1932,7 +1932,7 @@ function eio_syncfs($fd, int $pri = EIO_PRI_DEFAULT, ?callable $callback = null,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1980,7 +1980,7 @@ function eio_truncate(string $path, int $offset = 0, int $pri = EIO_PRI_DEFAULT,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -2030,7 +2030,7 @@ function eio_unlink(string $path, int $pri = EIO_PRI_DEFAULT, ?callable $callbac
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -2083,7 +2083,7 @@ function eio_utime(string $path, float $atime, float $mtime, int $pri = EIO_PRI_
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *

--- a/generated/8.1/exec.php
+++ b/generated/8.1/exec.php
@@ -148,7 +148,7 @@ function proc_nice(int $priority): void
  * PHP process)
  * @param array|null $env An array with the environment variables for the command that will be
  * run, or NULL to use the same environment as the current PHP process
- * @param array $other_options Allows you to specify additional options. Currently supported options
+ * @param array|null $other_options Allows you to specify additional options. Currently supported options
  * include:
  *
  *

--- a/generated/8.1/fileinfo.php
+++ b/generated/8.1/fileinfo.php
@@ -30,7 +30,7 @@ function finfo_close(\finfo $finfo): void
  *
  * @param int $flags One or disjunction of more Fileinfo
  * constants.
- * @param string $magic_database Name of a magic database file, usually something like
+ * @param null|string $magic_database Name of a magic database file, usually something like
  * /path/to/magic.mime. If not specified, the
  * MAGIC environment variable is used. If the
  * environment variable isn't set, then PHP's bundled magic database will

--- a/generated/8.1/ibase.php
+++ b/generated/8.1/ibase.php
@@ -112,7 +112,7 @@ function ibase_blob_cancel($blob_handle): void
  * ibase_blob_create creates a new BLOB for filling with
  * data.
  *
- * @param resource $link_identifier An InterBase link identifier. If omitted, the last opened link is
+ * @param null|resource $link_identifier An InterBase link identifier. If omitted, the last opened link is
  * assumed.
  * @return resource Returns a BLOB handle for later use with
  * ibase_blob_add.
@@ -161,7 +161,7 @@ function ibase_blob_get($blob_handle, int $len): string
  * Default transaction on link is committed, other transactions are
  * rolled back.
  *
- * @param resource $connection_id An InterBase link identifier returned from
+ * @param null|resource $connection_id An InterBase link identifier returned from
  * ibase_connect. If omitted, the last opened link
  * is assumed.
  * @throws IbaseException
@@ -184,7 +184,7 @@ function ibase_close($connection_id = null): void
 /**
  * Commits a transaction without closing it.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function commits the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function commits the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be committed. If the argument is a transaction identifier, the
@@ -211,7 +211,7 @@ function ibase_commit_ret($link_or_trans_identifier = null): void
 /**
  * Commits a transaction.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function commits the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function commits the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be committed. If the argument is a transaction identifier, the
@@ -317,7 +317,7 @@ function ibase_delete_user($service_handle, string $user_name): void
  * This functions drops a database that was opened by either ibase_connect
  * or ibase_pconnect. The database is closed and deleted from the server.
  *
- * @param resource $connection An InterBase link identifier. If omitted, the last opened link is
+ * @param null|resource $connection An InterBase link identifier. If omitted, the last opened link is
  * assumed.
  * @throws IbaseException
  *
@@ -573,7 +573,7 @@ function ibase_restore($service_handle, string $source_file, string $dest_db, in
 /**
  * Rolls back a transaction without closing it.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function rolls back the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function rolls back the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be rolled back. If the argument is a transaction identifier, the
@@ -600,7 +600,7 @@ function ibase_rollback_ret($link_or_trans_identifier = null): void
 /**
  * Rolls back a transaction.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function rolls back the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function rolls back the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be rolled back. If the argument is a transaction identifier, the

--- a/generated/8.1/iconv.php
+++ b/generated/8.1/iconv.php
@@ -76,7 +76,7 @@ function iconv_get_encoding(string $type = "all")
  *
  *
  *
- * @param string $encoding The optional encoding parameter specifies the
+ * @param null|string $encoding The optional encoding parameter specifies the
  * character set to represent the result by. If omitted or NULL,
  * iconv.internal_encoding
  * will be used.
@@ -249,7 +249,7 @@ function iconv_set_encoding(string $type, string $encoding): void
  * identical to the length of the string in byte.
  *
  * @param string $string The string.
- * @param string $encoding If encoding parameter is omitted or NULL,
+ * @param null|string $encoding If encoding parameter is omitted or NULL,
  * string is assumed to be encoded in
  * iconv.internal_encoding.
  * @return int Returns the character count of string, as an integer,

--- a/generated/8.1/image.php
+++ b/generated/8.1/image.php
@@ -104,7 +104,7 @@ function image_type_to_extension(int $image_type, bool $include_dot = true): str
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param array $affine Array with keys 0 to 5.
- * @param array $clip Array with keys "x", "y", "width" and "height"; or NULL.
+ * @param array|null $clip Array with keys "x", "y", "width" and "height"; or NULL.
  * @return \GdImage Return affined image object on success.
  * @throws ImageException
  *
@@ -2123,8 +2123,8 @@ function imagerectangle(\GdImage $image, int $x1, int $y1, int $x2, int $y2, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param int $resolution_x The horizontal resolution in DPI.
- * @param int $resolution_y The vertical resolution in DPI.
+ * @param int|null $resolution_x The horizontal resolution in DPI.
+ * @param int|null $resolution_y The vertical resolution in DPI.
  * @return mixed When used as getter,
  * it returns an indexed array of the horizontal and vertical resolution on
  * success.
@@ -2805,7 +2805,7 @@ function imagettftext(\GdImage $image, float $size, float $angle, int $x, int $y
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
- * @param int $foreground_color You can set the foreground color with this parameter by setting an
+ * @param int|null $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black.
  * @throws ImageException
@@ -2867,7 +2867,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  * alphanumeric characters of the current locale are substituted by
  * underscores. If filename is set to NULL,
  * image is used to build the C identifiers.
- * @param int $foreground_color You can set the foreground color with this parameter by setting an
+ * @param int|null $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black. All other colors are treated as
  * background.

--- a/generated/8.1/imap.php
+++ b/generated/8.1/imap.php
@@ -35,9 +35,9 @@ function imap_8bit(string $string): string
  * When talking to the Cyrus IMAP server, you must use "\r\n" as
  * your end-of-line terminator instead of "\n" or the operation will
  * fail
- * @param string $options If provided, the options will also be written
+ * @param null|string $options If provided, the options will also be written
  * to the folder
- * @param string $internal_date If this parameter is set, it will set the INTERNALDATE on the appended message.  The parameter should be a date string that conforms to the rfc2060 specifications for a date_time value.
+ * @param null|string $internal_date If this parameter is set, it will set the INTERNALDATE on the appended message.  The parameter should be a date string that conforms to the rfc2060 specifications for a date_time value.
  * @throws ImapException
  *
  */
@@ -1439,11 +1439,11 @@ function imap_mail_move(\IMAP\Connection $imap, string $message_nums, string $ma
  * @param string $to The receiver
  * @param string $subject The mail subject
  * @param string $message The mail body, see imap_mail_compose
- * @param string $additional_headers As string with additional headers to be set on the mail
- * @param string $cc
- * @param string $bcc The receivers specified in bcc will get the
+ * @param null|string $additional_headers As string with additional headers to be set on the mail
+ * @param null|string $cc
+ * @param null|string $bcc The receivers specified in bcc will get the
  * mail, but are excluded from the headers.
- * @param string $return_path Use this parameter to specify return path upon mail delivery failure.
+ * @param null|string $return_path Use this parameter to specify return path upon mail delivery failure.
  * This is useful when using PHP as a mail client for multiple users.
  * @throws ImapException
  *
@@ -2051,9 +2051,9 @@ function imap_setflag_full(\IMAP\Connection $imap, string $sequence, string $fla
  *
  *
  *
- * @param string $search_criteria IMAP2-format search criteria string. For details see
+ * @param null|string $search_criteria IMAP2-format search criteria string. For details see
  * imap_search.
- * @param string $charset MIME character set to use when sorting strings.
+ * @param null|string $charset MIME character set to use when sorting strings.
  * @return array Returns an array of message numbers sorted by the given
  * parameters.
  * @throws ImapException

--- a/generated/8.1/ldap.php
+++ b/generated/8.1/ldap.php
@@ -43,7 +43,7 @@ function ldap_8859_to_t61(string $value): string
  * ]]>
  *
  *
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -94,7 +94,7 @@ function ldap_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $password
  * @param string $dn The distinguished name of an LDAP entity.
  * @param string $attribute The attribute name.
  * @param string $value The compared value.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @return bool Returns TRUE if value matches otherwise returns
  * FALSE.
  * @throws LdapException
@@ -184,7 +184,7 @@ function ldap_count_entries(\LDAP\Connection $ldap, \LDAP\Result $result): int
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -229,7 +229,7 @@ function ldap_dn2ufn(string $dn): string
  * @param string $user dn of the user to change the password of.
  * @param string $old_password The old password of this user. May be ommited depending of server configuration.
  * @param string $new_password The new password for this user. May be omitted or empty to have a generated password.
- * @param array $controls If provided, a password policy request control is send with the request and this is
+ * @param array|null $controls If provided, a password policy request control is send with the request and this is
  * filled with an array of LDAP Controls
  * returned with the request.
  * @return bool|string Returns the generated password if new_password is empty or omitted.
@@ -274,7 +274,7 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $reqoid The extended operation request OID. You may use one of LDAP_EXOP_START_TLS, LDAP_EXOP_MODIFY_PASSWD, LDAP_EXOP_REFRESH, LDAP_EXOP_WHO_AM_I, LDAP_EXOP_TURN, or a string with the OID of the operation you want to send.
- * @param string $reqdata The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
+ * @param null|string $reqdata The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
  * @param array|null $serverctrls Array of LDAP Controls to send with the request.
  * @param null|string $retdata Will be filled with the extended operation response data if provided.
  * If not provided you may use ldap_parse_exop on the result object
@@ -763,7 +763,7 @@ function ldap_get_values(\LDAP\Connection $ldap, \LDAP\ResultEntry $entry, strin
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry An associative array listing the attirbute values to add. If an attribute was not existing yet it will be added. If an attribute is existing you can only add values to it if it supports multiple values.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -789,7 +789,7 @@ function ldap_mod_add(\LDAP\Connection $ldap, string $dn, array $entry, ?array $
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -814,7 +814,7 @@ function ldap_mod_del(\LDAP\Connection $ldap, string $dn, array $entry, ?array $
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry An associative array listing the attributes to replace. Sending an empty array as value will remove the attribute, while sending an attribute not existing yet on this entry will add it.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -911,7 +911,7 @@ function ldap_mod_replace(\LDAP\Connection $ldap, string $dn, array $entry, ?arr
  * value for values must be an array of strings, and
  * any value for modtype must be one of the
  * LDAP_MODIFY_BATCH_* constants listed above.
- * @param array $controls Each value specified through values is added (as
+ * @param array|null $controls Each value specified through values is added (as
  * an additional value) to the attribute named by
  * attrib.
  * @throws LdapException
@@ -1012,7 +1012,7 @@ function ldap_parse_result(\LDAP\Connection $ldap, \LDAP\Result $result, ?int &$
  * @param string $new_parent The new parent/superior entry.
  * @param bool $delete_old_rdn If TRUE the old RDN value(s) is removed, else the old RDN value(s)
  * is retained as non-distinguished values of the entry.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -1034,13 +1034,13 @@ function ldap_rename(\LDAP\Connection $ldap, string $dn, string $new_rdn, string
  *
  *
  * @param \LDAP\Connection $ldap
- * @param string $dn
- * @param string $password
- * @param string $mech
- * @param string $realm
- * @param string $authc_id
- * @param string $authz_id
- * @param string $props
+ * @param null|string $dn
+ * @param null|string $password
+ * @param null|string $mech
+ * @param null|string $realm
+ * @param null|string $authc_id
+ * @param null|string $authz_id
+ * @param null|string $props
  * @throws LdapException
  *
  */

--- a/generated/8.1/mbstring.php
+++ b/generated/8.1/mbstring.php
@@ -11,7 +11,7 @@ use Safe\Exceptions\MbstringException;
  * This function complements mb_ord.
  *
  * @param int $codepoint A Unicode codepoint value, e.g. 128024 for U+1F418 ELEPHANT
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return string A string containing the requested character, if it can be represented in the specified
@@ -74,7 +74,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * Sets the automatic character
  * encoding detection order to encoding.
  *
- * @param non-empty-array|non-falsy-string $encoding encoding is an array or
+ * @param non-empty-array|non-falsy-string|null $encoding encoding is an array or
  * comma separated list of character encoding. See supported encodings.
  *
  * If encoding is omitted or NULL, it returns
@@ -160,7 +160,7 @@ function mb_encoding_aliases(string $encoding): array
  * clutter the function namespace with a callback function's name
  * not used anywhere else.
  * @param string $string The string being checked.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -190,7 +190,7 @@ function mb_ereg_replace_callback(string $pattern, callable $callback, string $s
  * Multibyte characters may be used in pattern.
  * @param string $replacement The replacement text.
  * @param string $string The string being checked.
- * @param string $options
+ * @param null|string $options
  * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -239,8 +239,8 @@ function mb_ereg_search_getregs(): array
  * mb_ereg_search_regs.
  *
  * @param string $string The search string.
- * @param string $pattern The search pattern.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $pattern The search pattern.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @throws MbstringException
  *
  */
@@ -263,8 +263,8 @@ function mb_ereg_search_init(string $string, ?string $pattern = null, ?string $o
 /**
  * Returns the matched part of a multibyte regular expression.
  *
- * @param string $pattern The search pattern.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $pattern The search pattern.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @return array
  * @throws MbstringException
  *
@@ -309,7 +309,7 @@ function mb_ereg_search_setpos(int $offset): void
  * @param string $pattern The regular expression pattern.  Multibyte characters may be used. The case will be ignored.
  * @param string $replacement The replacement text.
  * @param string $string The searched string.
- * @param string $options
+ * @param null|string $options
  * @return string The resultant string.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -373,7 +373,7 @@ function mb_get_info(string $type = "all")
  * Set/Get the HTTP output character encoding.
  * Output after this function is called will be converted from the set internal encoding to encoding.
  *
- * @param string $encoding If encoding is set,
+ * @param null|string $encoding If encoding is set,
  * mb_http_output sets the HTTP output character
  * encoding to encoding.
  *
@@ -405,7 +405,7 @@ function mb_http_output(?string $encoding = null)
 /**
  * Set/Get the internal character encoding
  *
- * @param string $encoding encoding is the character encoding name
+ * @param null|string $encoding encoding is the character encoding name
  * used for the HTTP input character encoding conversion, HTTP output
  * character encoding conversion, and the default character encoding
  * for string functions defined by the mbstring module.
@@ -439,7 +439,7 @@ function mb_internal_encoding(?string $encoding = null)
  * This function complements mb_chr.
  *
  * @param string $string A string
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return int The Unicode code point for the first character of string.
@@ -487,7 +487,7 @@ function mb_parse_str(string $string, ?array &$result): void
 /**
  * Set/Get character encoding for a multibyte regex.
  *
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return bool|string
@@ -546,7 +546,7 @@ function mb_regex_encoding(?string $encoding = null)
  * automatically (which leads to doubling CR if CRLF is used).
  * This should be a last resort, as it does not comply with
  * RFC 2822.
- * @param string $additional_params additional_params is a MTA command line
+ * @param null|string $additional_params additional_params is a MTA command line
  * parameter. It is useful when setting the correct Return-Path
  * header when using sendmail.
  *

--- a/generated/8.1/misc.php
+++ b/generated/8.1/misc.php
@@ -400,7 +400,7 @@ function sapi_windows_set_ctrl_handler(?callable $handler, bool $add = true): vo
  * They allow the modification of the terminal's output. On Windows these sequences are called Console Virtual Terminal Sequences.
  *
  * @param resource $stream The stream on which the function will operate.
- * @param bool $enable If bool, the VT100 feature will be enabled (if TRUE) or disabled (if FALSE).
+ * @param bool|null $enable If bool, the VT100 feature will be enabled (if TRUE) or disabled (if FALSE).
  * @throws MiscException
  *
  */

--- a/generated/8.1/mysql.php
+++ b/generated/8.1/mysql.php
@@ -18,7 +18,7 @@ use Safe\Exceptions\MysqlException;
  * improve performance. For related information, see
  * freeing resources
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no connection is found or
  * established, an E_WARNING level error is
@@ -102,7 +102,7 @@ function mysql_connect(?string $server = null, ?string $username = null, ?string
  * identifier.
  *
  * @param string $database_name The name of the database being created.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -184,7 +184,7 @@ function mysql_db_name($result, int $row, $field = null): string
  * @param string $query The MySQL query.
  *
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -215,7 +215,7 @@ function mysql_db_query(string $database, string $query, $link_identifier = null
  * DROP DATABASE statement instead.
  *
  * @param string $database_name The name of the database that will be deleted.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -407,7 +407,7 @@ function mysql_free_result($result): void
  * Describes the type of connection in use for the connection, including the
  * server host name.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -432,7 +432,7 @@ function mysql_get_host_info($link_identifier = null): string
 /**
  * Retrieves the MySQL protocol.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -456,7 +456,7 @@ function mysql_get_proto_info($link_identifier = null): int
 /**
  * Retrieves the MySQL server version.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -480,7 +480,7 @@ function mysql_get_server_info($link_identifier = null): string
 /**
  * Returns detailed information about the last query.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -507,7 +507,7 @@ function mysql_info($link_identifier = null): string
  * Returns a result pointer containing the databases available from the
  * current mysql daemon.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -539,7 +539,7 @@ function mysql_list_dbs($link_identifier = null)
  *
  * @param string $database_name The name of the database that's being queried.
  * @param string $table_name The name of the table that's being queried.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -568,7 +568,7 @@ function mysql_list_fields(string $database_name, string $table_name, $link_iden
 /**
  * Retrieves the current MySQL server threads.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -597,7 +597,7 @@ function mysql_list_processes($link_identifier = null)
  * [FROM db_name] [LIKE 'pattern'] statement instead.
  *
  * @param string $database The name of the database
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -678,7 +678,7 @@ function mysql_num_rows($result): int
  *
  * The query string should not end with a semicolon.
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -734,7 +734,7 @@ function mysql_query(string $query, $link_identifier = null)
  * safe before sending a query to MySQL.
  *
  * @param string $unescaped_string The string that is to be escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -798,7 +798,7 @@ function mysql_result($result, int $row, $field = 0): string
  * mysql_query will be made on the active database.
  *
  * @param string $database_name The name of the database that is to be selected.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -821,7 +821,7 @@ function mysql_select_db(string $database_name, $link_identifier = null): void
  * Sets the default character set for the current connection.
  *
  * @param string $charset A valid character set name.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -874,7 +874,7 @@ function mysql_tablename($result, int $i): string
  * with mysql_ping is executed, the thread ID will
  * change. This means only retrieve the thread ID when needed.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -912,7 +912,7 @@ function mysql_thread_id($link_identifier = null): int
  * @param string $query The SQL query to execute.
  *
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called

--- a/generated/8.1/network.php
+++ b/generated/8.1/network.php
@@ -290,7 +290,7 @@ function dns_get_record(string $hostname, int $type = DNS_ANY, ?array &$authorit
  * connect() call. This is most likely due to a
  * problem initializing the socket.
  * @param null|string $error_message The error message as a string.
- * @param float $timeout The connection timeout, in seconds. When NULL, the
+ * @param float|null $timeout The connection timeout, in seconds. When NULL, the
  * default_socket_timeout php.ini setting is used.
  *
  * If you need to set a timeout for reading/writing data over the
@@ -643,7 +643,7 @@ function openlog(string $prefix, int $flags, int $facility): void
  * @param int $port
  * @param int|null $error_code
  * @param null|string $error_message
- * @param float $timeout
+ * @param float|null $timeout
  * @return resource pfsockopen returns a file pointer which may be used
  * together with the other file functions (such as
  * fgets, fgetss,

--- a/generated/8.1/oci8.php
+++ b/generated/8.1/oci8.php
@@ -389,7 +389,7 @@ function oci_commit($connection): void
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from
@@ -780,7 +780,7 @@ function oci_free_statement($statement): void
  * @param resource $connection An Oracle connection identifier, returned by
  * oci_connect or oci_pconnect.
  * @param string $type_name Should be a valid named type (uppercase).
- * @param string $schema Should point to the scheme, where the named type was created. The name
+ * @param null|string $schema Should point to the scheme, where the named type was created. The name
  * of the current user is used when NULL is passed.
  * @return \OCI-Collection Returns a new OCICollection object.
  * @throws Oci8Exception
@@ -812,7 +812,7 @@ function oci_new_collection($connection, string $type_name, ?string $schema = nu
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from
@@ -1015,7 +1015,7 @@ function oci_parse($connection, string $sql)
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from

--- a/generated/8.1/openssl.php
+++ b/generated/8.1/openssl.php
@@ -274,7 +274,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  * otherwise obtained from the other openssl_pkey family of functions).
  * The corresponding public portion of the key will be used to sign the
  * CSR.
- * @param array $options By default, the information in your system openssl.conf
+ * @param array|null $options By default, the information in your system openssl.conf
  * is used to initialize the request; you can specify a configuration file
  * section by setting the config_section_section key of
  * options.  You can also specify an alternative
@@ -366,7 +366,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  *
  *
  *
- * @param array $extra_attributes extra_attributes is used to specify additional
+ * @param array|null $extra_attributes extra_attributes is used to specify additional
  * configuration options for the CSR.  Both distinguished_names and
  * extra_attributes are associative arrays whose keys are
  * converted to OIDs and applied to the relevant part of the request.
@@ -405,7 +405,7 @@ function openssl_csr_new(array $distinguished_names, \OpenSSLAsymmetricKey &$pri
  * ca_certificate.
  * @param int $days days specifies the length of time for which the
  * generated certificate will be valid, in days.
- * @param array $options You can finetune the CSR signing by options.
+ * @param array|null $options You can finetune the CSR signing by options.
  * See openssl_csr_new for more information about
  * options.
  * @param int $serial An optional the serial number of issued certificate. If not specified
@@ -588,7 +588,7 @@ function openssl_get_curve_names(): array
  * It is strongly recommended to explicitly specify a secure cipher method.
  *
  *
- * @param string $iv The initialization vector.
+ * @param null|string $iv The initialization vector.
  * @throws OpensslException
  *
  */
@@ -836,7 +836,7 @@ function openssl_pkcs7_read(string $data, ?array &$certificates): void
  * openssl_pkcs7_encrypt for more information about
  * the format of this parameter).
  * @param int $flags flags can be used to alter the output - see PKCS7 constants.
- * @param string $untrusted_certificates_filename untrusted_certificates_filename specifies the name of a file containing
+ * @param null|string $untrusted_certificates_filename untrusted_certificates_filename specifies the name of a file containing
  * a bunch of extra certificates to include in the signature which can for
  * example be used to help the recipient to verify the certificate that you used.
  * @throws OpensslException
@@ -889,7 +889,7 @@ function openssl_pkey_derive($public_key, $private_key, int $key_length = 0): st
  * @param string $output_filename Path to the output file.
  * @param null|string $passphrase The key can be optionally protected by a
  * passphrase.
- * @param array $options options can be used to fine-tune the export
+ * @param array|null $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file. See openssl_csr_new for more
  * information about options.
@@ -920,7 +920,7 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param null|string $output
  * @param null|string $passphrase The key is optionally protected by passphrase.
- * @param array $options options can be used to fine-tune the export
+ * @param array|null $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file.  See openssl_csr_new for more
  * information about options.
@@ -1012,7 +1012,7 @@ function openssl_pkey_get_public($public_key): \OpenSSLAsymmetricKey
  * key.
  * How to obtain the public component of the key is shown in an example below.
  *
- * @param array $options You can finetune the key generation (such as specifying the number of
+ * @param array|null $options You can finetune the key generation (such as specifying the number of
  * bits) using options.  See
  * openssl_csr_new for more information about
  * options.
@@ -1416,7 +1416,7 @@ function openssl_verify(string $data, string $signature, $public_key, $algorithm
  * @param array $ca_info ca_info should be an array of trusted CA files/dirs
  * as described in Certificate
  * Verification.
- * @param string $untrusted_certificates_file If specified, this should be the name of a PEM encoded file holding
+ * @param null|string $untrusted_certificates_file If specified, this should be the name of a PEM encoded file holding
  * certificates that can be used to help verify the certificate, although
  * no trust is placed in the certificates that come from that file.
  * @return bool|int Returns TRUE if the certificate can be used for the intended purpose,

--- a/generated/8.1/pcntl.php
+++ b/generated/8.1/pcntl.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\PcntlException;
  * system types and kernel versions, please see your system's getpriority(2)
  * man page for specific details.
  *
- * @param int $process_id If NULL, the process id of the current process is used.
+ * @param int|null $process_id If NULL, the process id of the current process is used.
  * @param int $mode One of PRIO_PGRP, PRIO_USER
  * or PRIO_PROCESS.
  * @return int pcntl_getpriority returns the priority of the process.  A lower numerical value causes more favorable
@@ -45,7 +45,7 @@ function pcntl_getpriority(?int $process_id = null, int $mode = PRIO_PROCESS): i
  * favorable scheduling.  Because priority levels can differ between
  * system types and kernel versions, please see your system's setpriority(2)
  * man page for specific details.
- * @param int $process_id If NULL, the process id of the current process is used.
+ * @param int|null $process_id If NULL, the process id of the current process is used.
  * @param int $mode One of PRIO_PGRP, PRIO_USER
  * or PRIO_PROCESS.
  * @throws PcntlException

--- a/generated/8.1/pgsql.php
+++ b/generated/8.1/pgsql.php
@@ -763,7 +763,7 @@ function pg_lo_unlink(\PgSql\Connection $connection, int $oid): void
  * @param string $data The data to be written to the large object.  If length is
  * an int and is less than the length of data, only
  * length bytes will be written.
- * @param int $length An optional maximum number of bytes to write.  Must be greater than zero
+ * @param int|null $length An optional maximum number of bytes to write.  Must be greater than zero
  * and no greater than the length of data.  Defaults to
  * the length of data.
  * @return int The number of bytes written to the large object.

--- a/generated/8.1/readline.php
+++ b/generated/8.1/readline.php
@@ -86,7 +86,7 @@ function readline_completion_function(callable $callback): void
 /**
  * This function reads a command history from a file.
  *
- * @param string $filename Path to the filename containing the command history.
+ * @param null|string $filename Path to the filename containing the command history.
  * @throws ReadlineException
  *
  */
@@ -107,7 +107,7 @@ function readline_read_history(?string $filename = null): void
 /**
  * This function writes the command history to a file.
  *
- * @param string $filename Path to the saved file.
+ * @param null|string $filename Path to the saved file.
  * @throws ReadlineException
  *
  */

--- a/generated/8.1/sem.php
+++ b/generated/8.1/sem.php
@@ -434,7 +434,7 @@ function sem_remove(\SysvSemaphore $semaphore): void
  * permissions will be ignored.
  *
  * @param int $key A numeric shared memory segment ID
- * @param int $size The memory size. If not provided, default to the
+ * @param int|null $size The memory size. If not provided, default to the
  * sysvshm.init_mem in the php.ini, otherwise 10000
  * bytes.
  * @param int $permissions The optional permission bits. Default to 0666.

--- a/generated/8.1/session.php
+++ b/generated/8.1/session.php
@@ -136,7 +136,7 @@ function session_encode(): string
  * adding to URLs. See also Session
  * handling.
  *
- * @param string $id If id is specified and not NULL, it will replace the current
+ * @param null|string $id If id is specified and not NULL, it will replace the current
  * session id. session_id needs to be called before
  * session_start for that purpose. Depending on the
  * session handler, not all characters are allowed within the session id.
@@ -169,7 +169,7 @@ function session_id(?string $id = null): string
  * session module, which is also known as
  * session.save_handler.
  *
- * @param string $module If module is specified and not NULL, that module will be
+ * @param null|string $module If module is specified and not NULL, that module will be
  * used instead.
  * Passing "user" to this parameter is forbidden. Instead
  * session_set_save_handler has to be called to set a user
@@ -213,7 +213,7 @@ function session_module_name(?string $module = null): string
  * call session_name for every request (and before
  * session_start is called).
  *
- * @param string $name The session name references the name of the session, which is
+ * @param null|string $name The session name references the name of the session, which is
  * used in cookies and URLs (e.g. PHPSESSID). It
  * should contain only alphanumeric characters; it should be short and
  * descriptive (i.e. for users with enabled cookie warnings).
@@ -297,7 +297,7 @@ function session_reset(): void
  * session_save_path returns the path of the current
  * directory used to save session data.
  *
- * @param string $path Session data path. If specified and not NULL, the path to which data is saved will
+ * @param null|string $path Session data path. If specified and not NULL, the path to which data is saved will
  * be changed. session_save_path needs to be called
  * before session_start for that purpose.
  *

--- a/generated/8.1/sockets.php
+++ b/generated/8.1/sockets.php
@@ -160,7 +160,7 @@ function socket_bind(\Socket $socket, string $address, int $port = 0): void
  * socket is AF_INET6
  * or the pathname of a Unix domain socket, if the socket family is
  * AF_UNIX.
- * @param int $port The port parameter is only used and is mandatory
+ * @param int|null $port The port parameter is only used and is mandatory
  * when connecting to an AF_INET or an
  * AF_INET6 socket, and designates
  * the port on the remote host to which a connection should be made.
@@ -645,7 +645,7 @@ function socket_sendmsg(\Socket $socket, array $message, int $flags = 0): int
  *
  *
  * @param string $address IP address of the remote host.
- * @param int $port port is the remote port number at which the data
+ * @param int|null $port port is the remote port number at which the data
  * will be sent.
  * @return int socket_sendto returns the number of bytes sent to the
  * remote host.

--- a/generated/8.1/spl.php
+++ b/generated/8.1/spl.php
@@ -84,7 +84,7 @@ function class_uses($object_or_class, bool $autoload = true): array
  * runs through each of them in the order they are defined. By contrast,
  * __autoload may only be defined once.
  *
- * @param callable(string):void $callback The autoload function being registered.
+ * @param callable(string):void|null $callback The autoload function being registered.
  * If NULL, then the default implementation of
  * spl_autoload will be registered.
  * @param bool $throw This parameter specifies whether

--- a/generated/8.1/ssh2.php
+++ b/generated/8.1/ssh2.php
@@ -717,7 +717,7 @@ function ssh2_sftp($session)
  * ssh2_connect.
  * @param string $term_type term_type should correspond to one of the
  * entries in the target system's /etc/termcap file.
- * @param array $env env may be passed as an associative array of
+ * @param array|null $env env may be passed as an associative array of
  * name/value pairs to set in the target environment.
  * @param int $width Width of the virtual terminal.
  * @param int $height Height of the virtual terminal.

--- a/generated/8.1/stream.php
+++ b/generated/8.1/stream.php
@@ -33,7 +33,7 @@ function stream_context_set_params($context, array $params): void
  *
  * @param resource $from The source stream
  * @param resource $to The destination stream
- * @param int $length Maximum bytes to copy. By default all bytes left are copied.
+ * @param int|null $length Maximum bytes to copy. By default all bytes left are copied.
  * @param int $offset The offset where to start to copy data
  * @return int Returns the total count of bytes copied.
  * @throws StreamException

--- a/generated/8.1/uodbc.php
+++ b/generated/8.1/uodbc.php
@@ -197,16 +197,16 @@ function odbc_columnprivileges($odbc, string $catalog, string $schema, string $t
  *
  * @param resource $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $table The table name.
+ * @param null|string $table The table name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $column The column name.
+ * @param null|string $column The column name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
@@ -774,16 +774,16 @@ function odbc_primarykeys($odbc, string $catalog, string $schema, string $table)
  *
  * @param  $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $procedure The proc.
+ * @param null|string $procedure The proc.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $column The column.
+ * @param null|string $column The column.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
@@ -843,12 +843,12 @@ function odbc_procedurecolumns($odbc, ?string $catalog = null, ?string $schema =
  *
  * @param  $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $procedure The name.
+ * @param null|string $procedure The name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
@@ -1170,16 +1170,16 @@ function odbc_tableprivileges($odbc, string $catalog, string $schema, string $ta
  *
  * @param resource $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $table The name.
+ * @param null|string $table The name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $types If table_type is not an empty string, it
+ * @param null|string $types If table_type is not an empty string, it
  * must contain a list of comma-separated values for the types of
  * interest; each value may be enclosed in single quotes (') or
  * unquoted. For example, 'TABLE','VIEW' or TABLE, VIEW.  If the

--- a/generated/8.1/yaml.php
+++ b/generated/8.1/yaml.php
@@ -12,7 +12,7 @@ use Safe\Exceptions\YamlException;
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * details.
@@ -50,7 +50,7 @@ function yaml_parse_file(string $filename, int $pos = 0, ?int &$ndocs = null, ?a
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * @return mixed Returns the value encoded in input in appropriate
@@ -83,7 +83,7 @@ function yaml_parse_url(string $url, int $pos = 0, ?int &$ndocs = null, ?array $
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * details.

--- a/generated/8.1/zlib.php
+++ b/generated/8.1/zlib.php
@@ -293,7 +293,7 @@ function gzfile(string $filename, int $use_include_path = 0): array
  *
  * @param resource $stream The gz-file pointer. It must be valid, and must point to a file
  * successfully opened by gzopen.
- * @param int $length The length of data to get.
+ * @param int|null $length The length of data to get.
  * @return string The uncompressed string.
  * @throws ZlibException
  *
@@ -491,7 +491,7 @@ function gzuncompress(string $data, int $max_length = 0): string
  * @param resource $stream The gz-file pointer. It must be valid, and must point to a file
  * successfully opened by gzopen.
  * @param string $data The string to write.
- * @param int $length The number of uncompressed bytes to write. If supplied, writing will
+ * @param int|null $length The number of uncompressed bytes to write. If supplied, writing will
  * stop after length (uncompressed) bytes have been
  * written or the end of data is reached,
  * whichever comes first.

--- a/generated/8.2/bzip2.php
+++ b/generated/8.2/bzip2.php
@@ -98,7 +98,7 @@ function bzread($bz, int $length = 1024): string
  * @param resource $bz The file pointer. It must be valid and must point to a file
  * successfully opened by bzopen.
  * @param string $data The written data.
- * @param int $length If supplied, writing will stop after length
+ * @param int|null $length If supplied, writing will stop after length
  * (uncompressed) bytes have been written or the end of
  * data is reached, whichever comes first.
  * @return int Returns the number of bytes written.

--- a/generated/8.2/calendar.php
+++ b/generated/8.2/calendar.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\CalendarException;
  * timestamp is given. Either way, the time is regarded
  * as local time (not UTC).
  *
- * @param int $timestamp A unix timestamp to convert.
+ * @param int|null $timestamp A unix timestamp to convert.
  * @return int A julian day number as integer.
  * @throws CalendarException
  *

--- a/generated/8.2/com.php
+++ b/generated/8.2/com.php
@@ -132,7 +132,7 @@ function com_load_typelib(string $typelib, bool $case_insensitive = true): void
  * @param object $variant variant should be either an instance of a COM
  * object, or be the name of a typelibrary (which will be resolved according
  * to the rules set out in com_load_typelib).
- * @param string $dispatch_interface The name of an IDispatch descendant interface that you want to display.
+ * @param null|string $dispatch_interface The name of an IDispatch descendant interface that you want to display.
  * @param bool $display_sink If set to TRUE, the corresponding sink interface will be displayed
  * instead.
  * @throws ComException

--- a/generated/8.2/curl.php
+++ b/generated/8.2/curl.php
@@ -75,7 +75,7 @@ function curl_exec(\CurlHandle $handle)
  *
  * @param \CurlHandle $handle A cURL handle returned by
  * curl_init.
- * @param int $option This may be one of the following constants:
+ * @param int|null $option This may be one of the following constants:
  *
  *
  *
@@ -552,7 +552,7 @@ function curl_getinfo(\CurlHandle $handle, ?int $option = null)
  * curl_setopt, curl_exec,
  * and curl_close functions.
  *
- * @param string $url If provided, the CURLOPT_URL option will be set
+ * @param null|string $url If provided, the CURLOPT_URL option will be set
  * to its value. You can manually set this using the
  * curl_setopt function.
  *

--- a/generated/8.2/datetime.php
+++ b/generated/8.2/datetime.php
@@ -272,11 +272,11 @@ function date_sun_info(int $timestamp, float $latitude, float $longitude): array
  *
  *
  *
- * @param float $latitude Defaults to North, pass in a negative value for South.
+ * @param float|null $latitude Defaults to North, pass in a negative value for South.
  * See also: date.default_latitude
- * @param float $longitude Defaults to East, pass in a negative value for West.
+ * @param float|null $longitude Defaults to East, pass in a negative value for West.
  * See also: date.default_longitude
- * @param float $zenith zenith is the angle between the center of the sun
+ * @param float|null $zenith zenith is the angle between the center of the sun
  * and a line perpendicular to earth's surface. It defaults to
  * date.sunrise_zenith
  *
@@ -308,7 +308,7 @@ function date_sun_info(int $timestamp, float $latitude, float $longitude): array
  *
  *
  *
- * @param float $utcOffset Specified in hours.
+ * @param float|null $utcOffset Specified in hours.
  * The utcOffset is ignored, if
  * returnFormat is
  * SUNFUNCS_RET_TIMESTAMP.
@@ -375,11 +375,11 @@ function date_sunrise(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?
  *
  *
  *
- * @param float $latitude Defaults to North, pass in a negative value for South.
+ * @param float|null $latitude Defaults to North, pass in a negative value for South.
  * See also: date.default_latitude
- * @param float $longitude Defaults to East, pass in a negative value for West.
+ * @param float|null $longitude Defaults to East, pass in a negative value for West.
  * See also: date.default_longitude
- * @param float $zenith zenith is the angle between the center of the sun
+ * @param float|null $zenith zenith is the angle between the center of the sun
  * and a line perpendicular to earth's surface. It defaults to
  * date.sunset_zenith
  *
@@ -411,7 +411,7 @@ function date_sunrise(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?
  *
  *
  *
- * @param float $utcOffset Specified in hours.
+ * @param float|null $utcOffset Specified in hours.
  * The utcOffset is ignored, if
  * returnFormat is
  * SUNFUNCS_RET_TIMESTAMP.
@@ -450,7 +450,7 @@ function date_sunset(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?f
  * is optional and defaults to the value of time.
  *
  * @param string $format Format accepted by DateTimeInterface::format.
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -488,21 +488,21 @@ function date(string $format, ?int $timestamp = null): string
  * month, day and year.
  * Negative values reference the hour before midnight of the day in question.
  * Values greater than 23 reference the appropriate hour in the following day(s).
- * @param int $minute The number of the minute relative to the start of the hour.
+ * @param int|null $minute The number of the minute relative to the start of the hour.
  * Negative values reference the minute in the previous hour.
  * Values greater than 59 reference the appropriate minute in the following hour(s).
- * @param int $second The number of seconds relative to the start of the minute.
+ * @param int|null $second The number of seconds relative to the start of the minute.
  * Negative values reference the second in the previous minute.
  * Values greater than 59 reference the appropriate second in the following minute(s).
- * @param int $month The number of the month relative to the end of the previous year.
+ * @param int|null $month The number of the month relative to the end of the previous year.
  * Values 1 to 12 reference the normal calendar months of the year in question.
  * Values less than 1 (including negative values) reference the months in the previous year in reverse order, so 0 is December, -1 is November, etc.
  * Values greater than 12 reference the appropriate month in the following year(s).
- * @param int $day The number of the day relative to the end of the previous month.
+ * @param int|null $day The number of the day relative to the end of the previous month.
  * Values 1 to 28, 29, 30 or 31 (depending upon the month) reference the normal days in the relevant month.
  * Values less than 1 (including negative values) reference the days in the previous month, so 0 is the last day of the previous month, -1 is the day before that, etc.
  * Values greater than the number of days in the relevant month reference the appropriate day in the following month(s).
- * @param int $year The year
+ * @param int|null $year The year
  * @return int Returns a int Unix timestamp on success.
  * @throws DatetimeException
  *
@@ -538,7 +538,7 @@ function gmmktime(int $hour, ?int $minute = null, ?int $second = null, ?int $mon
  * 01:00:00".
  *
  * @param string $format See description in strftime.
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -670,7 +670,7 @@ function gmstrftime(string $format, ?int $timestamp = null): string
  *
  *
  *
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -985,7 +985,7 @@ function idate(string $format, ?int $timestamp = null): int
  *
  * The %z and %Z modifiers both
  * return the time zone name instead of the offset or abbreviation.
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -1106,7 +1106,7 @@ function strptime(string $timestamp, string $format): array
  * ways to define the default time zone.
  *
  * @param string $datetime A date/time string. Valid formats are explained in Date and Time Formats.
- * @param int $baseTimestamp The timestamp which is used as a base for the calculation of relative
+ * @param int|null $baseTimestamp The timestamp which is used as a base for the calculation of relative
  * dates.
  * @return int Returns a timestamp on success.
  * @throws DatetimeException

--- a/generated/8.2/eio.php
+++ b/generated/8.2/eio.php
@@ -13,7 +13,7 @@ use Safe\Exceptions\EioException;
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback This callback is called when all the group requests are done.
+ * @param callable|null $callback This callback is called when all the group requests are done.
  * @param mixed $data Arbitrary variable passed to callback.
  * @return resource eio_busy returns request resource on success.
  * @throws EioException
@@ -41,7 +41,7 @@ function eio_busy(int $delay, int $pri = EIO_PRI_DEFAULT, ?callable $callback = 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -93,7 +93,7 @@ function eio_chmod(string $path, int $mode, int $pri = EIO_PRI_DEFAULT, ?callabl
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -142,7 +142,7 @@ function eio_chown(string $path, int $uid, int $gid = -1, int $pri = EIO_PRI_DEF
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -250,7 +250,7 @@ function eio_custom(callable $execute, int $pri, callable $callback, $data = nul
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -322,7 +322,7 @@ function eio_event_loop(): void
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -372,7 +372,7 @@ function eio_fallocate($fd, int $mode, int $offset, int $length, int $pri = EIO_
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -423,7 +423,7 @@ function eio_fchmod($fd, int $mode, int $pri = EIO_PRI_DEFAULT, ?callable $callb
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -471,7 +471,7 @@ function eio_fchown($fd, int $uid, int $gid = -1, int $pri = EIO_PRI_DEFAULT, ?c
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -625,7 +625,7 @@ function eio_fstatvfs($fd, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -676,7 +676,7 @@ function eio_fsync($fd, int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -727,7 +727,7 @@ function eio_ftruncate($fd, int $offset = 0, int $pri = EIO_PRI_DEFAULT, ?callab
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -796,7 +796,7 @@ function eio_futime($fd, float $atime, float $mtime, int $pri = EIO_PRI_DEFAULT,
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_grp returns request group resource on success.
  * @throws EioException
  *
@@ -870,7 +870,7 @@ function eio_lstat(string $path, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -935,7 +935,7 @@ function eio_mkdir(string $path, int $mode, int $pri = EIO_PRI_DEFAULT, ?callabl
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -983,7 +983,7 @@ function eio_mknod(string $path, int $mode, int $dev, int $pri = EIO_PRI_DEFAULT
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1034,7 +1034,7 @@ function eio_nop(int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, $data =
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1111,7 +1111,7 @@ function eio_readahead($fd, int $offset, int $length, int $pri = EIO_PRI_DEFAULT
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_readdir returns request resource on success.
  * Sets result argument of
  * callback function according to
@@ -1411,7 +1411,7 @@ function eio_readdir(string $path, int $flags, int $pri, callable $callback, ?st
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_readlink returns request resource on success.
  * @throws EioException
  *
@@ -1435,7 +1435,7 @@ function eio_readlink(string $path, int $pri, callable $callback, ?string $data 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1483,7 +1483,7 @@ function eio_rename(string $path, string $new_path, int $pri = EIO_PRI_DEFAULT, 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1539,7 +1539,7 @@ function eio_rmdir(string $path, int $pri = EIO_PRI_DEFAULT, ?callable $callback
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1754,7 +1754,7 @@ function eio_statvfs(string $path, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1813,7 +1813,7 @@ function eio_symlink(string $path, string $new_path, int $pri = EIO_PRI_DEFAULT,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1858,7 +1858,7 @@ function eio_sync_file_range($fd, int $offset, int $nbytes, int $flags, int $pri
  *
  *
  * @param int $pri
- * @param callable $callback
+ * @param callable|null $callback
  * @param mixed $data
  * @return resource eio_sync returns request resource on success.
  * @throws EioException
@@ -1882,7 +1882,7 @@ function eio_sync(int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, $data 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1932,7 +1932,7 @@ function eio_syncfs($fd, int $pri = EIO_PRI_DEFAULT, ?callable $callback = null,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1980,7 +1980,7 @@ function eio_truncate(string $path, int $offset = 0, int $pri = EIO_PRI_DEFAULT,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -2030,7 +2030,7 @@ function eio_unlink(string $path, int $pri = EIO_PRI_DEFAULT, ?callable $callbac
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -2083,7 +2083,7 @@ function eio_utime(string $path, float $atime, float $mtime, int $pri = EIO_PRI_
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *

--- a/generated/8.2/errorfunc.php
+++ b/generated/8.2/errorfunc.php
@@ -57,9 +57,9 @@ use Safe\Exceptions\ErrorfuncException;
  *
  *
  *
- * @param string $destination The destination. Its meaning depends on the
+ * @param null|string $destination The destination. Its meaning depends on the
  * message_type parameter as described above.
- * @param string $additional_headers The extra headers. It's used when the message_type
+ * @param null|string $additional_headers The extra headers. It's used when the message_type
  * parameter is set to 1.
  * This message type uses the same internal function as
  * mail does.

--- a/generated/8.2/exec.php
+++ b/generated/8.2/exec.php
@@ -178,7 +178,7 @@ function proc_nice(int $priority): void
  * PHP process)
  * @param array|null $env_vars An array with the environment variables for the command that will be
  * run, or NULL to use the same environment as the current PHP process
- * @param array $options Allows you to specify additional options. Currently supported options
+ * @param array|null $options Allows you to specify additional options. Currently supported options
  * include:
  *
  *

--- a/generated/8.2/fileinfo.php
+++ b/generated/8.2/fileinfo.php
@@ -30,7 +30,7 @@ function finfo_close(\finfo $finfo): void
  *
  * @param int $flags One or disjunction of more Fileinfo
  * constants.
- * @param string $magic_database Name of a magic database file, usually something like
+ * @param null|string $magic_database Name of a magic database file, usually something like
  * /path/to/magic.mime. If not specified, the
  * MAGIC environment variable is used. If the
  * environment variable isn't set, then PHP's bundled magic database will

--- a/generated/8.2/filesystem.php
+++ b/generated/8.2/filesystem.php
@@ -253,7 +253,7 @@ function fflush($stream): void
  * Seeking (offset) is not supported with remote files.
  * Attempting to seek on non-local files may work with small offsets, but this
  * is unpredictable because it works on the buffered stream.
- * @param int $length Maximum length of data read. The default is to read until end
+ * @param int|null $length Maximum length of data read. The default is to read until end
  * of file is reached. Note that this parameter is applied to the
  * stream processed by the filters.
  * @return string The function returns the read data.
@@ -1027,7 +1027,7 @@ function ftruncate($stream, int $size): void
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
  * @param string $data The string that is to be written.
- * @param int $length If length is an integer, writing will stop
+ * @param int|null $length If length is an integer, writing will stop
  * after length bytes have been written or the
  * end of data is reached, whichever comes first.
  * @return int
@@ -1658,9 +1658,9 @@ function tmpfile()
  * If the file does not exist, it will be created.
  *
  * @param string $filename The name of the file being touched.
- * @param int $mtime The touch time. If mtime is NULL,
+ * @param int|null $mtime The touch time. If mtime is NULL,
  * the current system time is used.
- * @param int $atime If not NULL, the access time of the given filename is set to
+ * @param int|null $atime If not NULL, the access time of the given filename is set to
  * the value of atime. Otherwise, it is set to
  * the value passed to the mtime parameter.
  * If both are NULL, the current system time is used.

--- a/generated/8.2/ibase.php
+++ b/generated/8.2/ibase.php
@@ -112,7 +112,7 @@ function ibase_blob_cancel($blob_handle): void
  * ibase_blob_create creates a new BLOB for filling with
  * data.
  *
- * @param resource $link_identifier An InterBase link identifier. If omitted, the last opened link is
+ * @param null|resource $link_identifier An InterBase link identifier. If omitted, the last opened link is
  * assumed.
  * @return resource Returns a BLOB handle for later use with
  * ibase_blob_add.
@@ -161,7 +161,7 @@ function ibase_blob_get($blob_handle, int $len): string
  * Default transaction on link is committed, other transactions are
  * rolled back.
  *
- * @param resource $connection_id An InterBase link identifier returned from
+ * @param null|resource $connection_id An InterBase link identifier returned from
  * ibase_connect. If omitted, the last opened link
  * is assumed.
  * @throws IbaseException
@@ -184,7 +184,7 @@ function ibase_close($connection_id = null): void
 /**
  * Commits a transaction without closing it.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function commits the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function commits the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be committed. If the argument is a transaction identifier, the
@@ -211,7 +211,7 @@ function ibase_commit_ret($link_or_trans_identifier = null): void
 /**
  * Commits a transaction.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function commits the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function commits the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be committed. If the argument is a transaction identifier, the
@@ -317,7 +317,7 @@ function ibase_delete_user($service_handle, string $user_name): void
  * This functions drops a database that was opened by either ibase_connect
  * or ibase_pconnect. The database is closed and deleted from the server.
  *
- * @param resource $connection An InterBase link identifier. If omitted, the last opened link is
+ * @param null|resource $connection An InterBase link identifier. If omitted, the last opened link is
  * assumed.
  * @throws IbaseException
  *
@@ -573,7 +573,7 @@ function ibase_restore($service_handle, string $source_file, string $dest_db, in
 /**
  * Rolls back a transaction without closing it.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function rolls back the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function rolls back the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be rolled back. If the argument is a transaction identifier, the
@@ -600,7 +600,7 @@ function ibase_rollback_ret($link_or_trans_identifier = null): void
 /**
  * Rolls back a transaction.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function rolls back the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function rolls back the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be rolled back. If the argument is a transaction identifier, the

--- a/generated/8.2/iconv.php
+++ b/generated/8.2/iconv.php
@@ -76,7 +76,7 @@ function iconv_get_encoding(string $type = "all")
  *
  *
  *
- * @param string $encoding The optional encoding parameter specifies the
+ * @param null|string $encoding The optional encoding parameter specifies the
  * character set to represent the result by. If omitted or NULL,
  * iconv.internal_encoding
  * will be used.
@@ -249,7 +249,7 @@ function iconv_set_encoding(string $type, string $encoding): void
  * identical to the length of the string in byte.
  *
  * @param string $string The string.
- * @param string $encoding If encoding parameter is omitted or NULL,
+ * @param null|string $encoding If encoding parameter is omitted or NULL,
  * string is assumed to be encoded in
  * iconv.internal_encoding.
  * @return int Returns the character count of string, as an integer,

--- a/generated/8.2/image.php
+++ b/generated/8.2/image.php
@@ -104,7 +104,7 @@ function image_type_to_extension(int $image_type, bool $include_dot = true): str
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param array $affine Array with keys 0 to 5.
- * @param array $clip Array with keys "x", "y", "width" and "height"; or NULL.
+ * @param array|null $clip Array with keys "x", "y", "width" and "height"; or NULL.
  * @return \GdImage Return affined image object on success.
  * @throws ImageException
  *
@@ -2096,8 +2096,8 @@ function imagerectangle(\GdImage $image, int $x1, int $y1, int $x2, int $y2, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param int $resolution_x The horizontal resolution in DPI.
- * @param int $resolution_y The vertical resolution in DPI.
+ * @param int|null $resolution_x The horizontal resolution in DPI.
+ * @param int|null $resolution_y The vertical resolution in DPI.
  * @return mixed When used as getter,
  * it returns an indexed array of the horizontal and vertical resolution on
  * success.
@@ -2790,7 +2790,7 @@ function imagettftext(\GdImage $image, float $size, float $angle, int $x, int $y
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
- * @param int $foreground_color You can set the foreground color with this parameter by setting an
+ * @param int|null $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black.
  * @throws ImageException
@@ -2852,7 +2852,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  * alphanumeric characters of the current locale are substituted by
  * underscores. If filename is set to NULL,
  * image is used to build the C identifiers.
- * @param int $foreground_color You can set the foreground color with this parameter by setting an
+ * @param int|null $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black. All other colors are treated as
  * background.

--- a/generated/8.2/imap.php
+++ b/generated/8.2/imap.php
@@ -35,9 +35,9 @@ function imap_8bit(string $string): string
  * When talking to the Cyrus IMAP server, you must use "\r\n" as
  * your end-of-line terminator instead of "\n" or the operation will
  * fail
- * @param string $options If provided, the options will also be written
+ * @param null|string $options If provided, the options will also be written
  * to the folder
- * @param string $internal_date If this parameter is set, it will set the INTERNALDATE on the appended message.  The parameter should be a date string that conforms to the rfc2060 specifications for a date_time value.
+ * @param null|string $internal_date If this parameter is set, it will set the INTERNALDATE on the appended message.  The parameter should be a date string that conforms to the rfc2060 specifications for a date_time value.
  * @throws ImapException
  *
  */
@@ -1443,11 +1443,11 @@ function imap_mail_move(\IMAP\Connection $imap, string $message_nums, string $ma
  * @param string $to The receiver
  * @param string $subject The mail subject
  * @param string $message The mail body, see imap_mail_compose
- * @param string $additional_headers As string with additional headers to be set on the mail
- * @param string $cc
- * @param string $bcc The receivers specified in bcc will get the
+ * @param null|string $additional_headers As string with additional headers to be set on the mail
+ * @param null|string $cc
+ * @param null|string $bcc The receivers specified in bcc will get the
  * mail, but are excluded from the headers.
- * @param string $return_path Use this parameter to specify return path upon mail delivery failure.
+ * @param null|string $return_path Use this parameter to specify return path upon mail delivery failure.
  * This is useful when using PHP as a mail client for multiple users.
  * @throws ImapException
  *
@@ -2055,9 +2055,9 @@ function imap_setflag_full(\IMAP\Connection $imap, string $sequence, string $fla
  *
  *
  *
- * @param string $search_criteria IMAP2-format search criteria string. For details see
+ * @param null|string $search_criteria IMAP2-format search criteria string. For details see
  * imap_search.
- * @param string $charset MIME character set to use when sorting strings.
+ * @param null|string $charset MIME character set to use when sorting strings.
  * @return array Returns an array of message numbers sorted by the given
  * parameters.
  * @throws ImapException

--- a/generated/8.2/ldap.php
+++ b/generated/8.2/ldap.php
@@ -43,7 +43,7 @@ function ldap_8859_to_t61(string $value): string
  * ]]>
  *
  *
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -94,7 +94,7 @@ function ldap_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $password
  * @param string $dn The distinguished name of an LDAP entity.
  * @param string $attribute The attribute name.
  * @param string $value The compared value.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @return bool Returns TRUE if value matches otherwise returns
  * FALSE.
  * @throws LdapException
@@ -184,7 +184,7 @@ function ldap_count_entries(\LDAP\Connection $ldap, \LDAP\Result $result): int
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -229,7 +229,7 @@ function ldap_dn2ufn(string $dn): string
  * @param string $user dn of the user to change the password of.
  * @param string $old_password The old password of this user. May be ommited depending of server configuration.
  * @param string $new_password The new password for this user. May be omitted or empty to have a generated password.
- * @param array $controls If provided, a password policy request control is send with the request and this is
+ * @param array|null $controls If provided, a password policy request control is send with the request and this is
  * filled with an array of LDAP Controls
  * returned with the request.
  * @return bool|string Returns the generated password if new_password is empty or omitted.
@@ -274,7 +274,7 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $request_oid The extended operation request OID. You may use one of LDAP_EXOP_START_TLS, LDAP_EXOP_MODIFY_PASSWD, LDAP_EXOP_REFRESH, LDAP_EXOP_WHO_AM_I, LDAP_EXOP_TURN, or a string with the OID of the operation you want to send.
- * @param string $request_data The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
+ * @param null|string $request_data The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
  * @param array|null $controls Array of LDAP Controls to send with the request.
  * @param null|string $response_data Will be filled with the extended operation response data if provided.
  * If not provided you may use ldap_parse_exop on the result object
@@ -763,7 +763,7 @@ function ldap_get_values(\LDAP\Connection $ldap, \LDAP\ResultEntry $entry, strin
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry An associative array listing the attirbute values to add. If an attribute was not existing yet it will be added. If an attribute is existing you can only add values to it if it supports multiple values.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -789,7 +789,7 @@ function ldap_mod_add(\LDAP\Connection $ldap, string $dn, array $entry, ?array $
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -814,7 +814,7 @@ function ldap_mod_del(\LDAP\Connection $ldap, string $dn, array $entry, ?array $
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry An associative array listing the attributes to replace. Sending an empty array as value will remove the attribute, while sending an attribute not existing yet on this entry will add it.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -911,7 +911,7 @@ function ldap_mod_replace(\LDAP\Connection $ldap, string $dn, array $entry, ?arr
  * value for values must be an array of strings, and
  * any value for modtype must be one of the
  * LDAP_MODIFY_BATCH_* constants listed above.
- * @param array $controls Each value specified through values is added (as
+ * @param array|null $controls Each value specified through values is added (as
  * an additional value) to the attribute named by
  * attrib.
  * @throws LdapException
@@ -1012,7 +1012,7 @@ function ldap_parse_result(\LDAP\Connection $ldap, \LDAP\Result $result, ?int &$
  * @param string $new_parent The new parent/superior entry.
  * @param bool $delete_old_rdn If TRUE the old RDN value(s) is removed, else the old RDN value(s)
  * is retained as non-distinguished values of the entry.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -1034,13 +1034,13 @@ function ldap_rename(\LDAP\Connection $ldap, string $dn, string $new_rdn, string
  *
  *
  * @param \LDAP\Connection $ldap
- * @param string $dn
- * @param string $password
- * @param string $mech
- * @param string $realm
- * @param string $authc_id
- * @param string $authz_id
- * @param string $props
+ * @param null|string $dn
+ * @param null|string $password
+ * @param null|string $mech
+ * @param null|string $realm
+ * @param null|string $authc_id
+ * @param null|string $authz_id
+ * @param null|string $props
  * @throws LdapException
  *
  */

--- a/generated/8.2/mbstring.php
+++ b/generated/8.2/mbstring.php
@@ -11,7 +11,7 @@ use Safe\Exceptions\MbstringException;
  * This function complements mb_ord.
  *
  * @param int $codepoint A Unicode codepoint value, e.g. 128024 for U+1F418 ELEPHANT
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return string A string containing the requested character, if it can be represented in the specified
@@ -77,7 +77,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * Sets the automatic character
  * encoding detection order to encoding.
  *
- * @param non-empty-array|non-falsy-string $encoding encoding is an array or
+ * @param non-empty-array|non-falsy-string|null $encoding encoding is an array or
  * comma separated list of character encoding. See supported encodings.
  *
  * If encoding is omitted or NULL, it returns
@@ -163,7 +163,7 @@ function mb_encoding_aliases(string $encoding): array
  * clutter the function namespace with a callback function's name
  * not used anywhere else.
  * @param string $string The string being checked.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -193,7 +193,7 @@ function mb_ereg_replace_callback(string $pattern, callable $callback, string $s
  * Multibyte characters may be used in pattern.
  * @param string $replacement The replacement text.
  * @param string $string The string being checked.
- * @param string $options
+ * @param null|string $options
  * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -242,8 +242,8 @@ function mb_ereg_search_getregs(): array
  * mb_ereg_search_regs.
  *
  * @param string $string The search string.
- * @param string $pattern The search pattern.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $pattern The search pattern.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @throws MbstringException
  *
  */
@@ -266,8 +266,8 @@ function mb_ereg_search_init(string $string, ?string $pattern = null, ?string $o
 /**
  * Returns the matched part of a multibyte regular expression.
  *
- * @param string $pattern The search pattern.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $pattern The search pattern.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @return array
  * @throws MbstringException
  *
@@ -312,7 +312,7 @@ function mb_ereg_search_setpos(int $offset): void
  * @param string $pattern The regular expression pattern.  Multibyte characters may be used. The case will be ignored.
  * @param string $replacement The replacement text.
  * @param string $string The searched string.
- * @param string $options
+ * @param null|string $options
  * @return string The resultant string.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -376,7 +376,7 @@ function mb_get_info(string $type = "all")
  * Set/Get the HTTP output character encoding.
  * Output after this function is called will be converted from the set internal encoding to encoding.
  *
- * @param string $encoding If encoding is set,
+ * @param null|string $encoding If encoding is set,
  * mb_http_output sets the HTTP output character
  * encoding to encoding.
  *
@@ -408,7 +408,7 @@ function mb_http_output(?string $encoding = null)
 /**
  * Set/Get the internal character encoding
  *
- * @param string $encoding encoding is the character encoding name
+ * @param null|string $encoding encoding is the character encoding name
  * used for the HTTP input character encoding conversion, HTTP output
  * character encoding conversion, and the default character encoding
  * for string functions defined by the mbstring module.
@@ -442,7 +442,7 @@ function mb_internal_encoding(?string $encoding = null)
  * This function complements mb_chr.
  *
  * @param string $string A string
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return int The Unicode code point for the first character of string.
@@ -490,7 +490,7 @@ function mb_parse_str(string $string, ?array &$result): void
 /**
  * Set/Get character encoding for a multibyte regex.
  *
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return bool|string
@@ -549,7 +549,7 @@ function mb_regex_encoding(?string $encoding = null)
  * automatically (which leads to doubling CR if CRLF is used).
  * This should be a last resort, as it does not comply with
  * RFC 2822.
- * @param string $additional_params additional_params is a MTA command line
+ * @param null|string $additional_params additional_params is a MTA command line
  * parameter. It is useful when setting the correct Return-Path
  * header when using sendmail.
  *

--- a/generated/8.2/misc.php
+++ b/generated/8.2/misc.php
@@ -400,7 +400,7 @@ function sapi_windows_set_ctrl_handler(?callable $handler, bool $add = true): vo
  * They allow the modification of the terminal's output. On Windows these sequences are called Console Virtual Terminal Sequences.
  *
  * @param resource $stream The stream on which the function will operate.
- * @param bool $enable If bool, the VT100 feature will be enabled (if TRUE) or disabled (if FALSE).
+ * @param bool|null $enable If bool, the VT100 feature will be enabled (if TRUE) or disabled (if FALSE).
  * @throws MiscException
  *
  */

--- a/generated/8.2/mysql.php
+++ b/generated/8.2/mysql.php
@@ -18,7 +18,7 @@ use Safe\Exceptions\MysqlException;
  * improve performance. For related information, see
  * freeing resources
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no connection is found or
  * established, an E_WARNING level error is
@@ -102,7 +102,7 @@ function mysql_connect(?string $server = null, ?string $username = null, ?string
  * identifier.
  *
  * @param string $database_name The name of the database being created.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -184,7 +184,7 @@ function mysql_db_name($result, int $row, $field = null): string
  * @param string $query The MySQL query.
  *
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -215,7 +215,7 @@ function mysql_db_query(string $database, string $query, $link_identifier = null
  * DROP DATABASE statement instead.
  *
  * @param string $database_name The name of the database that will be deleted.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -407,7 +407,7 @@ function mysql_free_result($result): void
  * Describes the type of connection in use for the connection, including the
  * server host name.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -432,7 +432,7 @@ function mysql_get_host_info($link_identifier = null): string
 /**
  * Retrieves the MySQL protocol.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -456,7 +456,7 @@ function mysql_get_proto_info($link_identifier = null): int
 /**
  * Retrieves the MySQL server version.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -480,7 +480,7 @@ function mysql_get_server_info($link_identifier = null): string
 /**
  * Returns detailed information about the last query.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -507,7 +507,7 @@ function mysql_info($link_identifier = null): string
  * Returns a result pointer containing the databases available from the
  * current mysql daemon.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -539,7 +539,7 @@ function mysql_list_dbs($link_identifier = null)
  *
  * @param string $database_name The name of the database that's being queried.
  * @param string $table_name The name of the table that's being queried.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -568,7 +568,7 @@ function mysql_list_fields(string $database_name, string $table_name, $link_iden
 /**
  * Retrieves the current MySQL server threads.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -597,7 +597,7 @@ function mysql_list_processes($link_identifier = null)
  * [FROM db_name] [LIKE 'pattern'] statement instead.
  *
  * @param string $database The name of the database
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -678,7 +678,7 @@ function mysql_num_rows($result): int
  *
  * The query string should not end with a semicolon.
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -734,7 +734,7 @@ function mysql_query(string $query, $link_identifier = null)
  * safe before sending a query to MySQL.
  *
  * @param string $unescaped_string The string that is to be escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -798,7 +798,7 @@ function mysql_result($result, int $row, $field = 0): string
  * mysql_query will be made on the active database.
  *
  * @param string $database_name The name of the database that is to be selected.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -821,7 +821,7 @@ function mysql_select_db(string $database_name, $link_identifier = null): void
  * Sets the default character set for the current connection.
  *
  * @param string $charset A valid character set name.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -874,7 +874,7 @@ function mysql_tablename($result, int $i): string
  * with mysql_ping is executed, the thread ID will
  * change. This means only retrieve the thread ID when needed.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -912,7 +912,7 @@ function mysql_thread_id($link_identifier = null): int
  * @param string $query The SQL query to execute.
  *
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called

--- a/generated/8.2/network.php
+++ b/generated/8.2/network.php
@@ -290,7 +290,7 @@ function dns_get_record(string $hostname, int $type = DNS_ANY, ?array &$authorit
  * connect() call. This is most likely due to a
  * problem initializing the socket.
  * @param null|string $error_message The error message as a string.
- * @param float $timeout The connection timeout, in seconds. When NULL, the
+ * @param float|null $timeout The connection timeout, in seconds. When NULL, the
  * default_socket_timeout php.ini setting is used.
  *
  * If you need to set a timeout for reading/writing data over the
@@ -748,7 +748,7 @@ function openlog(string $prefix, int $flags, int $facility): void
  * @param int $port
  * @param int|null $error_code
  * @param null|string $error_message
- * @param float $timeout
+ * @param float|null $timeout
  * @return resource pfsockopen returns a file pointer which may be used
  * together with the other file functions (such as
  * fgets, fgetss,

--- a/generated/8.2/oci8.php
+++ b/generated/8.2/oci8.php
@@ -389,7 +389,7 @@ function oci_commit($connection): void
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from
@@ -780,7 +780,7 @@ function oci_free_statement($statement): void
  * @param resource $connection An Oracle connection identifier, returned by
  * oci_connect or oci_pconnect.
  * @param string $type_name Should be a valid named type (uppercase).
- * @param string $schema Should point to the scheme, where the named type was created. The name
+ * @param null|string $schema Should point to the scheme, where the named type was created. The name
  * of the current user is used when NULL is passed.
  * @return \OCI-Collection Returns a new OCICollection object.
  * @throws Oci8Exception
@@ -812,7 +812,7 @@ function oci_new_collection($connection, string $type_name, ?string $schema = nu
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from
@@ -1015,7 +1015,7 @@ function oci_parse($connection, string $sql)
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from

--- a/generated/8.2/openssl.php
+++ b/generated/8.2/openssl.php
@@ -293,7 +293,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  * otherwise obtained from the other openssl_pkey family of functions).
  * The corresponding public portion of the key will be used to sign the
  * CSR.
- * @param array $options By default, the information in your system openssl.conf
+ * @param array|null $options By default, the information in your system openssl.conf
  * is used to initialize the request; you can specify a configuration file
  * section by setting the config_section_section key of
  * options.  You can also specify an alternative
@@ -385,7 +385,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  *
  *
  *
- * @param array $extra_attributes extra_attributes is used to specify additional
+ * @param array|null $extra_attributes extra_attributes is used to specify additional
  * configuration options for the CSR.  Both distinguished_names and
  * extra_attributes are associative arrays whose keys are
  * converted to OIDs and applied to the relevant part of the request.
@@ -424,7 +424,7 @@ function openssl_csr_new(array $distinguished_names, \OpenSSLAsymmetricKey &$pri
  * ca_certificate.
  * @param int $days days specifies the length of time for which the
  * generated certificate will be valid, in days.
- * @param array $options You can finetune the CSR signing by options.
+ * @param array|null $options You can finetune the CSR signing by options.
  * See openssl_csr_new for more information about
  * options.
  * @param int $serial An optional the serial number of issued certificate. If not specified
@@ -461,7 +461,7 @@ function openssl_csr_sign($csr, $ca_certificate, $private_key, int $days, ?array
  * OPENSSL_RAW_DATA,
  * OPENSSL_ZERO_PADDING.
  * @param string $iv A non-NULL Initialization Vector.
- * @param string $tag The authentication tag in AEAD cipher mode. If it is incorrect, the authentication fails and the function returns FALSE.
+ * @param null|string $tag The authentication tag in AEAD cipher mode. If it is incorrect, the authentication fails and the function returns FALSE.
  * @param string $aad Additional authenticated data.
  * @return string The decrypted string on success.
  * @throws OpensslException
@@ -613,7 +613,7 @@ function openssl_get_curve_names(): array
  * It is strongly recommended to explicitly specify a secure cipher method.
  *
  *
- * @param string $iv The initialization vector.
+ * @param null|string $iv The initialization vector.
  * @throws OpensslException
  *
  */
@@ -861,7 +861,7 @@ function openssl_pkcs7_read(string $data, ?array &$certificates): void
  * openssl_pkcs7_encrypt for more information about
  * the format of this parameter).
  * @param int $flags flags can be used to alter the output - see PKCS7 constants.
- * @param string $untrusted_certificates_filename untrusted_certificates_filename specifies the name of a file containing
+ * @param null|string $untrusted_certificates_filename untrusted_certificates_filename specifies the name of a file containing
  * a bunch of extra certificates to include in the signature which can for
  * example be used to help the recipient to verify the certificate that you used.
  * @throws OpensslException
@@ -914,7 +914,7 @@ function openssl_pkey_derive($public_key, $private_key, int $key_length = 0): st
  * @param string $output_filename Path to the output file.
  * @param null|string $passphrase The key can be optionally protected by a
  * passphrase.
- * @param array $options options can be used to fine-tune the export
+ * @param array|null $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file. See openssl_csr_new for more
  * information about options.
@@ -945,7 +945,7 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param null|string $output
  * @param null|string $passphrase The key is optionally protected by passphrase.
- * @param array $options options can be used to fine-tune the export
+ * @param array|null $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file.  See openssl_csr_new for more
  * information about options.
@@ -1037,7 +1037,7 @@ function openssl_pkey_get_public($public_key): \OpenSSLAsymmetricKey
  * key.
  * How to obtain the public component of the key is shown in an example below.
  *
- * @param array $options You can finetune the key generation (such as specifying the number of
+ * @param array|null $options You can finetune the key generation (such as specifying the number of
  * bits) using options.  See
  * openssl_csr_new for more information about
  * options.
@@ -1413,7 +1413,7 @@ function openssl_verify(string $data, string $signature, $public_key, $algorithm
  * @param array $ca_info ca_info should be an array of trusted CA files/dirs
  * as described in Certificate
  * Verification.
- * @param string $untrusted_certificates_file If specified, this should be the name of a PEM encoded file holding
+ * @param null|string $untrusted_certificates_file If specified, this should be the name of a PEM encoded file holding
  * certificates that can be used to help verify the certificate, although
  * no trust is placed in the certificates that come from that file.
  * @return bool|int Returns TRUE if the certificate can be used for the intended purpose,

--- a/generated/8.2/pcntl.php
+++ b/generated/8.2/pcntl.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\PcntlException;
  * system types and kernel versions, please see your system's getpriority(2)
  * man page for specific details.
  *
- * @param int $process_id If NULL, the process id of the current process is used.
+ * @param int|null $process_id If NULL, the process id of the current process is used.
  * @param int $mode One of PRIO_PGRP, PRIO_USER,
  * PRIO_PROCESS,
  * PRIO_DARWIN_BG or PRIO_DARWIN_THREAD.
@@ -46,7 +46,7 @@ function pcntl_getpriority(?int $process_id = null, int $mode = PRIO_PROCESS): i
  * favorable scheduling.  Because priority levels can differ between
  * system types and kernel versions, please see your system's setpriority(2)
  * man page for specific details.
- * @param int $process_id If NULL, the process id of the current process is used.
+ * @param int|null $process_id If NULL, the process id of the current process is used.
  * @param int $mode One of PRIO_PGRP, PRIO_USER,
  * PRIO_PROCESS,
  * PRIO_DARWIN_BG or PRIO_DARWIN_THREAD.

--- a/generated/8.2/pgsql.php
+++ b/generated/8.2/pgsql.php
@@ -765,7 +765,7 @@ function pg_lo_unlink(\PgSql\Connection $connection, int $oid): void
  * @param string $data The data to be written to the large object.  If length is
  * an int and is less than the length of data, only
  * length bytes will be written.
- * @param int $length An optional maximum number of bytes to write.  Must be greater than zero
+ * @param int|null $length An optional maximum number of bytes to write.  Must be greater than zero
  * and no greater than the length of data.  Defaults to
  * the length of data.
  * @return int The number of bytes written to the large object.

--- a/generated/8.2/readline.php
+++ b/generated/8.2/readline.php
@@ -86,7 +86,7 @@ function readline_completion_function(callable $callback): void
 /**
  * This function reads a command history from a file.
  *
- * @param string $filename Path to the filename containing the command history.
+ * @param null|string $filename Path to the filename containing the command history.
  * @throws ReadlineException
  *
  */
@@ -107,7 +107,7 @@ function readline_read_history(?string $filename = null): void
 /**
  * This function writes the command history to a file.
  *
- * @param string $filename Path to the saved file.
+ * @param null|string $filename Path to the saved file.
  * @throws ReadlineException
  *
  */

--- a/generated/8.2/sem.php
+++ b/generated/8.2/sem.php
@@ -434,7 +434,7 @@ function sem_remove(\SysvSemaphore $semaphore): void
  * permissions will be ignored.
  *
  * @param int $key A numeric shared memory segment ID
- * @param int $size The memory size. If not provided, default to the
+ * @param int|null $size The memory size. If not provided, default to the
  * sysvshm.init_mem in the php.ini, otherwise 10000
  * bytes.
  * @param int $permissions The optional permission bits. Default to 0666.

--- a/generated/8.2/session.php
+++ b/generated/8.2/session.php
@@ -136,7 +136,7 @@ function session_encode(): string
  * adding to URLs. See also Session
  * handling.
  *
- * @param string $id If id is specified and not NULL, it will replace the current
+ * @param null|string $id If id is specified and not NULL, it will replace the current
  * session id. session_id needs to be called before
  * session_start for that purpose. Depending on the
  * session handler, not all characters are allowed within the session id.
@@ -169,7 +169,7 @@ function session_id(?string $id = null): string
  * session module, which is also known as
  * session.save_handler.
  *
- * @param string $module If module is specified and not NULL, that module will be
+ * @param null|string $module If module is specified and not NULL, that module will be
  * used instead.
  * Passing "user" to this parameter is forbidden. Instead
  * session_set_save_handler has to be called to set a user
@@ -213,7 +213,7 @@ function session_module_name(?string $module = null): string
  * call session_name for every request (and before
  * session_start is called).
  *
- * @param string $name The session name references the name of the session, which is
+ * @param null|string $name The session name references the name of the session, which is
  * used in cookies and URLs (e.g. PHPSESSID). It
  * should contain only alphanumeric characters; it should be short and
  * descriptive (i.e. for users with enabled cookie warnings).
@@ -297,7 +297,7 @@ function session_reset(): void
  * session_save_path returns the path of the current
  * directory used to save session data.
  *
- * @param string $path Session data path. If specified and not NULL, the path to which data is saved will
+ * @param null|string $path Session data path. If specified and not NULL, the path to which data is saved will
  * be changed. session_save_path needs to be called
  * before session_start for that purpose.
  *

--- a/generated/8.2/sockets.php
+++ b/generated/8.2/sockets.php
@@ -160,7 +160,7 @@ function socket_bind(\Socket $socket, string $address, int $port = 0): void
  * socket is AF_INET6
  * or the pathname of a Unix domain socket, if the socket family is
  * AF_UNIX.
- * @param int $port The port parameter is only used and is mandatory
+ * @param int|null $port The port parameter is only used and is mandatory
  * when connecting to an AF_INET or an
  * AF_INET6 socket, and designates
  * the port on the remote host to which a connection should be made.
@@ -645,7 +645,7 @@ function socket_sendmsg(\Socket $socket, array $message, int $flags = 0): int
  *
  *
  * @param string $address IP address of the remote host.
- * @param int $port port is the remote port number at which the data
+ * @param int|null $port port is the remote port number at which the data
  * will be sent.
  * @return int socket_sendto returns the number of bytes sent to the
  * remote host.

--- a/generated/8.2/spl.php
+++ b/generated/8.2/spl.php
@@ -84,7 +84,7 @@ function class_uses($object_or_class, bool $autoload = true): array
  * runs through each of them in the order they are defined. By contrast,
  * __autoload may only be defined once.
  *
- * @param callable(string):void $callback The autoload function being registered.
+ * @param callable(string):void|null $callback The autoload function being registered.
  * If NULL, then the default implementation of
  * spl_autoload will be registered.
  * @param bool $throw This parameter specifies whether

--- a/generated/8.2/ssh2.php
+++ b/generated/8.2/ssh2.php
@@ -717,7 +717,7 @@ function ssh2_sftp($session)
  * ssh2_connect.
  * @param string $termtype termtype should correspond to one of the
  * entries in the target system's /etc/termcap file.
- * @param array $env env may be passed as an associative array of
+ * @param array|null $env env may be passed as an associative array of
  * name/value pairs to set in the target environment.
  * @param int $width Width of the virtual terminal.
  * @param int $height Height of the virtual terminal.

--- a/generated/8.2/stream.php
+++ b/generated/8.2/stream.php
@@ -33,7 +33,7 @@ function stream_context_set_params($context, array $params): void
  *
  * @param resource $from The source stream
  * @param resource $to The destination stream
- * @param int $length Maximum bytes to copy. By default all bytes left are copied.
+ * @param int|null $length Maximum bytes to copy. By default all bytes left are copied.
  * @param int $offset The offset where to start to copy data
  * @return int Returns the total count of bytes copied.
  * @throws StreamException
@@ -210,7 +210,7 @@ function stream_filter_remove($stream_filter): void
  * offset.
  *
  * @param resource $stream A stream resource (e.g. returned from fopen)
- * @param int $length The maximum bytes to read. Defaults to NULL (read all the remaining
+ * @param int|null $length The maximum bytes to read. Defaults to NULL (read all the remaining
  * buffer).
  * @param int $offset Seek to the specified offset before reading. If this number is negative,
  * no seeking will occur and reading will start from the current position.
@@ -364,7 +364,7 @@ function stream_set_timeout($stream, int $seconds, int $microseconds = 0): void
  * stream_socket_server.
  *
  * @param resource $socket The server socket to accept a connection from.
- * @param float $timeout Override the default socket accept timeout. Time should be given in
+ * @param float|null $timeout Override the default socket accept timeout. Time should be given in
  * seconds. By default, default_socket_timeout
  * is used.
  * @param null|string $peer_name Will be set to the name (address) of the client which connected, if
@@ -407,7 +407,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * @param string $address Address to the socket to connect to.
  * @param int|null $error_code Will be set to the system level error number if connection fails.
  * @param null|string $error_message Will be set to the system level error message if the connection fails.
- * @param float $timeout Number of seconds until the connect() system call
+ * @param float|null $timeout Number of seconds until the connect() system call
  * should timeout. By default, default_socket_timeout
  * is used.
  *

--- a/generated/8.2/uodbc.php
+++ b/generated/8.2/uodbc.php
@@ -197,16 +197,16 @@ function odbc_columnprivileges($odbc, string $catalog, string $schema, string $t
  *
  * @param resource $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $table The table name.
+ * @param null|string $table The table name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $column The column name.
+ * @param null|string $column The column name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
@@ -774,16 +774,16 @@ function odbc_primarykeys($odbc, string $catalog, string $schema, string $table)
  *
  * @param  $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $procedure The proc.
+ * @param null|string $procedure The proc.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $column The column.
+ * @param null|string $column The column.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
@@ -843,12 +843,12 @@ function odbc_procedurecolumns($odbc, ?string $catalog = null, ?string $schema =
  *
  * @param  $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $procedure The name.
+ * @param null|string $procedure The name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
@@ -1170,16 +1170,16 @@ function odbc_tableprivileges($odbc, string $catalog, string $schema, string $ta
  *
  * @param resource $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $table The name.
+ * @param null|string $table The name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $types If table_type is not an empty string, it
+ * @param null|string $types If table_type is not an empty string, it
  * must contain a list of comma-separated values for the types of
  * interest; each value may be enclosed in single quotes (') or
  * unquoted. For example, 'TABLE','VIEW' or TABLE, VIEW.  If the

--- a/generated/8.2/yaml.php
+++ b/generated/8.2/yaml.php
@@ -12,7 +12,7 @@ use Safe\Exceptions\YamlException;
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * details.
@@ -50,7 +50,7 @@ function yaml_parse_file(string $filename, int $pos = 0, ?int &$ndocs = null, ?a
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * @return mixed Returns the value encoded in input in appropriate
@@ -83,7 +83,7 @@ function yaml_parse_url(string $url, int $pos = 0, ?int &$ndocs = null, ?array $
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * details.

--- a/generated/8.2/zlib.php
+++ b/generated/8.2/zlib.php
@@ -293,7 +293,7 @@ function gzfile(string $filename, int $use_include_path = 0): array
  *
  * @param resource $stream The gz-file pointer. It must be valid, and must point to a file
  * successfully opened by gzopen.
- * @param int $length The length of data to get.
+ * @param int|null $length The length of data to get.
  * @return string The uncompressed string.
  * @throws ZlibException
  *
@@ -491,7 +491,7 @@ function gzuncompress(string $data, int $max_length = 0): string
  * @param resource $stream The gz-file pointer. It must be valid, and must point to a file
  * successfully opened by gzopen.
  * @param string $data The string to write.
- * @param int $length The number of uncompressed bytes to write. If supplied, writing will
+ * @param int|null $length The number of uncompressed bytes to write. If supplied, writing will
  * stop after length (uncompressed) bytes have been
  * written or the end of data is reached,
  * whichever comes first.

--- a/generated/8.3/bzip2.php
+++ b/generated/8.3/bzip2.php
@@ -98,7 +98,7 @@ function bzread($bz, int $length = 1024): string
  * @param resource $bz The file pointer. It must be valid and must point to a file
  * successfully opened by bzopen.
  * @param string $data The written data.
- * @param int $length If supplied, writing will stop after length
+ * @param int|null $length If supplied, writing will stop after length
  * (uncompressed) bytes have been written or the end of
  * data is reached, whichever comes first.
  * @return int Returns the number of bytes written.

--- a/generated/8.3/calendar.php
+++ b/generated/8.3/calendar.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\CalendarException;
  * timestamp is given. Either way, the time is regarded
  * as local time (not UTC).
  *
- * @param int $timestamp A unix timestamp to convert.
+ * @param int|null $timestamp A unix timestamp to convert.
  * @return int A julian day number as integer.
  * @throws CalendarException
  *

--- a/generated/8.3/com.php
+++ b/generated/8.3/com.php
@@ -132,7 +132,7 @@ function com_load_typelib(string $typelib, bool $case_insensitive = true): void
  * @param object $variant variant should be either an instance of a COM
  * object, or be the name of a typelibrary (which will be resolved according
  * to the rules set out in com_load_typelib).
- * @param string $dispatch_interface The name of an IDispatch descendant interface that you want to display.
+ * @param null|string $dispatch_interface The name of an IDispatch descendant interface that you want to display.
  * @param bool $display_sink If set to TRUE, the corresponding sink interface will be displayed
  * instead.
  * @throws ComException

--- a/generated/8.3/curl.php
+++ b/generated/8.3/curl.php
@@ -75,7 +75,7 @@ function curl_exec(\CurlHandle $handle)
  *
  * @param \CurlHandle $handle A cURL handle returned by
  * curl_init.
- * @param int $option This may be one of the following constants:
+ * @param int|null $option This may be one of the following constants:
  *
  *
  *
@@ -552,7 +552,7 @@ function curl_getinfo(\CurlHandle $handle, ?int $option = null)
  * curl_setopt, curl_exec,
  * and curl_close functions.
  *
- * @param string $url If provided, the CURLOPT_URL option will be set
+ * @param null|string $url If provided, the CURLOPT_URL option will be set
  * to its value. You can manually set this using the
  * curl_setopt function.
  *

--- a/generated/8.3/datetime.php
+++ b/generated/8.3/datetime.php
@@ -272,11 +272,11 @@ function date_sun_info(int $timestamp, float $latitude, float $longitude): array
  *
  *
  *
- * @param float $latitude Defaults to North, pass in a negative value for South.
+ * @param float|null $latitude Defaults to North, pass in a negative value for South.
  * See also: date.default_latitude
- * @param float $longitude Defaults to East, pass in a negative value for West.
+ * @param float|null $longitude Defaults to East, pass in a negative value for West.
  * See also: date.default_longitude
- * @param float $zenith zenith is the angle between the center of the sun
+ * @param float|null $zenith zenith is the angle between the center of the sun
  * and a line perpendicular to earth's surface. It defaults to
  * date.sunrise_zenith
  *
@@ -308,7 +308,7 @@ function date_sun_info(int $timestamp, float $latitude, float $longitude): array
  *
  *
  *
- * @param float $utcOffset Specified in hours.
+ * @param float|null $utcOffset Specified in hours.
  * The utcOffset is ignored, if
  * returnFormat is
  * SUNFUNCS_RET_TIMESTAMP.
@@ -375,11 +375,11 @@ function date_sunrise(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?
  *
  *
  *
- * @param float $latitude Defaults to North, pass in a negative value for South.
+ * @param float|null $latitude Defaults to North, pass in a negative value for South.
  * See also: date.default_latitude
- * @param float $longitude Defaults to East, pass in a negative value for West.
+ * @param float|null $longitude Defaults to East, pass in a negative value for West.
  * See also: date.default_longitude
- * @param float $zenith zenith is the angle between the center of the sun
+ * @param float|null $zenith zenith is the angle between the center of the sun
  * and a line perpendicular to earth's surface. It defaults to
  * date.sunset_zenith
  *
@@ -411,7 +411,7 @@ function date_sunrise(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?
  *
  *
  *
- * @param float $utcOffset Specified in hours.
+ * @param float|null $utcOffset Specified in hours.
  * The utcOffset is ignored, if
  * returnFormat is
  * SUNFUNCS_RET_TIMESTAMP.
@@ -450,7 +450,7 @@ function date_sunset(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?f
  * is optional and defaults to the value of time.
  *
  * @param string $format Format accepted by DateTimeInterface::format.
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -488,21 +488,21 @@ function date(string $format, ?int $timestamp = null): string
  * month, day and year.
  * Negative values reference the hour before midnight of the day in question.
  * Values greater than 23 reference the appropriate hour in the following day(s).
- * @param int $minute The number of the minute relative to the start of the hour.
+ * @param int|null $minute The number of the minute relative to the start of the hour.
  * Negative values reference the minute in the previous hour.
  * Values greater than 59 reference the appropriate minute in the following hour(s).
- * @param int $second The number of seconds relative to the start of the minute.
+ * @param int|null $second The number of seconds relative to the start of the minute.
  * Negative values reference the second in the previous minute.
  * Values greater than 59 reference the appropriate second in the following minute(s).
- * @param int $month The number of the month relative to the end of the previous year.
+ * @param int|null $month The number of the month relative to the end of the previous year.
  * Values 1 to 12 reference the normal calendar months of the year in question.
  * Values less than 1 (including negative values) reference the months in the previous year in reverse order, so 0 is December, -1 is November, etc.
  * Values greater than 12 reference the appropriate month in the following year(s).
- * @param int $day The number of the day relative to the end of the previous month.
+ * @param int|null $day The number of the day relative to the end of the previous month.
  * Values 1 to 28, 29, 30 or 31 (depending upon the month) reference the normal days in the relevant month.
  * Values less than 1 (including negative values) reference the days in the previous month, so 0 is the last day of the previous month, -1 is the day before that, etc.
  * Values greater than the number of days in the relevant month reference the appropriate day in the following month(s).
- * @param int $year The year
+ * @param int|null $year The year
  * @return int Returns a int Unix timestamp on success.
  * @throws DatetimeException
  *
@@ -538,7 +538,7 @@ function gmmktime(int $hour, ?int $minute = null, ?int $second = null, ?int $mon
  * 01:00:00".
  *
  * @param string $format See description in strftime.
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -670,7 +670,7 @@ function gmstrftime(string $format, ?int $timestamp = null): string
  *
  *
  *
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -985,7 +985,7 @@ function idate(string $format, ?int $timestamp = null): int
  *
  * The %z and %Z modifiers both
  * return the time zone name instead of the offset or abbreviation.
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -1106,7 +1106,7 @@ function strptime(string $timestamp, string $format): array
  * ways to define the default time zone.
  *
  * @param string $datetime A date/time string. Valid formats are explained in Date and Time Formats.
- * @param int $baseTimestamp The timestamp which is used as a base for the calculation of relative
+ * @param int|null $baseTimestamp The timestamp which is used as a base for the calculation of relative
  * dates.
  * @return int Returns a timestamp on success.
  * @throws DatetimeException

--- a/generated/8.3/eio.php
+++ b/generated/8.3/eio.php
@@ -13,7 +13,7 @@ use Safe\Exceptions\EioException;
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback This callback is called when all the group requests are done.
+ * @param callable|null $callback This callback is called when all the group requests are done.
  * @param mixed $data Arbitrary variable passed to callback.
  * @return resource eio_busy returns request resource on success.
  * @throws EioException
@@ -41,7 +41,7 @@ function eio_busy(int $delay, int $pri = EIO_PRI_DEFAULT, ?callable $callback = 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -93,7 +93,7 @@ function eio_chmod(string $path, int $mode, int $pri = EIO_PRI_DEFAULT, ?callabl
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -142,7 +142,7 @@ function eio_chown(string $path, int $uid, int $gid = -1, int $pri = EIO_PRI_DEF
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -250,7 +250,7 @@ function eio_custom(callable $execute, int $pri, callable $callback, $data = nul
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -322,7 +322,7 @@ function eio_event_loop(): void
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -372,7 +372,7 @@ function eio_fallocate($fd, int $mode, int $offset, int $length, int $pri = EIO_
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -423,7 +423,7 @@ function eio_fchmod($fd, int $mode, int $pri = EIO_PRI_DEFAULT, ?callable $callb
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -471,7 +471,7 @@ function eio_fchown($fd, int $uid, int $gid = -1, int $pri = EIO_PRI_DEFAULT, ?c
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -625,7 +625,7 @@ function eio_fstatvfs($fd, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -676,7 +676,7 @@ function eio_fsync($fd, int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -727,7 +727,7 @@ function eio_ftruncate($fd, int $offset = 0, int $pri = EIO_PRI_DEFAULT, ?callab
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -796,7 +796,7 @@ function eio_futime($fd, float $atime, float $mtime, int $pri = EIO_PRI_DEFAULT,
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_grp returns request group resource on success.
  * @throws EioException
  *
@@ -870,7 +870,7 @@ function eio_lstat(string $path, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -935,7 +935,7 @@ function eio_mkdir(string $path, int $mode, int $pri = EIO_PRI_DEFAULT, ?callabl
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -983,7 +983,7 @@ function eio_mknod(string $path, int $mode, int $dev, int $pri = EIO_PRI_DEFAULT
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1034,7 +1034,7 @@ function eio_nop(int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, $data =
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1111,7 +1111,7 @@ function eio_readahead($fd, int $offset, int $length, int $pri = EIO_PRI_DEFAULT
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_readdir returns request resource on success.
  * Sets result argument of
  * callback function according to
@@ -1411,7 +1411,7 @@ function eio_readdir(string $path, int $flags, int $pri, callable $callback, ?st
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_readlink returns request resource on success.
  * @throws EioException
  *
@@ -1435,7 +1435,7 @@ function eio_readlink(string $path, int $pri, callable $callback, ?string $data 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1483,7 +1483,7 @@ function eio_rename(string $path, string $new_path, int $pri = EIO_PRI_DEFAULT, 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1539,7 +1539,7 @@ function eio_rmdir(string $path, int $pri = EIO_PRI_DEFAULT, ?callable $callback
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1754,7 +1754,7 @@ function eio_statvfs(string $path, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1813,7 +1813,7 @@ function eio_symlink(string $path, string $new_path, int $pri = EIO_PRI_DEFAULT,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1858,7 +1858,7 @@ function eio_sync_file_range($fd, int $offset, int $nbytes, int $flags, int $pri
  *
  *
  * @param int $pri
- * @param callable $callback
+ * @param callable|null $callback
  * @param mixed $data
  * @return resource eio_sync returns request resource on success.
  * @throws EioException
@@ -1882,7 +1882,7 @@ function eio_sync(int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, $data 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1932,7 +1932,7 @@ function eio_syncfs($fd, int $pri = EIO_PRI_DEFAULT, ?callable $callback = null,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1980,7 +1980,7 @@ function eio_truncate(string $path, int $offset = 0, int $pri = EIO_PRI_DEFAULT,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -2030,7 +2030,7 @@ function eio_unlink(string $path, int $pri = EIO_PRI_DEFAULT, ?callable $callbac
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -2083,7 +2083,7 @@ function eio_utime(string $path, float $atime, float $mtime, int $pri = EIO_PRI_
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *

--- a/generated/8.3/errorfunc.php
+++ b/generated/8.3/errorfunc.php
@@ -57,9 +57,9 @@ use Safe\Exceptions\ErrorfuncException;
  *
  *
  *
- * @param string $destination The destination. Its meaning depends on the
+ * @param null|string $destination The destination. Its meaning depends on the
  * message_type parameter as described above.
- * @param string $additional_headers The extra headers. It's used when the message_type
+ * @param null|string $additional_headers The extra headers. It's used when the message_type
  * parameter is set to 1.
  * This message type uses the same internal function as
  * mail does.

--- a/generated/8.3/exec.php
+++ b/generated/8.3/exec.php
@@ -178,7 +178,7 @@ function proc_nice(int $priority): void
  * PHP process)
  * @param array|null $env_vars An array with the environment variables for the command that will be
  * run, or NULL to use the same environment as the current PHP process
- * @param array $options Allows you to specify additional options. Currently supported options
+ * @param array|null $options Allows you to specify additional options. Currently supported options
  * include:
  *
  *

--- a/generated/8.3/fileinfo.php
+++ b/generated/8.3/fileinfo.php
@@ -30,7 +30,7 @@ function finfo_close(\finfo $finfo): void
  *
  * @param int $flags One or disjunction of more Fileinfo
  * constants.
- * @param string $magic_database Name of a magic database file, usually something like
+ * @param null|string $magic_database Name of a magic database file, usually something like
  * /path/to/magic.mime. If not specified, the
  * MAGIC environment variable is used. If the
  * environment variable isn't set, then PHP's bundled magic database will

--- a/generated/8.3/filesystem.php
+++ b/generated/8.3/filesystem.php
@@ -253,7 +253,7 @@ function fflush($stream): void
  * Seeking (offset) is not supported with remote files.
  * Attempting to seek on non-local files may work with small offsets, but this
  * is unpredictable because it works on the buffered stream.
- * @param int $length Maximum length of data read. The default is to read until end
+ * @param int|null $length Maximum length of data read. The default is to read until end
  * of file is reached. Note that this parameter is applied to the
  * stream processed by the filters.
  * @return string The function returns the read data.
@@ -1027,7 +1027,7 @@ function ftruncate($stream, int $size): void
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
  * @param string $data The string that is to be written.
- * @param int $length If length is an integer, writing will stop
+ * @param int|null $length If length is an integer, writing will stop
  * after length bytes have been written or the
  * end of data is reached, whichever comes first.
  * @return int
@@ -1658,9 +1658,9 @@ function tmpfile()
  * If the file does not exist, it will be created.
  *
  * @param string $filename The name of the file being touched.
- * @param int $mtime The touch time. If mtime is NULL,
+ * @param int|null $mtime The touch time. If mtime is NULL,
  * the current system time is used.
- * @param int $atime If not NULL, the access time of the given filename is set to
+ * @param int|null $atime If not NULL, the access time of the given filename is set to
  * the value of atime. Otherwise, it is set to
  * the value passed to the mtime parameter.
  * If both are NULL, the current system time is used.

--- a/generated/8.3/ibase.php
+++ b/generated/8.3/ibase.php
@@ -112,7 +112,7 @@ function ibase_blob_cancel($blob_handle): void
  * ibase_blob_create creates a new BLOB for filling with
  * data.
  *
- * @param resource $link_identifier An InterBase link identifier. If omitted, the last opened link is
+ * @param null|resource $link_identifier An InterBase link identifier. If omitted, the last opened link is
  * assumed.
  * @return resource Returns a BLOB handle for later use with
  * ibase_blob_add.
@@ -161,7 +161,7 @@ function ibase_blob_get($blob_handle, int $len): string
  * Default transaction on link is committed, other transactions are
  * rolled back.
  *
- * @param resource $connection_id An InterBase link identifier returned from
+ * @param null|resource $connection_id An InterBase link identifier returned from
  * ibase_connect. If omitted, the last opened link
  * is assumed.
  * @throws IbaseException
@@ -184,7 +184,7 @@ function ibase_close($connection_id = null): void
 /**
  * Commits a transaction without closing it.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function commits the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function commits the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be committed. If the argument is a transaction identifier, the
@@ -211,7 +211,7 @@ function ibase_commit_ret($link_or_trans_identifier = null): void
 /**
  * Commits a transaction.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function commits the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function commits the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be committed. If the argument is a transaction identifier, the
@@ -317,7 +317,7 @@ function ibase_delete_user($service_handle, string $user_name): void
  * This functions drops a database that was opened by either ibase_connect
  * or ibase_pconnect. The database is closed and deleted from the server.
  *
- * @param resource $connection An InterBase link identifier. If omitted, the last opened link is
+ * @param null|resource $connection An InterBase link identifier. If omitted, the last opened link is
  * assumed.
  * @throws IbaseException
  *
@@ -573,7 +573,7 @@ function ibase_restore($service_handle, string $source_file, string $dest_db, in
 /**
  * Rolls back a transaction without closing it.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function rolls back the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function rolls back the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be rolled back. If the argument is a transaction identifier, the
@@ -600,7 +600,7 @@ function ibase_rollback_ret($link_or_trans_identifier = null): void
 /**
  * Rolls back a transaction.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function rolls back the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function rolls back the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be rolled back. If the argument is a transaction identifier, the

--- a/generated/8.3/iconv.php
+++ b/generated/8.3/iconv.php
@@ -76,7 +76,7 @@ function iconv_get_encoding(string $type = "all")
  *
  *
  *
- * @param string $encoding The optional encoding parameter specifies the
+ * @param null|string $encoding The optional encoding parameter specifies the
  * character set to represent the result by. If omitted or NULL,
  * iconv.internal_encoding
  * will be used.
@@ -249,7 +249,7 @@ function iconv_set_encoding(string $type, string $encoding): void
  * identical to the length of the string in byte.
  *
  * @param string $string The string.
- * @param string $encoding If encoding parameter is omitted or NULL,
+ * @param null|string $encoding If encoding parameter is omitted or NULL,
  * string is assumed to be encoded in
  * iconv.internal_encoding.
  * @return int Returns the character count of string, as an integer,

--- a/generated/8.3/image.php
+++ b/generated/8.3/image.php
@@ -104,7 +104,7 @@ function image_type_to_extension(int $image_type, bool $include_dot = true): str
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param array $affine Array with keys 0 to 5.
- * @param array $clip Array with keys "x", "y", "width" and "height"; or NULL.
+ * @param array|null $clip Array with keys "x", "y", "width" and "height"; or NULL.
  * @return \GdImage Return affined image object on success.
  * @throws ImageException
  *
@@ -2096,8 +2096,8 @@ function imagerectangle(\GdImage $image, int $x1, int $y1, int $x2, int $y2, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param int $resolution_x The horizontal resolution in DPI.
- * @param int $resolution_y The vertical resolution in DPI.
+ * @param int|null $resolution_x The horizontal resolution in DPI.
+ * @param int|null $resolution_y The vertical resolution in DPI.
  * @return mixed When used as getter,
  * it returns an indexed array of the horizontal and vertical resolution on
  * success.
@@ -2778,7 +2778,7 @@ function imagettftext(\GdImage $image, float $size, float $angle, int $x, int $y
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
- * @param int $foreground_color You can set the foreground color with this parameter by setting an
+ * @param int|null $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black.
  * @throws ImageException
@@ -2840,7 +2840,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  * alphanumeric characters of the current locale are substituted by
  * underscores. If filename is set to NULL,
  * image is used to build the C identifiers.
- * @param int $foreground_color You can set the foreground color with this parameter by setting an
+ * @param int|null $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black. All other colors are treated as
  * background.

--- a/generated/8.3/imap.php
+++ b/generated/8.3/imap.php
@@ -35,9 +35,9 @@ function imap_8bit(string $string): string
  * When talking to the Cyrus IMAP server, you must use "\r\n" as
  * your end-of-line terminator instead of "\n" or the operation will
  * fail
- * @param string $options If provided, the options will also be written
+ * @param null|string $options If provided, the options will also be written
  * to the folder
- * @param string $internal_date If this parameter is set, it will set the INTERNALDATE on the appended message.  The parameter should be a date string that conforms to the rfc2060 specifications for a date_time value.
+ * @param null|string $internal_date If this parameter is set, it will set the INTERNALDATE on the appended message.  The parameter should be a date string that conforms to the rfc2060 specifications for a date_time value.
  * @throws ImapException
  *
  */
@@ -1443,11 +1443,11 @@ function imap_mail_move(\IMAP\Connection $imap, string $message_nums, string $ma
  * @param string $to The receiver
  * @param string $subject The mail subject
  * @param string $message The mail body, see imap_mail_compose
- * @param string $additional_headers As string with additional headers to be set on the mail
- * @param string $cc
- * @param string $bcc The receivers specified in bcc will get the
+ * @param null|string $additional_headers As string with additional headers to be set on the mail
+ * @param null|string $cc
+ * @param null|string $bcc The receivers specified in bcc will get the
  * mail, but are excluded from the headers.
- * @param string $return_path Use this parameter to specify return path upon mail delivery failure.
+ * @param null|string $return_path Use this parameter to specify return path upon mail delivery failure.
  * This is useful when using PHP as a mail client for multiple users.
  * @throws ImapException
  *
@@ -2055,9 +2055,9 @@ function imap_setflag_full(\IMAP\Connection $imap, string $sequence, string $fla
  *
  *
  *
- * @param string $search_criteria IMAP2-format search criteria string. For details see
+ * @param null|string $search_criteria IMAP2-format search criteria string. For details see
  * imap_search.
- * @param string $charset MIME character set to use when sorting strings.
+ * @param null|string $charset MIME character set to use when sorting strings.
  * @return array Returns an array of message numbers sorted by the given
  * parameters.
  * @throws ImapException

--- a/generated/8.3/ldap.php
+++ b/generated/8.3/ldap.php
@@ -43,7 +43,7 @@ function ldap_8859_to_t61(string $value): string
  * ]]>
  *
  *
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -94,7 +94,7 @@ function ldap_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $password
  * @param string $dn The distinguished name of an LDAP entity.
  * @param string $attribute The attribute name.
  * @param string $value The compared value.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @return bool Returns TRUE if value matches otherwise returns
  * FALSE.
  * @throws LdapException
@@ -184,7 +184,7 @@ function ldap_count_entries(\LDAP\Connection $ldap, \LDAP\Result $result): int
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -229,7 +229,7 @@ function ldap_dn2ufn(string $dn): string
  * @param string $user dn of the user to change the password of.
  * @param string $old_password The old password of this user. May be ommited depending of server configuration.
  * @param string $new_password The new password for this user. May be omitted or empty to have a generated password.
- * @param array $controls If provided, a password policy request control is send with the request and this is
+ * @param array|null $controls If provided, a password policy request control is send with the request and this is
  * filled with an array of LDAP Controls
  * returned with the request.
  * @return bool|string Returns the generated password if new_password is empty or omitted.
@@ -274,7 +274,7 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $request_oid The extended operation request OID. You may use one of LDAP_EXOP_START_TLS, LDAP_EXOP_MODIFY_PASSWD, LDAP_EXOP_REFRESH, LDAP_EXOP_WHO_AM_I, LDAP_EXOP_TURN, or a string with the OID of the operation you want to send.
- * @param string $request_data The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
+ * @param null|string $request_data The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
  * @param array|null $controls Array of LDAP Controls to send with the request.
  * @param null|string $response_data Will be filled with the extended operation response data if provided.
  * If not provided you may use ldap_parse_exop on the result object
@@ -763,7 +763,7 @@ function ldap_get_values(\LDAP\Connection $ldap, \LDAP\ResultEntry $entry, strin
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry An associative array listing the attirbute values to add. If an attribute was not existing yet it will be added. If an attribute is existing you can only add values to it if it supports multiple values.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -789,7 +789,7 @@ function ldap_mod_add(\LDAP\Connection $ldap, string $dn, array $entry, ?array $
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -814,7 +814,7 @@ function ldap_mod_del(\LDAP\Connection $ldap, string $dn, array $entry, ?array $
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry An associative array listing the attributes to replace. Sending an empty array as value will remove the attribute, while sending an attribute not existing yet on this entry will add it.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -911,7 +911,7 @@ function ldap_mod_replace(\LDAP\Connection $ldap, string $dn, array $entry, ?arr
  * value for values must be an array of strings, and
  * any value for modtype must be one of the
  * LDAP_MODIFY_BATCH_* constants listed above.
- * @param array $controls Each value specified through values is added (as
+ * @param array|null $controls Each value specified through values is added (as
  * an additional value) to the attribute named by
  * attrib.
  * @throws LdapException
@@ -1012,7 +1012,7 @@ function ldap_parse_result(\LDAP\Connection $ldap, \LDAP\Result $result, ?int &$
  * @param string $new_parent The new parent/superior entry.
  * @param bool $delete_old_rdn If TRUE the old RDN value(s) is removed, else the old RDN value(s)
  * is retained as non-distinguished values of the entry.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -1034,13 +1034,13 @@ function ldap_rename(\LDAP\Connection $ldap, string $dn, string $new_rdn, string
  *
  *
  * @param \LDAP\Connection $ldap
- * @param string $dn
- * @param string $password
- * @param string $mech
- * @param string $realm
- * @param string $authc_id
- * @param string $authz_id
- * @param string $props
+ * @param null|string $dn
+ * @param null|string $password
+ * @param null|string $mech
+ * @param null|string $realm
+ * @param null|string $authc_id
+ * @param null|string $authz_id
+ * @param null|string $props
  * @throws LdapException
  *
  */

--- a/generated/8.3/mbstring.php
+++ b/generated/8.3/mbstring.php
@@ -11,7 +11,7 @@ use Safe\Exceptions\MbstringException;
  * This function complements mb_ord.
  *
  * @param int $codepoint A Unicode codepoint value, e.g. 128024 for U+1F418 ELEPHANT
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return string A string containing the requested character, if it can be represented in the specified
@@ -77,7 +77,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * Sets the automatic character
  * encoding detection order to encoding.
  *
- * @param non-empty-array|non-falsy-string $encoding encoding is an array or
+ * @param non-empty-array|non-falsy-string|null $encoding encoding is an array or
  * comma separated list of character encoding. See supported encodings.
  *
  * If encoding is omitted or NULL, it returns
@@ -163,7 +163,7 @@ function mb_encoding_aliases(string $encoding): array
  * clutter the function namespace with a callback function's name
  * not used anywhere else.
  * @param string $string The string being checked.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -193,7 +193,7 @@ function mb_ereg_replace_callback(string $pattern, callable $callback, string $s
  * Multibyte characters may be used in pattern.
  * @param string $replacement The replacement text.
  * @param string $string The string being checked.
- * @param string $options
+ * @param null|string $options
  * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -242,8 +242,8 @@ function mb_ereg_search_getregs(): array
  * mb_ereg_search_regs.
  *
  * @param string $string The search string.
- * @param string $pattern The search pattern.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $pattern The search pattern.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @throws MbstringException
  *
  */
@@ -266,8 +266,8 @@ function mb_ereg_search_init(string $string, ?string $pattern = null, ?string $o
 /**
  * Returns the matched part of a multibyte regular expression.
  *
- * @param string $pattern The search pattern.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $pattern The search pattern.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @return array
  * @throws MbstringException
  *
@@ -312,7 +312,7 @@ function mb_ereg_search_setpos(int $offset): void
  * @param string $pattern The regular expression pattern.  Multibyte characters may be used. The case will be ignored.
  * @param string $replacement The replacement text.
  * @param string $string The searched string.
- * @param string $options
+ * @param null|string $options
  * @return string The resultant string.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -376,7 +376,7 @@ function mb_get_info(string $type = "all")
  * Set/Get the HTTP output character encoding.
  * Output after this function is called will be converted from the set internal encoding to encoding.
  *
- * @param string $encoding If encoding is set,
+ * @param null|string $encoding If encoding is set,
  * mb_http_output sets the HTTP output character
  * encoding to encoding.
  *
@@ -408,7 +408,7 @@ function mb_http_output(?string $encoding = null)
 /**
  * Set/Get the internal character encoding
  *
- * @param string $encoding encoding is the character encoding name
+ * @param null|string $encoding encoding is the character encoding name
  * used for the HTTP input character encoding conversion, HTTP output
  * character encoding conversion, and the default character encoding
  * for string functions defined by the mbstring module.
@@ -442,7 +442,7 @@ function mb_internal_encoding(?string $encoding = null)
  * This function complements mb_chr.
  *
  * @param string $string A string
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return int The Unicode code point for the first character of string.
@@ -490,7 +490,7 @@ function mb_parse_str(string $string, ?array &$result): void
 /**
  * Set/Get character encoding for a multibyte regex.
  *
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return bool|string
@@ -549,7 +549,7 @@ function mb_regex_encoding(?string $encoding = null)
  * automatically (which leads to doubling CR if CRLF is used).
  * This should be a last resort, as it does not comply with
  * RFC 2822.
- * @param string $additional_params additional_params is a MTA command line
+ * @param null|string $additional_params additional_params is a MTA command line
  * parameter. It is useful when setting the correct Return-Path
  * header when using sendmail.
  *

--- a/generated/8.3/misc.php
+++ b/generated/8.3/misc.php
@@ -400,7 +400,7 @@ function sapi_windows_set_ctrl_handler(?callable $handler, bool $add = true): vo
  * They allow the modification of the terminal's output. On Windows these sequences are called Console Virtual Terminal Sequences.
  *
  * @param resource $stream The stream on which the function will operate.
- * @param bool $enable If bool, the VT100 feature will be enabled (if TRUE) or disabled (if FALSE).
+ * @param bool|null $enable If bool, the VT100 feature will be enabled (if TRUE) or disabled (if FALSE).
  * @throws MiscException
  *
  */

--- a/generated/8.3/mysql.php
+++ b/generated/8.3/mysql.php
@@ -18,7 +18,7 @@ use Safe\Exceptions\MysqlException;
  * improve performance. For related information, see
  * freeing resources
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no connection is found or
  * established, an E_WARNING level error is
@@ -102,7 +102,7 @@ function mysql_connect(?string $server = null, ?string $username = null, ?string
  * identifier.
  *
  * @param string $database_name The name of the database being created.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -184,7 +184,7 @@ function mysql_db_name($result, int $row, $field = null): string
  * @param string $query The MySQL query.
  *
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -215,7 +215,7 @@ function mysql_db_query(string $database, string $query, $link_identifier = null
  * DROP DATABASE statement instead.
  *
  * @param string $database_name The name of the database that will be deleted.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -407,7 +407,7 @@ function mysql_free_result($result): void
  * Describes the type of connection in use for the connection, including the
  * server host name.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -432,7 +432,7 @@ function mysql_get_host_info($link_identifier = null): string
 /**
  * Retrieves the MySQL protocol.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -456,7 +456,7 @@ function mysql_get_proto_info($link_identifier = null): int
 /**
  * Retrieves the MySQL server version.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -480,7 +480,7 @@ function mysql_get_server_info($link_identifier = null): string
 /**
  * Returns detailed information about the last query.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -507,7 +507,7 @@ function mysql_info($link_identifier = null): string
  * Returns a result pointer containing the databases available from the
  * current mysql daemon.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -539,7 +539,7 @@ function mysql_list_dbs($link_identifier = null)
  *
  * @param string $database_name The name of the database that's being queried.
  * @param string $table_name The name of the table that's being queried.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -568,7 +568,7 @@ function mysql_list_fields(string $database_name, string $table_name, $link_iden
 /**
  * Retrieves the current MySQL server threads.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -597,7 +597,7 @@ function mysql_list_processes($link_identifier = null)
  * [FROM db_name] [LIKE 'pattern'] statement instead.
  *
  * @param string $database The name of the database
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -678,7 +678,7 @@ function mysql_num_rows($result): int
  *
  * The query string should not end with a semicolon.
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -734,7 +734,7 @@ function mysql_query(string $query, $link_identifier = null)
  * safe before sending a query to MySQL.
  *
  * @param string $unescaped_string The string that is to be escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -798,7 +798,7 @@ function mysql_result($result, int $row, $field = 0): string
  * mysql_query will be made on the active database.
  *
  * @param string $database_name The name of the database that is to be selected.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -821,7 +821,7 @@ function mysql_select_db(string $database_name, $link_identifier = null): void
  * Sets the default character set for the current connection.
  *
  * @param string $charset A valid character set name.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -874,7 +874,7 @@ function mysql_tablename($result, int $i): string
  * with mysql_ping is executed, the thread ID will
  * change. This means only retrieve the thread ID when needed.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -912,7 +912,7 @@ function mysql_thread_id($link_identifier = null): int
  * @param string $query The SQL query to execute.
  *
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called

--- a/generated/8.3/network.php
+++ b/generated/8.3/network.php
@@ -290,7 +290,7 @@ function dns_get_record(string $hostname, int $type = DNS_ANY, ?array &$authorit
  * connect() call. This is most likely due to a
  * problem initializing the socket.
  * @param null|string $error_message The error message as a string.
- * @param float $timeout The connection timeout, in seconds. When NULL, the
+ * @param float|null $timeout The connection timeout, in seconds. When NULL, the
  * default_socket_timeout php.ini setting is used.
  *
  * If you need to set a timeout for reading/writing data over the
@@ -748,7 +748,7 @@ function openlog(string $prefix, int $flags, int $facility): void
  * @param int $port
  * @param int|null $error_code
  * @param null|string $error_message
- * @param float $timeout
+ * @param float|null $timeout
  * @return resource pfsockopen returns a file pointer which may be used
  * together with the other file functions (such as
  * fgets, fgetss,

--- a/generated/8.3/oci8.php
+++ b/generated/8.3/oci8.php
@@ -389,7 +389,7 @@ function oci_commit($connection): void
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from
@@ -780,7 +780,7 @@ function oci_free_statement($statement): void
  * @param resource $connection An Oracle connection identifier, returned by
  * oci_connect or oci_pconnect.
  * @param string $type_name Should be a valid named type (uppercase).
- * @param string $schema Should point to the scheme, where the named type was created. The name
+ * @param null|string $schema Should point to the scheme, where the named type was created. The name
  * of the current user is used when NULL is passed.
  * @return \OCI-Collection Returns a new OCICollection object.
  * @throws Oci8Exception
@@ -812,7 +812,7 @@ function oci_new_collection($connection, string $type_name, ?string $schema = nu
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from
@@ -1015,7 +1015,7 @@ function oci_parse($connection, string $sql)
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from

--- a/generated/8.3/openssl.php
+++ b/generated/8.3/openssl.php
@@ -293,7 +293,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  * otherwise obtained from the other openssl_pkey family of functions).
  * The corresponding public portion of the key will be used to sign the
  * CSR.
- * @param array $options By default, the information in your system openssl.conf
+ * @param array|null $options By default, the information in your system openssl.conf
  * is used to initialize the request; you can specify a configuration file
  * section by setting the config_section_section key of
  * options.  You can also specify an alternative
@@ -385,7 +385,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  *
  *
  *
- * @param array $extra_attributes extra_attributes is used to specify additional
+ * @param array|null $extra_attributes extra_attributes is used to specify additional
  * configuration options for the CSR.  Both distinguished_names and
  * extra_attributes are associative arrays whose keys are
  * converted to OIDs and applied to the relevant part of the request.
@@ -424,7 +424,7 @@ function openssl_csr_new(array $distinguished_names, \OpenSSLAsymmetricKey &$pri
  * ca_certificate.
  * @param int $days days specifies the length of time for which the
  * generated certificate will be valid, in days.
- * @param array $options You can finetune the CSR signing by options.
+ * @param array|null $options You can finetune the CSR signing by options.
  * See openssl_csr_new for more information about
  * options.
  * @param int $serial An optional the serial number of issued certificate. If not specified
@@ -461,7 +461,7 @@ function openssl_csr_sign($csr, $ca_certificate, $private_key, int $days, ?array
  * OPENSSL_RAW_DATA,
  * OPENSSL_ZERO_PADDING.
  * @param string $iv A non-NULL Initialization Vector.
- * @param string $tag The authentication tag in AEAD cipher mode. If it is incorrect, the authentication fails and the function returns FALSE.
+ * @param null|string $tag The authentication tag in AEAD cipher mode. If it is incorrect, the authentication fails and the function returns FALSE.
  * @param string $aad Additional authenticated data.
  * @return string The decrypted string on success.
  * @throws OpensslException
@@ -613,7 +613,7 @@ function openssl_get_curve_names(): array
  * It is strongly recommended to explicitly specify a secure cipher method.
  *
  *
- * @param string $iv The initialization vector.
+ * @param null|string $iv The initialization vector.
  * @throws OpensslException
  *
  */
@@ -861,7 +861,7 @@ function openssl_pkcs7_read(string $data, ?array &$certificates): void
  * openssl_pkcs7_encrypt for more information about
  * the format of this parameter).
  * @param int $flags flags can be used to alter the output - see PKCS7 constants.
- * @param string $untrusted_certificates_filename untrusted_certificates_filename specifies the name of a file containing
+ * @param null|string $untrusted_certificates_filename untrusted_certificates_filename specifies the name of a file containing
  * a bunch of extra certificates to include in the signature which can for
  * example be used to help the recipient to verify the certificate that you used.
  * @throws OpensslException
@@ -914,7 +914,7 @@ function openssl_pkey_derive($public_key, $private_key, int $key_length = 0): st
  * @param string $output_filename Path to the output file.
  * @param null|string $passphrase The key can be optionally protected by a
  * passphrase.
- * @param array $options options can be used to fine-tune the export
+ * @param array|null $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file. See openssl_csr_new for more
  * information about options.
@@ -945,7 +945,7 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param null|string $output
  * @param null|string $passphrase The key is optionally protected by passphrase.
- * @param array $options options can be used to fine-tune the export
+ * @param array|null $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file.  See openssl_csr_new for more
  * information about options.
@@ -1037,7 +1037,7 @@ function openssl_pkey_get_public($public_key): \OpenSSLAsymmetricKey
  * key.
  * How to obtain the public component of the key is shown in an example below.
  *
- * @param array $options You can finetune the key generation (such as specifying the number of
+ * @param array|null $options You can finetune the key generation (such as specifying the number of
  * bits) using options.  See
  * openssl_csr_new for more information about
  * options.
@@ -1413,7 +1413,7 @@ function openssl_verify(string $data, string $signature, $public_key, $algorithm
  * @param array $ca_info ca_info should be an array of trusted CA files/dirs
  * as described in Certificate
  * Verification.
- * @param string $untrusted_certificates_file If specified, this should be the name of a PEM encoded file holding
+ * @param null|string $untrusted_certificates_file If specified, this should be the name of a PEM encoded file holding
  * certificates that can be used to help verify the certificate, although
  * no trust is placed in the certificates that come from that file.
  * @return bool|int Returns TRUE if the certificate can be used for the intended purpose,

--- a/generated/8.3/pcntl.php
+++ b/generated/8.3/pcntl.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\PcntlException;
  * system types and kernel versions, please see your system's getpriority(2)
  * man page for specific details.
  *
- * @param int $process_id If NULL, the process id of the current process is used.
+ * @param int|null $process_id If NULL, the process id of the current process is used.
  * @param int $mode One of PRIO_PGRP, PRIO_USER,
  * PRIO_PROCESS,
  * PRIO_DARWIN_BG or PRIO_DARWIN_THREAD.
@@ -46,7 +46,7 @@ function pcntl_getpriority(?int $process_id = null, int $mode = PRIO_PROCESS): i
  * favorable scheduling.  Because priority levels can differ between
  * system types and kernel versions, please see your system's setpriority(2)
  * man page for specific details.
- * @param int $process_id If NULL, the process id of the current process is used.
+ * @param int|null $process_id If NULL, the process id of the current process is used.
  * @param int $mode One of PRIO_PGRP, PRIO_USER,
  * PRIO_PROCESS,
  * PRIO_DARWIN_BG or PRIO_DARWIN_THREAD.

--- a/generated/8.3/pgsql.php
+++ b/generated/8.3/pgsql.php
@@ -765,7 +765,7 @@ function pg_lo_unlink(\PgSql\Connection $connection, int $oid): void
  * @param string $data The data to be written to the large object.  If length is
  * an int and is less than the length of data, only
  * length bytes will be written.
- * @param int $length An optional maximum number of bytes to write.  Must be greater than zero
+ * @param int|null $length An optional maximum number of bytes to write.  Must be greater than zero
  * and no greater than the length of data.  Defaults to
  * the length of data.
  * @return int The number of bytes written to the large object.

--- a/generated/8.3/readline.php
+++ b/generated/8.3/readline.php
@@ -86,7 +86,7 @@ function readline_completion_function(callable $callback): void
 /**
  * This function reads a command history from a file.
  *
- * @param string $filename Path to the filename containing the command history.
+ * @param null|string $filename Path to the filename containing the command history.
  * @throws ReadlineException
  *
  */
@@ -107,7 +107,7 @@ function readline_read_history(?string $filename = null): void
 /**
  * This function writes the command history to a file.
  *
- * @param string $filename Path to the saved file.
+ * @param null|string $filename Path to the saved file.
  * @throws ReadlineException
  *
  */

--- a/generated/8.3/sem.php
+++ b/generated/8.3/sem.php
@@ -434,7 +434,7 @@ function sem_remove(\SysvSemaphore $semaphore): void
  * permissions will be ignored.
  *
  * @param int $key A numeric shared memory segment ID
- * @param int $size The memory size. If not provided, default to the
+ * @param int|null $size The memory size. If not provided, default to the
  * sysvshm.init_mem in the php.ini, otherwise 10000
  * bytes.
  * @param int $permissions The optional permission bits. Default to 0666.

--- a/generated/8.3/session.php
+++ b/generated/8.3/session.php
@@ -136,7 +136,7 @@ function session_encode(): string
  * adding to URLs. See also Session
  * handling.
  *
- * @param string $id If id is specified and not NULL, it will replace the current
+ * @param null|string $id If id is specified and not NULL, it will replace the current
  * session id. session_id needs to be called before
  * session_start for that purpose. Depending on the
  * session handler, not all characters are allowed within the session id.
@@ -169,7 +169,7 @@ function session_id(?string $id = null): string
  * session module, which is also known as
  * session.save_handler.
  *
- * @param string $module If module is specified and not NULL, that module will be
+ * @param null|string $module If module is specified and not NULL, that module will be
  * used instead.
  * Passing "user" to this parameter is forbidden. Instead
  * session_set_save_handler has to be called to set a user
@@ -213,7 +213,7 @@ function session_module_name(?string $module = null): string
  * call session_name for every request (and before
  * session_start is called).
  *
- * @param string $name The session name references the name of the session, which is
+ * @param null|string $name The session name references the name of the session, which is
  * used in cookies and URLs (e.g. PHPSESSID). It
  * should contain only alphanumeric characters; it should be short and
  * descriptive (i.e. for users with enabled cookie warnings).
@@ -297,7 +297,7 @@ function session_reset(): void
  * session_save_path returns the path of the current
  * directory used to save session data.
  *
- * @param string $path Session data path. If specified and not NULL, the path to which data is saved will
+ * @param null|string $path Session data path. If specified and not NULL, the path to which data is saved will
  * be changed. session_save_path needs to be called
  * before session_start for that purpose.
  *

--- a/generated/8.3/sockets.php
+++ b/generated/8.3/sockets.php
@@ -160,7 +160,7 @@ function socket_bind(\Socket $socket, string $address, int $port = 0): void
  * socket is AF_INET6
  * or the pathname of a Unix domain socket, if the socket family is
  * AF_UNIX.
- * @param int $port The port parameter is only used and is mandatory
+ * @param int|null $port The port parameter is only used and is mandatory
  * when connecting to an AF_INET or an
  * AF_INET6 socket, and designates
  * the port on the remote host to which a connection should be made.
@@ -645,7 +645,7 @@ function socket_sendmsg(\Socket $socket, array $message, int $flags = 0): int
  *
  *
  * @param string $address IP address of the remote host.
- * @param int $port port is the remote port number at which the data
+ * @param int|null $port port is the remote port number at which the data
  * will be sent.
  * @return int socket_sendto returns the number of bytes sent to the
  * remote host.

--- a/generated/8.3/spl.php
+++ b/generated/8.3/spl.php
@@ -84,7 +84,7 @@ function class_uses($object_or_class, bool $autoload = true): array
  * runs through each of them in the order they are defined. By contrast,
  * __autoload may only be defined once.
  *
- * @param callable(string):void $callback The autoload function being registered.
+ * @param callable(string):void|null $callback The autoload function being registered.
  * If NULL, then the default implementation of
  * spl_autoload will be registered.
  * @param bool $throw This parameter specifies whether

--- a/generated/8.3/ssh2.php
+++ b/generated/8.3/ssh2.php
@@ -717,7 +717,7 @@ function ssh2_sftp($session)
  * ssh2_connect.
  * @param string $termtype termtype should correspond to one of the
  * entries in the target system's /etc/termcap file.
- * @param array $env env may be passed as an associative array of
+ * @param array|null $env env may be passed as an associative array of
  * name/value pairs to set in the target environment.
  * @param int $width Width of the virtual terminal.
  * @param int $height Height of the virtual terminal.

--- a/generated/8.3/stream.php
+++ b/generated/8.3/stream.php
@@ -33,7 +33,7 @@ function stream_context_set_params($context, array $params): void
  *
  * @param resource $from The source stream
  * @param resource $to The destination stream
- * @param int $length Maximum bytes to copy. By default all bytes left are copied.
+ * @param int|null $length Maximum bytes to copy. By default all bytes left are copied.
  * @param int $offset The offset where to start to copy data
  * @return int Returns the total count of bytes copied.
  * @throws StreamException
@@ -210,7 +210,7 @@ function stream_filter_remove($stream_filter): void
  * offset.
  *
  * @param resource $stream A stream resource (e.g. returned from fopen)
- * @param int $length The maximum bytes to read. Defaults to NULL (read all the remaining
+ * @param int|null $length The maximum bytes to read. Defaults to NULL (read all the remaining
  * buffer).
  * @param int $offset Seek to the specified offset before reading. If this number is negative,
  * no seeking will occur and reading will start from the current position.
@@ -364,7 +364,7 @@ function stream_set_timeout($stream, int $seconds, int $microseconds = 0): void
  * stream_socket_server.
  *
  * @param resource $socket The server socket to accept a connection from.
- * @param float $timeout Override the default socket accept timeout. Time should be given in
+ * @param float|null $timeout Override the default socket accept timeout. Time should be given in
  * seconds. By default, default_socket_timeout
  * is used.
  * @param null|string $peer_name Will be set to the name (address) of the client which connected, if
@@ -407,7 +407,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * @param string $address Address to the socket to connect to.
  * @param int|null $error_code Will be set to the system level error number if connection fails.
  * @param null|string $error_message Will be set to the system level error message if the connection fails.
- * @param float $timeout Number of seconds until the connect() system call
+ * @param float|null $timeout Number of seconds until the connect() system call
  * should timeout. By default, default_socket_timeout
  * is used.
  *

--- a/generated/8.3/uodbc.php
+++ b/generated/8.3/uodbc.php
@@ -197,16 +197,16 @@ function odbc_columnprivileges($odbc, string $catalog, string $schema, string $t
  *
  * @param resource $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $table The table name.
+ * @param null|string $table The table name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $column The column name.
+ * @param null|string $column The column name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
@@ -774,16 +774,16 @@ function odbc_primarykeys($odbc, string $catalog, string $schema, string $table)
  *
  * @param  $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $procedure The proc.
+ * @param null|string $procedure The proc.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $column The column.
+ * @param null|string $column The column.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
@@ -843,12 +843,12 @@ function odbc_procedurecolumns($odbc, ?string $catalog = null, ?string $schema =
  *
  * @param  $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $procedure The name.
+ * @param null|string $procedure The name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
@@ -1170,16 +1170,16 @@ function odbc_tableprivileges($odbc, string $catalog, string $schema, string $ta
  *
  * @param resource $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $table The name.
+ * @param null|string $table The name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $types If table_type is not an empty string, it
+ * @param null|string $types If table_type is not an empty string, it
  * must contain a list of comma-separated values for the types of
  * interest; each value may be enclosed in single quotes (') or
  * unquoted. For example, 'TABLE','VIEW' or TABLE, VIEW.  If the

--- a/generated/8.3/yaml.php
+++ b/generated/8.3/yaml.php
@@ -12,7 +12,7 @@ use Safe\Exceptions\YamlException;
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * details.
@@ -50,7 +50,7 @@ function yaml_parse_file(string $filename, int $pos = 0, ?int &$ndocs = null, ?a
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * @return mixed Returns the value encoded in input in appropriate
@@ -83,7 +83,7 @@ function yaml_parse_url(string $url, int $pos = 0, ?int &$ndocs = null, ?array $
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * details.

--- a/generated/8.3/zlib.php
+++ b/generated/8.3/zlib.php
@@ -293,7 +293,7 @@ function gzfile(string $filename, int $use_include_path = 0): array
  *
  * @param resource $stream The gz-file pointer. It must be valid, and must point to a file
  * successfully opened by gzopen.
- * @param int $length The length of data to get.
+ * @param int|null $length The length of data to get.
  * @return string The uncompressed string.
  * @throws ZlibException
  *
@@ -491,7 +491,7 @@ function gzuncompress(string $data, int $max_length = 0): string
  * @param resource $stream The gz-file pointer. It must be valid, and must point to a file
  * successfully opened by gzopen.
  * @param string $data The string to write.
- * @param int $length The number of uncompressed bytes to write. If supplied, writing will
+ * @param int|null $length The number of uncompressed bytes to write. If supplied, writing will
  * stop after length (uncompressed) bytes have been
  * written or the end of data is reached,
  * whichever comes first.

--- a/generated/8.4/bzip2.php
+++ b/generated/8.4/bzip2.php
@@ -98,7 +98,7 @@ function bzread($bz, int $length = 1024): string
  * @param resource $bz The file pointer. It must be valid and must point to a file
  * successfully opened by bzopen.
  * @param string $data The written data.
- * @param int $length If supplied, writing will stop after length
+ * @param int|null $length If supplied, writing will stop after length
  * (uncompressed) bytes have been written or the end of
  * data is reached, whichever comes first.
  * @return int Returns the number of bytes written.

--- a/generated/8.4/calendar.php
+++ b/generated/8.4/calendar.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\CalendarException;
  * timestamp is given. Either way, the time is regarded
  * as local time (not UTC).
  *
- * @param int $timestamp A unix timestamp to convert.
+ * @param int|null $timestamp A unix timestamp to convert.
  * @return int A julian day number as integer.
  * @throws CalendarException
  *

--- a/generated/8.4/com.php
+++ b/generated/8.4/com.php
@@ -132,7 +132,7 @@ function com_load_typelib(string $typelib, bool $case_insensitive = true): void
  * @param object $variant variant should be either an instance of a COM
  * object, or be the name of a typelibrary (which will be resolved according
  * to the rules set out in com_load_typelib).
- * @param string $dispatch_interface The name of an IDispatch descendant interface that you want to display.
+ * @param null|string $dispatch_interface The name of an IDispatch descendant interface that you want to display.
  * @param bool $display_sink If set to TRUE, the corresponding sink interface will be displayed
  * instead.
  * @throws ComException

--- a/generated/8.4/curl.php
+++ b/generated/8.4/curl.php
@@ -77,7 +77,7 @@ function curl_exec(\CurlHandle $handle)
  *
  * @param \CurlHandle $handle A cURL handle returned by
  * curl_init.
- * @param int $option One of the CURLINFO_* constants.
+ * @param int|null $option One of the CURLINFO_* constants.
  * @return mixed If option is given, returns its value.
  * Otherwise, returns an associative array with the following elements
  * (which correspond to option):
@@ -246,7 +246,7 @@ function curl_getinfo(\CurlHandle $handle, ?int $option = null)
 /**
  * Initializes a new session and returns a cURL handle.
  *
- * @param string $url If provided, the CURLOPT_URL option will be set
+ * @param null|string $url If provided, the CURLOPT_URL option will be set
  * to its value. This can be set manually using the
  * curl_setopt function.
  *

--- a/generated/8.4/datetime.php
+++ b/generated/8.4/datetime.php
@@ -150,11 +150,11 @@ function date_parse_from_format(string $format, string $datetime): ?array
  *
  *
  *
- * @param float $latitude Defaults to North, pass in a negative value for South.
+ * @param float|null $latitude Defaults to North, pass in a negative value for South.
  * See also: date.default_latitude
- * @param float $longitude Defaults to East, pass in a negative value for West.
+ * @param float|null $longitude Defaults to East, pass in a negative value for West.
  * See also: date.default_longitude
- * @param float $zenith zenith is the angle between the center of the sun
+ * @param float|null $zenith zenith is the angle between the center of the sun
  * and a line perpendicular to earth's surface. It defaults to
  * date.sunrise_zenith
  *
@@ -186,7 +186,7 @@ function date_parse_from_format(string $format, string $datetime): ?array
  *
  *
  *
- * @param float $utcOffset Specified in hours.
+ * @param float|null $utcOffset Specified in hours.
  * The utcOffset is ignored, if
  * returnFormat is
  * SUNFUNCS_RET_TIMESTAMP.
@@ -253,11 +253,11 @@ function date_sunrise(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?
  *
  *
  *
- * @param float $latitude Defaults to North, pass in a negative value for South.
+ * @param float|null $latitude Defaults to North, pass in a negative value for South.
  * See also: date.default_latitude
- * @param float $longitude Defaults to East, pass in a negative value for West.
+ * @param float|null $longitude Defaults to East, pass in a negative value for West.
  * See also: date.default_longitude
- * @param float $zenith zenith is the angle between the center of the sun
+ * @param float|null $zenith zenith is the angle between the center of the sun
  * and a line perpendicular to earth's surface. It defaults to
  * date.sunset_zenith
  *
@@ -289,7 +289,7 @@ function date_sunrise(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?
  *
  *
  *
- * @param float $utcOffset Specified in hours.
+ * @param float|null $utcOffset Specified in hours.
  * The utcOffset is ignored, if
  * returnFormat is
  * SUNFUNCS_RET_TIMESTAMP.
@@ -329,7 +329,7 @@ function date_sunset(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?f
  * 01:00:00".
  *
  * @param string $format See description in strftime.
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -461,7 +461,7 @@ function gmstrftime(string $format, ?int $timestamp = null): string
  *
  *
  *
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -776,7 +776,7 @@ function idate(string $format, ?int $timestamp = null): int
  *
  * The %z and %Z modifiers both
  * return the time zone name instead of the offset or abbreviation.
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -897,7 +897,7 @@ function strptime(string $timestamp, string $format): array
  * ways to define the default time zone.
  *
  * @param string $datetime A date/time string. Valid formats are explained in Date and Time Formats.
- * @param int $baseTimestamp The timestamp which is used as a base for the calculation of relative
+ * @param int|null $baseTimestamp The timestamp which is used as a base for the calculation of relative
  * dates.
  * @return int Returns a timestamp on success.
  * @throws DatetimeException

--- a/generated/8.4/eio.php
+++ b/generated/8.4/eio.php
@@ -13,7 +13,7 @@ use Safe\Exceptions\EioException;
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback This callback is called when all the group requests are done.
+ * @param callable|null $callback This callback is called when all the group requests are done.
  * @param mixed $data Arbitrary variable passed to callback.
  * @return resource eio_busy returns request resource on success.
  * @throws EioException
@@ -41,7 +41,7 @@ function eio_busy(int $delay, int $pri = EIO_PRI_DEFAULT, ?callable $callback = 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -93,7 +93,7 @@ function eio_chmod(string $path, int $mode, int $pri = EIO_PRI_DEFAULT, ?callabl
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -142,7 +142,7 @@ function eio_chown(string $path, int $uid, int $gid = -1, int $pri = EIO_PRI_DEF
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -250,7 +250,7 @@ function eio_custom(callable $execute, int $pri, callable $callback, $data = nul
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -322,7 +322,7 @@ function eio_event_loop(): void
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -372,7 +372,7 @@ function eio_fallocate($fd, int $mode, int $offset, int $length, int $pri = EIO_
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -423,7 +423,7 @@ function eio_fchmod($fd, int $mode, int $pri = EIO_PRI_DEFAULT, ?callable $callb
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -471,7 +471,7 @@ function eio_fchown($fd, int $uid, int $gid = -1, int $pri = EIO_PRI_DEFAULT, ?c
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -625,7 +625,7 @@ function eio_fstatvfs($fd, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -676,7 +676,7 @@ function eio_fsync($fd, int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -727,7 +727,7 @@ function eio_ftruncate($fd, int $offset = 0, int $pri = EIO_PRI_DEFAULT, ?callab
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -796,7 +796,7 @@ function eio_futime($fd, float $atime, float $mtime, int $pri = EIO_PRI_DEFAULT,
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_grp returns request group resource on success.
  * @throws EioException
  *
@@ -870,7 +870,7 @@ function eio_lstat(string $path, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -935,7 +935,7 @@ function eio_mkdir(string $path, int $mode, int $pri = EIO_PRI_DEFAULT, ?callabl
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -983,7 +983,7 @@ function eio_mknod(string $path, int $mode, int $dev, int $pri = EIO_PRI_DEFAULT
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1034,7 +1034,7 @@ function eio_nop(int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, $data =
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1111,7 +1111,7 @@ function eio_readahead($fd, int $offset, int $length, int $pri = EIO_PRI_DEFAULT
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_readdir returns request resource on success.
  * Sets result argument of
  * callback function according to
@@ -1411,7 +1411,7 @@ function eio_readdir(string $path, int $flags, int $pri, callable $callback, ?st
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_readlink returns request resource on success.
  * @throws EioException
  *
@@ -1435,7 +1435,7 @@ function eio_readlink(string $path, int $pri, callable $callback, ?string $data 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1483,7 +1483,7 @@ function eio_rename(string $path, string $new_path, int $pri = EIO_PRI_DEFAULT, 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1541,7 +1541,7 @@ function eio_rmdir(string $path, int $pri = EIO_PRI_DEFAULT, ?callable $callback
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1756,7 +1756,7 @@ function eio_statvfs(string $path, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1815,7 +1815,7 @@ function eio_symlink(string $path, string $new_path, int $pri = EIO_PRI_DEFAULT,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1860,7 +1860,7 @@ function eio_sync_file_range($fd, int $offset, int $nbytes, int $flags, int $pri
  *
  *
  * @param int $pri
- * @param callable $callback
+ * @param callable|null $callback
  * @param mixed $data
  * @return resource eio_sync returns request resource on success.
  * @throws EioException
@@ -1884,7 +1884,7 @@ function eio_sync(int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, $data 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1934,7 +1934,7 @@ function eio_syncfs($fd, int $pri = EIO_PRI_DEFAULT, ?callable $callback = null,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1982,7 +1982,7 @@ function eio_truncate(string $path, int $offset = 0, int $pri = EIO_PRI_DEFAULT,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -2032,7 +2032,7 @@ function eio_unlink(string $path, int $pri = EIO_PRI_DEFAULT, ?callable $callbac
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -2085,7 +2085,7 @@ function eio_utime(string $path, float $atime, float $mtime, int $pri = EIO_PRI_
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *

--- a/generated/8.4/errorfunc.php
+++ b/generated/8.4/errorfunc.php
@@ -57,9 +57,9 @@ use Safe\Exceptions\ErrorfuncException;
  *
  *
  *
- * @param string $destination The destination. Its meaning depends on the
+ * @param null|string $destination The destination. Its meaning depends on the
  * message_type parameter as described above.
- * @param string $additional_headers The extra headers. It's used when the message_type
+ * @param null|string $additional_headers The extra headers. It's used when the message_type
  * parameter is set to 1.
  * This message type uses the same internal function as
  * mail does.

--- a/generated/8.4/exec.php
+++ b/generated/8.4/exec.php
@@ -178,7 +178,7 @@ function proc_nice(int $priority): void
  * PHP process)
  * @param array|null $env_vars An array with the environment variables for the command that will be
  * run, or NULL to use the same environment as the current PHP process
- * @param array $options Allows you to specify additional options. Currently supported options
+ * @param array|null $options Allows you to specify additional options. Currently supported options
  * include:
  *
  *

--- a/generated/8.4/fileinfo.php
+++ b/generated/8.4/fileinfo.php
@@ -30,7 +30,7 @@ function finfo_close(\finfo $finfo): void
  *
  * @param int $flags One or disjunction of more Fileinfo
  * constants.
- * @param string $magic_database Name of a magic database file, usually something like
+ * @param null|string $magic_database Name of a magic database file, usually something like
  * /path/to/magic.mime. If not specified, the
  * MAGIC environment variable is used. If the
  * environment variable isn't set, then PHP's bundled magic database will

--- a/generated/8.4/filesystem.php
+++ b/generated/8.4/filesystem.php
@@ -253,7 +253,7 @@ function fflush($stream): void
  * Seeking (offset) is not supported with remote files.
  * Attempting to seek on non-local files may work with small offsets, but this
  * is unpredictable because it works on the buffered stream.
- * @param int $length Maximum length of data read. The default is to read until end
+ * @param int|null $length Maximum length of data read. The default is to read until end
  * of file is reached. Note that this parameter is applied to the
  * stream processed by the filters.
  * @return string The function returns the read data.
@@ -1037,7 +1037,7 @@ function ftruncate($stream, int $size): void
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
  * @param string $data The string that is to be written.
- * @param int $length If length is an integer, writing will stop
+ * @param int|null $length If length is an integer, writing will stop
  * after length bytes have been written or the
  * end of data is reached, whichever comes first.
  * @return int
@@ -1620,9 +1620,9 @@ function tmpfile()
  * If the file does not exist, it will be created.
  *
  * @param string $filename The name of the file being touched.
- * @param int $mtime The touch time. If mtime is NULL,
+ * @param int|null $mtime The touch time. If mtime is NULL,
  * the current system time is used.
- * @param int $atime If not NULL, the access time of the given filename is set to
+ * @param int|null $atime If not NULL, the access time of the given filename is set to
  * the value of atime. Otherwise, it is set to
  * the value passed to the mtime parameter.
  * If both are NULL, the current system time is used.

--- a/generated/8.4/gettext.php
+++ b/generated/8.4/gettext.php
@@ -9,7 +9,7 @@ use Safe\Exceptions\GettextException;
  * for a domain.
  *
  * @param string $domain The domain.
- * @param string $directory The directory path.
+ * @param null|string $directory The directory path.
  * An empty string means the current directory.
  * If NULL, the currently set directory is returned.
  * @return string The full pathname for the domain currently being set.

--- a/generated/8.4/ibase.php
+++ b/generated/8.4/ibase.php
@@ -112,7 +112,7 @@ function ibase_blob_cancel($blob_handle): void
  * ibase_blob_create creates a new BLOB for filling with
  * data.
  *
- * @param resource $link_identifier An InterBase link identifier. If omitted, the last opened link is
+ * @param null|resource $link_identifier An InterBase link identifier. If omitted, the last opened link is
  * assumed.
  * @return resource Returns a BLOB handle for later use with
  * ibase_blob_add.
@@ -161,7 +161,7 @@ function ibase_blob_get($blob_handle, int $len): string
  * Default transaction on link is committed, other transactions are
  * rolled back.
  *
- * @param resource $connection_id An InterBase link identifier returned from
+ * @param null|resource $connection_id An InterBase link identifier returned from
  * ibase_connect. If omitted, the last opened link
  * is assumed.
  * @throws IbaseException
@@ -184,7 +184,7 @@ function ibase_close($connection_id = null): void
 /**
  * Commits a transaction without closing it.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function commits the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function commits the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be committed. If the argument is a transaction identifier, the
@@ -211,7 +211,7 @@ function ibase_commit_ret($link_or_trans_identifier = null): void
 /**
  * Commits a transaction.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function commits the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function commits the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be committed. If the argument is a transaction identifier, the
@@ -317,7 +317,7 @@ function ibase_delete_user($service_handle, string $user_name): void
  * This functions drops a database that was opened by either ibase_connect
  * or ibase_pconnect. The database is closed and deleted from the server.
  *
- * @param resource $connection An InterBase link identifier. If omitted, the last opened link is
+ * @param null|resource $connection An InterBase link identifier. If omitted, the last opened link is
  * assumed.
  * @throws IbaseException
  *
@@ -573,7 +573,7 @@ function ibase_restore($service_handle, string $source_file, string $dest_db, in
 /**
  * Rolls back a transaction without closing it.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function rolls back the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function rolls back the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be rolled back. If the argument is a transaction identifier, the
@@ -600,7 +600,7 @@ function ibase_rollback_ret($link_or_trans_identifier = null): void
 /**
  * Rolls back a transaction.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function rolls back the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function rolls back the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be rolled back. If the argument is a transaction identifier, the

--- a/generated/8.4/iconv.php
+++ b/generated/8.4/iconv.php
@@ -76,7 +76,7 @@ function iconv_get_encoding(string $type = "all")
  *
  *
  *
- * @param string $encoding The optional encoding parameter specifies the
+ * @param null|string $encoding The optional encoding parameter specifies the
  * character set to represent the result by. If omitted or NULL,
  * iconv.internal_encoding
  * will be used.
@@ -249,7 +249,7 @@ function iconv_set_encoding(string $type, string $encoding): void
  * identical to the length of the string in bytes.
  *
  * @param string $string The string.
- * @param string $encoding If encoding parameter is omitted or NULL,
+ * @param null|string $encoding If encoding parameter is omitted or NULL,
  * string is assumed to be encoded in
  * iconv.internal_encoding.
  * @return int Returns the character count of string, as an integer,

--- a/generated/8.4/image.php
+++ b/generated/8.4/image.php
@@ -104,7 +104,7 @@ function image_type_to_extension(int $image_type, bool $include_dot = true): str
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param array $affine Array with keys 0 to 5.
- * @param array $clip Array with keys "x", "y", "width" and "height"; or NULL.
+ * @param array|null $clip Array with keys "x", "y", "width" and "height"; or NULL.
  * @return \GdImage Return affined image object on success.
  * @throws ImageException
  *
@@ -2096,8 +2096,8 @@ function imagerectangle(\GdImage $image, int $x1, int $y1, int $x2, int $y2, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param int $resolution_x The horizontal resolution in DPI.
- * @param int $resolution_y The vertical resolution in DPI.
+ * @param int|null $resolution_x The horizontal resolution in DPI.
+ * @param int|null $resolution_y The vertical resolution in DPI.
  * @return mixed When used as getter,
  * it returns an indexed array of the horizontal and vertical resolution on
  * success.
@@ -2749,7 +2749,7 @@ function imagettftext(\GdImage $image, float $size, float $angle, int $x, int $y
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
- * @param int $foreground_color You can set the foreground color with this parameter by setting an
+ * @param int|null $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black.
  * @throws ImageException
@@ -2811,7 +2811,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  * alphanumeric characters of the current locale are substituted by
  * underscores. If filename is set to NULL,
  * image is used to build the C identifiers.
- * @param int $foreground_color You can set the foreground color with this parameter by setting an
+ * @param int|null $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black. All other colors are treated as
  * background.

--- a/generated/8.4/imap.php
+++ b/generated/8.4/imap.php
@@ -35,9 +35,9 @@ function imap_8bit(string $string): string
  * When talking to the Cyrus IMAP server, you must use "\r\n" as
  * your end-of-line terminator instead of "\n" or the operation will
  * fail
- * @param string $options If provided, the options will also be written
+ * @param null|string $options If provided, the options will also be written
  * to the folder
- * @param string $internal_date If this parameter is set, it will set the INTERNALDATE on the appended message.  The parameter should be a date string that conforms to the rfc2060 specifications for a date_time value.
+ * @param null|string $internal_date If this parameter is set, it will set the INTERNALDATE on the appended message.  The parameter should be a date string that conforms to the rfc2060 specifications for a date_time value.
  * @throws ImapException
  *
  */
@@ -1366,11 +1366,11 @@ function imap_mail_move(\IMAP\Connection $imap, string $message_nums, string $ma
  * @param string $to The receiver
  * @param string $subject The mail subject
  * @param string $message The mail body, see imap_mail_compose
- * @param string $additional_headers As string with additional headers to be set on the mail
- * @param string $cc
- * @param string $bcc The receivers specified in bcc will get the
+ * @param null|string $additional_headers As string with additional headers to be set on the mail
+ * @param null|string $cc
+ * @param null|string $bcc The receivers specified in bcc will get the
  * mail, but are excluded from the headers.
- * @param string $return_path Use this parameter to specify return path upon mail delivery failure.
+ * @param null|string $return_path Use this parameter to specify return path upon mail delivery failure.
  * This is useful when using PHP as a mail client for multiple users.
  * @throws ImapException
  *
@@ -1880,9 +1880,9 @@ function imap_setacl(\IMAP\Connection $imap, string $mailbox, string $user_id, s
  *
  *
  *
- * @param string $search_criteria IMAP2-format search criteria string. For details see
+ * @param null|string $search_criteria IMAP2-format search criteria string. For details see
  * imap_search.
- * @param string $charset MIME character set to use when sorting strings.
+ * @param null|string $charset MIME character set to use when sorting strings.
  * @return array Returns an array of message numbers sorted by the given
  * parameters.
  * @throws ImapException

--- a/generated/8.4/ldap.php
+++ b/generated/8.4/ldap.php
@@ -43,7 +43,7 @@ function ldap_8859_to_t61(string $value): string
  * ]]>
  *
  *
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -94,7 +94,7 @@ function ldap_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $password
  * @param string $dn The distinguished name of an LDAP entity.
  * @param string $attribute The attribute name.
  * @param string $value The compared value.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @return bool Returns TRUE if value matches otherwise returns
  * FALSE.
  * @throws LdapException
@@ -184,7 +184,7 @@ function ldap_count_entries(\LDAP\Connection $ldap, \LDAP\Result $result): int
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -229,7 +229,7 @@ function ldap_dn2ufn(string $dn): string
  * @param string $user dn of the user to change the password of.
  * @param string $old_password The old password of this user. May be ommited depending of server configuration.
  * @param string $new_password The new password for this user. May be omitted or empty to have a generated password.
- * @param array $controls If provided, a password policy request control is send with the request and this is
+ * @param array|null $controls If provided, a password policy request control is send with the request and this is
  * filled with an array of LDAP Controls
  * returned with the request.
  * @return bool|string Returns the generated password if new_password is empty or omitted.
@@ -274,7 +274,7 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $request_oid The extended operation request OID. You may use one of LDAP_EXOP_START_TLS, LDAP_EXOP_MODIFY_PASSWD, LDAP_EXOP_REFRESH, LDAP_EXOP_WHO_AM_I, LDAP_EXOP_TURN, or a string with the OID of the operation you want to send.
- * @param string $request_data The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
+ * @param null|string $request_data The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
  * @param array|null $controls Array of LDAP Controls to send with the request.
  * @param null|string $response_data Will be filled with the extended operation response data if provided.
  * If not provided you may use ldap_parse_exop on the result object
@@ -730,7 +730,7 @@ function ldap_get_values(\LDAP\Connection $ldap, \LDAP\ResultEntry $entry, strin
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry An associative array listing the attirbute values to add. If an attribute was not existing yet it will be added. If an attribute is existing you can only add values to it if it supports multiple values.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -756,7 +756,7 @@ function ldap_mod_add(\LDAP\Connection $ldap, string $dn, array $entry, ?array $
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -781,7 +781,7 @@ function ldap_mod_del(\LDAP\Connection $ldap, string $dn, array $entry, ?array $
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry An associative array listing the attributes to replace. Sending an empty array as value will remove the attribute, while sending an attribute not existing yet on this entry will add it.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -878,7 +878,7 @@ function ldap_mod_replace(\LDAP\Connection $ldap, string $dn, array $entry, ?arr
  * value for values must be an array of strings, and
  * any value for modtype must be one of the
  * LDAP_MODIFY_BATCH_* constants listed above.
- * @param array $controls Each value specified through values is added (as
+ * @param array|null $controls Each value specified through values is added (as
  * an additional value) to the attribute named by
  * attrib.
  * @throws LdapException
@@ -979,7 +979,7 @@ function ldap_parse_result(\LDAP\Connection $ldap, \LDAP\Result $result, ?int &$
  * @param string $new_parent The new parent/superior entry.
  * @param bool $delete_old_rdn If TRUE the old RDN value(s) is removed, else the old RDN value(s)
  * is retained as non-distinguished values of the entry.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -1001,13 +1001,13 @@ function ldap_rename(\LDAP\Connection $ldap, string $dn, string $new_rdn, string
  *
  *
  * @param \LDAP\Connection $ldap
- * @param string $dn
- * @param string $password
- * @param string $mech
- * @param string $realm
- * @param string $authc_id
- * @param string $authz_id
- * @param string $props
+ * @param null|string $dn
+ * @param null|string $password
+ * @param null|string $mech
+ * @param null|string $realm
+ * @param null|string $authc_id
+ * @param null|string $authz_id
+ * @param null|string $props
  * @throws LdapException
  *
  */

--- a/generated/8.4/mbstring.php
+++ b/generated/8.4/mbstring.php
@@ -11,7 +11,7 @@ use Safe\Exceptions\MbstringException;
  * This function complements mb_ord.
  *
  * @param int $codepoint A Unicode codepoint value, e.g. 128024 for U+1F418 ELEPHANT
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return string A string containing the requested character, if it can be represented in the specified
@@ -77,7 +77,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * Sets the automatic character
  * encoding detection order to encoding.
  *
- * @param non-empty-array|non-falsy-string $encoding encoding is an array or
+ * @param non-empty-array|non-falsy-string|null $encoding encoding is an array or
  * comma separated list of character encoding. See supported encodings.
  *
  * If encoding is omitted or NULL, it returns
@@ -144,7 +144,7 @@ function mb_detect_order($encoding = null)
  * clutter the function namespace with a callback function's name
  * not used anywhere else.
  * @param string $string The string being checked.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -174,7 +174,7 @@ function mb_ereg_replace_callback(string $pattern, callable $callback, string $s
  * Multibyte characters may be used in pattern.
  * @param string $replacement The replacement text.
  * @param string $string The string being checked.
- * @param string $options
+ * @param null|string $options
  * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -223,8 +223,8 @@ function mb_ereg_search_getregs(): array
  * mb_ereg_search_regs.
  *
  * @param string $string The search string.
- * @param string $pattern The search pattern.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $pattern The search pattern.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @throws MbstringException
  *
  */
@@ -247,8 +247,8 @@ function mb_ereg_search_init(string $string, ?string $pattern = null, ?string $o
 /**
  * Returns the matched part of a multibyte regular expression.
  *
- * @param string $pattern The search pattern.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $pattern The search pattern.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @return array
  * @throws MbstringException
  *
@@ -293,7 +293,7 @@ function mb_ereg_search_setpos(int $offset): void
  * @param string $pattern The regular expression pattern.  Multibyte characters may be used. The case will be ignored.
  * @param string $replacement The replacement text.
  * @param string $string The searched string.
- * @param string $options
+ * @param null|string $options
  * @return string The resultant string.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -357,7 +357,7 @@ function mb_get_info(string $type = "all")
  * Set/Get the HTTP output character encoding.
  * Output after this function is called will be converted from the set internal encoding to encoding.
  *
- * @param string $encoding If encoding is set,
+ * @param null|string $encoding If encoding is set,
  * mb_http_output sets the HTTP output character
  * encoding to encoding.
  *
@@ -389,7 +389,7 @@ function mb_http_output(?string $encoding = null)
 /**
  * Set/Get the internal character encoding
  *
- * @param string $encoding encoding is the character encoding name
+ * @param null|string $encoding encoding is the character encoding name
  * used for the HTTP input character encoding conversion, HTTP output
  * character encoding conversion, and the default character encoding
  * for string functions defined by the mbstring module.
@@ -423,7 +423,7 @@ function mb_internal_encoding(?string $encoding = null)
  * This function complements mb_chr.
  *
  * @param string $string A string
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return int The Unicode code point for the first character of string.
@@ -471,7 +471,7 @@ function mb_parse_str(string $string, ?array &$result): void
 /**
  * Set/Get character encoding for a multibyte regex.
  *
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return bool|string
@@ -530,7 +530,7 @@ function mb_regex_encoding(?string $encoding = null)
  * automatically (which leads to doubling CR if CRLF is used).
  * This should be a last resort, as it does not comply with
  * RFC 2822.
- * @param string $additional_params additional_params is a MTA command line
+ * @param null|string $additional_params additional_params is a MTA command line
  * parameter. It is useful when setting the correct Return-Path
  * header when using sendmail.
  *

--- a/generated/8.4/misc.php
+++ b/generated/8.4/misc.php
@@ -227,7 +227,7 @@ function sapi_windows_set_ctrl_handler(?callable $handler, bool $add = true): vo
  * They allow the modification of the terminal's output. On Windows these sequences are called Console Virtual Terminal Sequences.
  *
  * @param resource $stream The stream on which the function will operate.
- * @param bool $enable If bool, the VT100 feature will be enabled (if TRUE) or disabled (if FALSE).
+ * @param bool|null $enable If bool, the VT100 feature will be enabled (if TRUE) or disabled (if FALSE).
  * @throws MiscException
  *
  */

--- a/generated/8.4/mysql.php
+++ b/generated/8.4/mysql.php
@@ -18,7 +18,7 @@ use Safe\Exceptions\MysqlException;
  * improve performance. For related information, see
  * freeing resources
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no connection is found or
  * established, an E_WARNING level error is
@@ -102,7 +102,7 @@ function mysql_connect(?string $server = null, ?string $username = null, ?string
  * identifier.
  *
  * @param string $database_name The name of the database being created.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -184,7 +184,7 @@ function mysql_db_name($result, int $row, $field = null): string
  * @param string $query The MySQL query.
  *
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -215,7 +215,7 @@ function mysql_db_query(string $database, string $query, $link_identifier = null
  * DROP DATABASE statement instead.
  *
  * @param string $database_name The name of the database that will be deleted.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -407,7 +407,7 @@ function mysql_free_result($result): void
  * Describes the type of connection in use for the connection, including the
  * server host name.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -432,7 +432,7 @@ function mysql_get_host_info($link_identifier = null): string
 /**
  * Retrieves the MySQL protocol.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -456,7 +456,7 @@ function mysql_get_proto_info($link_identifier = null): int
 /**
  * Retrieves the MySQL server version.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -480,7 +480,7 @@ function mysql_get_server_info($link_identifier = null): string
 /**
  * Returns detailed information about the last query.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -507,7 +507,7 @@ function mysql_info($link_identifier = null): string
  * Returns a result pointer containing the databases available from the
  * current mysql daemon.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -539,7 +539,7 @@ function mysql_list_dbs($link_identifier = null)
  *
  * @param string $database_name The name of the database that's being queried.
  * @param string $table_name The name of the table that's being queried.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -568,7 +568,7 @@ function mysql_list_fields(string $database_name, string $table_name, $link_iden
 /**
  * Retrieves the current MySQL server threads.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -597,7 +597,7 @@ function mysql_list_processes($link_identifier = null)
  * [FROM db_name] [LIKE 'pattern'] statement instead.
  *
  * @param string $database The name of the database
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -678,7 +678,7 @@ function mysql_num_rows($result): int
  *
  * The query string should not end with a semicolon.
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -734,7 +734,7 @@ function mysql_query(string $query, $link_identifier = null)
  * safe before sending a query to MySQL.
  *
  * @param string $unescaped_string The string that is to be escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -798,7 +798,7 @@ function mysql_result($result, int $row, $field = 0): string
  * mysql_query will be made on the active database.
  *
  * @param string $database_name The name of the database that is to be selected.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -821,7 +821,7 @@ function mysql_select_db(string $database_name, $link_identifier = null): void
  * Sets the default character set for the current connection.
  *
  * @param string $charset A valid character set name.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -874,7 +874,7 @@ function mysql_tablename($result, int $i): string
  * with mysql_ping is executed, the thread ID will
  * change. This means only retrieve the thread ID when needed.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -912,7 +912,7 @@ function mysql_thread_id($link_identifier = null): int
  * @param string $query The SQL query to execute.
  *
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called

--- a/generated/8.4/network.php
+++ b/generated/8.4/network.php
@@ -258,7 +258,7 @@ function dns_get_record(string $hostname, int $type = DNS_ANY, ?array &$authorit
  * connect() call. This is most likely due to a
  * problem initializing the socket.
  * @param null|string $error_message The error message as a string.
- * @param float $timeout The connection timeout, in seconds. When NULL, the
+ * @param float|null $timeout The connection timeout, in seconds. When NULL, the
  * default_socket_timeout php.ini setting is used.
  *
  * If you need to set a timeout for reading/writing data over the
@@ -553,7 +553,7 @@ function net_get_interfaces(): array
  * @param int $port
  * @param int|null $error_code
  * @param null|string $error_message
- * @param float $timeout
+ * @param float|null $timeout
  * @return resource pfsockopen returns a file pointer which may be used
  * together with the other file functions (such as
  * fgets, fgetss,

--- a/generated/8.4/oci8.php
+++ b/generated/8.4/oci8.php
@@ -386,7 +386,7 @@ function oci_commit($connection): void
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from
@@ -774,7 +774,7 @@ function oci_free_statement($statement): void
  * @param resource $connection An Oracle connection identifier, returned by
  * oci_connect or oci_pconnect.
  * @param string $type_name Should be a valid named type (uppercase).
- * @param string $schema Should point to the scheme, where the named type was created. The name
+ * @param null|string $schema Should point to the scheme, where the named type was created. The name
  * of the current user is used when NULL is passed.
  * @return \OCI-Collection Returns a new OCICollection object.
  * @throws Oci8Exception
@@ -806,7 +806,7 @@ function oci_new_collection($connection, string $type_name, ?string $schema = nu
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from
@@ -1009,7 +1009,7 @@ function oci_parse($connection, string $sql)
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from

--- a/generated/8.4/openssl.php
+++ b/generated/8.4/openssl.php
@@ -297,7 +297,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  * generated based on the supplied options and
  * assigned to supplied variable. The corresponding public portion of the
  * key will be used to sign the CSR.
- * @param array $options By default, the information in your system openssl.conf
+ * @param array|null $options By default, the information in your system openssl.conf
  * is used to initialize the request; you can specify a configuration file
  * section by setting the config_section_section key in
  * options.  You can also specify an alternative
@@ -388,7 +388,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  *
  *
  *
- * @param array $extra_attributes extra_attributes is used to specify additional
+ * @param array|null $extra_attributes extra_attributes is used to specify additional
  * configuration options for the CSR.  Both
  * distinguished_names and
  * extra_attributes are associative arrays, whose keys
@@ -429,7 +429,7 @@ function openssl_csr_new(array $distinguished_names, ?\OpenSSLAsymmetricKey &$pr
  * ca_certificate.
  * @param int $days days specifies the length of time for which the
  * generated certificate will be valid, in days.
- * @param array $options You can finetune the CSR signing by options.
+ * @param array|null $options You can finetune the CSR signing by options.
  * See openssl_csr_new for more information about
  * options.
  * @param int $serial An optional the serial number of issued certificate. If not specified
@@ -474,7 +474,7 @@ function openssl_csr_sign($csr, $ca_certificate, $private_key, int $days, ?array
  * @param string $iv A non-NULL Initialization Vector. If the IV is shorter than expected, it is padded with
  * NUL characters and warning is emitted; if the passphrase is longer
  * than expected, it is truncated and warning is emitted.
- * @param string $tag The authentication tag in AEAD cipher mode. If it is incorrect, the authentication fails and the function returns FALSE.
+ * @param null|string $tag The authentication tag in AEAD cipher mode. If it is incorrect, the authentication fails and the function returns FALSE.
  * @param string $aad Additional authenticated data.
  * @return string The decrypted string on success.
  * @throws OpensslException
@@ -625,7 +625,7 @@ function openssl_get_curve_names(): array
  * method.
  *
  *
- * @param string $iv The initialization vector used for decryption of data. It is required
+ * @param null|string $iv The initialization vector used for decryption of data. It is required
  * if the cipher method requires IV. This can be found out by calling
  * openssl_cipher_iv_length with cipher_algo.
  * @throws OpensslException
@@ -878,7 +878,7 @@ function openssl_pkcs7_read(string $data, ?array &$certificates): void
  * openssl_pkcs7_encrypt for more information about
  * the format of this parameter).
  * @param int $flags flags can be used to alter the output - see PKCS7 constants.
- * @param string $untrusted_certificates_filename untrusted_certificates_filename specifies the name of a file containing
+ * @param null|string $untrusted_certificates_filename untrusted_certificates_filename specifies the name of a file containing
  * a bunch of extra certificates to include in the signature which can for
  * example be used to help the recipient to verify the certificate that you used.
  * @throws OpensslException
@@ -931,7 +931,7 @@ function openssl_pkey_derive($public_key, $private_key, int $key_length = 0): st
  * @param string $output_filename Path to the output file.
  * @param null|string $passphrase The key can be optionally protected by a
  * passphrase.
- * @param array $options options can be used to fine-tune the export
+ * @param array|null $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file. See openssl_csr_new for more
  * information about options.
@@ -962,7 +962,7 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param null|string $output
  * @param null|string $passphrase The key is optionally protected by passphrase.
- * @param array $options options can be used to fine-tune the export
+ * @param array|null $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file.  See openssl_csr_new for more
  * information about options.
@@ -1083,7 +1083,7 @@ function openssl_pkey_get_public($public_key): \OpenSSLAsymmetricKey
  * key.
  * How to obtain the public component of the key is shown in an example below.
  *
- * @param array $options You can finetune the key generation (such as specifying the number of
+ * @param array|null $options You can finetune the key generation (such as specifying the number of
  * bits) using options.  See
  * openssl_csr_new for more information about
  * options.
@@ -1464,7 +1464,7 @@ function openssl_verify(string $data, string $signature, $public_key, $algorithm
  * @param array $ca_info ca_info should be an array of trusted CA files/dirs
  * as described in Certificate
  * Verification.
- * @param string $untrusted_certificates_file If specified, this should be the name of a PEM encoded file holding
+ * @param null|string $untrusted_certificates_file If specified, this should be the name of a PEM encoded file holding
  * certificates that can be used to help verify the certificate, although
  * no trust is placed in the certificates that come from that file.
  * @return bool|int Returns TRUE if the certificate can be used for the intended purpose,

--- a/generated/8.4/pcntl.php
+++ b/generated/8.4/pcntl.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\PcntlException;
  * system types and kernel versions, please see your system's getpriority(2)
  * man page for specific details.
  *
- * @param int $process_id If NULL, the process id of the current process is used.
+ * @param int|null $process_id If NULL, the process id of the current process is used.
  * @param int $mode One of PRIO_PGRP, PRIO_USER,
  * PRIO_PROCESS,
  * PRIO_DARWIN_BG or PRIO_DARWIN_THREAD.
@@ -46,7 +46,7 @@ function pcntl_getpriority(?int $process_id = null, int $mode = PRIO_PROCESS): i
  * favorable scheduling.  Because priority levels can differ between
  * system types and kernel versions, please see your system's setpriority(2)
  * man page for specific details.
- * @param int $process_id If NULL, the process id of the current process is used.
+ * @param int|null $process_id If NULL, the process id of the current process is used.
  * @param int $mode One of PRIO_PGRP, PRIO_USER,
  * PRIO_PROCESS,
  * PRIO_DARWIN_BG or PRIO_DARWIN_THREAD.

--- a/generated/8.4/pgsql.php
+++ b/generated/8.4/pgsql.php
@@ -765,7 +765,7 @@ function pg_lo_unlink(\PgSql\Connection $connection, int $oid): void
  * @param string $data The data to be written to the large object.  If length is
  * an int and is less than the length of data, only
  * length bytes will be written.
- * @param int $length An optional maximum number of bytes to write.  Must be greater than zero
+ * @param int|null $length An optional maximum number of bytes to write.  Must be greater than zero
  * and no greater than the length of data.  Defaults to
  * the length of data.
  * @return int The number of bytes written to the large object.

--- a/generated/8.4/readline.php
+++ b/generated/8.4/readline.php
@@ -26,7 +26,7 @@ function readline_completion_function(callable $callback): void
 /**
  * This function reads a command history from a file.
  *
- * @param string $filename Path to the filename containing the command history.
+ * @param null|string $filename Path to the filename containing the command history.
  * @throws ReadlineException
  *
  */
@@ -47,7 +47,7 @@ function readline_read_history(?string $filename = null): void
 /**
  * This function writes the command history to a file.
  *
- * @param string $filename Path to the saved file.
+ * @param null|string $filename Path to the saved file.
  * @throws ReadlineException
  *
  */

--- a/generated/8.4/sem.php
+++ b/generated/8.4/sem.php
@@ -434,7 +434,7 @@ function sem_remove(\SysvSemaphore $semaphore): void
  * permissions will be ignored.
  *
  * @param int $key A numeric shared memory segment ID
- * @param int $size The memory size. If not provided, default to the
+ * @param int|null $size The memory size. If not provided, default to the
  * sysvshm.init_mem in the php.ini, otherwise 10000
  * bytes.
  * @param int $permissions The optional permission bits. Default to 0666.

--- a/generated/8.4/session.php
+++ b/generated/8.4/session.php
@@ -135,7 +135,7 @@ function session_encode(): string
  * adding to URLs. See also Session
  * handling.
  *
- * @param string $id If id is specified and not NULL, it will replace the current
+ * @param null|string $id If id is specified and not NULL, it will replace the current
  * session id. session_id needs to be called before
  * session_start for that purpose. Depending on the
  * session handler, not all characters are allowed within the session id.
@@ -168,7 +168,7 @@ function session_id(?string $id = null): string
  * session module, which is also known as
  * session.save_handler.
  *
- * @param string $module If module is specified and not NULL, that module will be
+ * @param null|string $module If module is specified and not NULL, that module will be
  * used instead.
  * Passing "user" to this parameter is forbidden. Instead
  * session_set_save_handler has to be called to set a user
@@ -212,7 +212,7 @@ function session_module_name(?string $module = null): string
  * call session_name for every request (and before
  * session_start is called).
  *
- * @param string $name The session name references the name of the session, which is
+ * @param null|string $name The session name references the name of the session, which is
  * used in cookies and URLs (e.g. PHPSESSID). It
  * should contain only alphanumeric characters; it should be short and
  * descriptive (i.e. for users with enabled cookie warnings).
@@ -296,7 +296,7 @@ function session_reset(): void
  * session_save_path returns the path of the current
  * directory used to save session data.
  *
- * @param string $path Session data path. If specified and not NULL, the path to which data is saved will
+ * @param null|string $path Session data path. If specified and not NULL, the path to which data is saved will
  * be changed. session_save_path needs to be called
  * before session_start for that purpose.
  *

--- a/generated/8.4/sockets.php
+++ b/generated/8.4/sockets.php
@@ -178,7 +178,7 @@ function socket_bind(\Socket $socket, string $address, int $port = 0): void
  * socket is AF_INET6
  * or the pathname of a Unix domain socket, if the socket family is
  * AF_UNIX.
- * @param int $port The port parameter is only used and is mandatory
+ * @param int|null $port The port parameter is only used and is mandatory
  * when connecting to an AF_INET or an
  * AF_INET6 socket, and designates
  * the port on the remote host to which a connection should be made.
@@ -663,7 +663,7 @@ function socket_sendmsg(\Socket $socket, array $message, int $flags = 0): int
  *
  *
  * @param string $address IP address of the remote host.
- * @param int $port port is the remote port number at which the data
+ * @param int|null $port port is the remote port number at which the data
  * will be sent.
  * @return int socket_sendto returns the number of bytes sent to the
  * remote host.

--- a/generated/8.4/spl.php
+++ b/generated/8.4/spl.php
@@ -87,7 +87,7 @@ function class_uses($object_or_class, bool $autoload = true): array
  * runs through each of them in the order they are defined. By contrast,
  * __autoload may only be defined once.
  *
- * @param callable(string):void $callback The autoload function being registered.
+ * @param callable(string):void|null $callback The autoload function being registered.
  * If NULL, then the default implementation of
  * spl_autoload will be registered.
  *

--- a/generated/8.4/ssh2.php
+++ b/generated/8.4/ssh2.php
@@ -717,7 +717,7 @@ function ssh2_sftp($session)
  * ssh2_connect.
  * @param string $termtype termtype should correspond to one of the
  * entries in the target system's /etc/termcap file.
- * @param array $env env may be passed as an associative array of
+ * @param array|null $env env may be passed as an associative array of
  * name/value pairs to set in the target environment.
  * @param int $width Width of the virtual terminal.
  * @param int $height Height of the virtual terminal.

--- a/generated/8.4/stream.php
+++ b/generated/8.4/stream.php
@@ -59,7 +59,7 @@ function stream_context_set_params($context, array $params): void
  *
  * @param resource $from The source stream
  * @param resource $to The destination stream
- * @param int $length Maximum bytes to copy. By default all bytes left are copied.
+ * @param int|null $length Maximum bytes to copy. By default all bytes left are copied.
  * @param int $offset The offset where to start to copy data
  * @return int Returns the total count of bytes copied.
  * @throws StreamException
@@ -236,7 +236,7 @@ function stream_filter_remove($stream_filter): void
  * offset.
  *
  * @param resource $stream A stream resource (e.g. returned from fopen)
- * @param int $length The maximum bytes to read. Defaults to NULL (read all the remaining
+ * @param int|null $length The maximum bytes to read. Defaults to NULL (read all the remaining
  * buffer).
  * @param int $offset Seek to the specified offset before reading. If this number is negative,
  * no seeking will occur and reading will start from the current position.
@@ -390,7 +390,7 @@ function stream_set_timeout($stream, int $seconds, int $microseconds = 0): void
  * stream_socket_server.
  *
  * @param resource $socket The server socket to accept a connection from.
- * @param float $timeout Override the default socket accept timeout. Time should be given in
+ * @param float|null $timeout Override the default socket accept timeout. Time should be given in
  * seconds. By default, default_socket_timeout
  * is used.
  * @param null|string $peer_name Will be set to the name (address) of the client which connected, if
@@ -433,7 +433,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * @param string $address Address to the socket to connect to.
  * @param int|null $error_code Will be set to the system level error number if connection fails.
  * @param null|string $error_message Will be set to the system level error message if the connection fails.
- * @param float $timeout Number of seconds until the connect() system call
+ * @param float|null $timeout Number of seconds until the connect() system call
  * should timeout. By default, default_socket_timeout
  * is used.
  *

--- a/generated/8.4/uodbc.php
+++ b/generated/8.4/uodbc.php
@@ -12,7 +12,7 @@ use Safe\Exceptions\UodbcException;
  *
  * @param \Odbc\Connection $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param bool $enable If enable is TRUE, auto-commit is enabled, if
+ * @param bool|null $enable If enable is TRUE, auto-commit is enabled, if
  * it is FALSE auto-commit is disabled.
  * If NULL is passed, this function returns the auto-commit status for
  * odbc.
@@ -203,7 +203,7 @@ function odbc_execute(\Odbc\Result $statement, array $params = []): void
  * that can be of any type since it will be converted to type
  * array. The array will contain the column values starting at array
  * index 0.
- * @param int $row The row number.
+ * @param int|null $row The row number.
  * @return int Returns the number of columns in the result;
  * FALSE on error.
  * @throws UodbcException
@@ -413,12 +413,12 @@ function odbc_prepare(\Odbc\Connection $odbc, string $query): \Odbc\Result
  *
  * @param  $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $procedure The name.
+ * @param null|string $procedure The name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
@@ -607,16 +607,16 @@ function odbc_setoption($odbc, int $which, int $option, int $value): void
  *
  * @param \Odbc\Connection $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $table The name.
+ * @param null|string $table The name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $types If table_type is not an empty string, it
+ * @param null|string $types If table_type is not an empty string, it
  * must contain a list of comma-separated values for the types of
  * interest; each value may be enclosed in single quotes (') or
  * unquoted. For example, 'TABLE','VIEW' or TABLE, VIEW.  If the

--- a/generated/8.4/yaml.php
+++ b/generated/8.4/yaml.php
@@ -12,7 +12,7 @@ use Safe\Exceptions\YamlException;
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * details.
@@ -50,7 +50,7 @@ function yaml_parse_file(string $filename, int $pos = 0, ?int &$ndocs = null, ?a
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more details.
  * @return mixed Returns the value encoded in url in appropriate
@@ -83,7 +83,7 @@ function yaml_parse_url(string $url, int $pos = 0, ?int &$ndocs = null, ?array $
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * details.

--- a/generated/8.4/zlib.php
+++ b/generated/8.4/zlib.php
@@ -293,7 +293,7 @@ function gzfile(string $filename, int $use_include_path = 0): array
  *
  * @param resource $stream The gz-file pointer. It must be valid, and must point to a file
  * successfully opened by gzopen.
- * @param int $length The length of data to get.
+ * @param int|null $length The length of data to get.
  * @return string The uncompressed string.
  * @throws ZlibException
  *
@@ -469,7 +469,7 @@ function gzuncompress(string $data, int $max_length = 0): string
  * @param resource $stream The gz-file pointer. It must be valid, and must point to a file
  * successfully opened by gzopen.
  * @param string $data The string to write.
- * @param int $length The number of uncompressed bytes to write. If supplied, writing will
+ * @param int|null $length The number of uncompressed bytes to write. If supplied, writing will
  * stop after length (uncompressed) bytes have been
  * written or the end of data is reached,
  * whichever comes first.

--- a/generated/8.5/bzip2.php
+++ b/generated/8.5/bzip2.php
@@ -98,7 +98,7 @@ function bzread($bz, int $length = 1024): string
  * @param resource $bz The file pointer. It must be valid and must point to a file
  * successfully opened by bzopen.
  * @param string $data The written data.
- * @param int $length If supplied, writing will stop after length
+ * @param int|null $length If supplied, writing will stop after length
  * (uncompressed) bytes have been written or the end of
  * data is reached, whichever comes first.
  * @return int Returns the number of bytes written.

--- a/generated/8.5/calendar.php
+++ b/generated/8.5/calendar.php
@@ -10,7 +10,7 @@ use Safe\Exceptions\CalendarException;
  * timestamp is given. Either way, the time is regarded
  * as local time (not UTC).
  *
- * @param int $timestamp A unix timestamp to convert.
+ * @param int|null $timestamp A unix timestamp to convert.
  * @return int A julian day number as integer.
  * @throws CalendarException
  *

--- a/generated/8.5/com.php
+++ b/generated/8.5/com.php
@@ -132,7 +132,7 @@ function com_load_typelib(string $typelib, bool $case_insensitive = true): void
  * @param object $variant variant should be either an instance of a COM
  * object, or be the name of a typelibrary (which will be resolved according
  * to the rules set out in com_load_typelib).
- * @param string $dispatch_interface The name of an IDispatch descendant interface that you want to display.
+ * @param null|string $dispatch_interface The name of an IDispatch descendant interface that you want to display.
  * @param bool $display_sink If set to TRUE, the corresponding sink interface will be displayed
  * instead.
  * @throws ComException

--- a/generated/8.5/curl.php
+++ b/generated/8.5/curl.php
@@ -77,7 +77,7 @@ function curl_exec(\CurlHandle $handle)
  *
  * @param \CurlHandle $handle A cURL handle returned by
  * curl_init.
- * @param int $option One of the CURLINFO_* constants.
+ * @param int|null $option One of the CURLINFO_* constants.
  * @return mixed If option is given, returns its value.
  * Otherwise, returns an associative array with the following elements
  * (which correspond to option):
@@ -246,7 +246,7 @@ function curl_getinfo(\CurlHandle $handle, ?int $option = null)
 /**
  * Initializes a new session and returns a cURL handle.
  *
- * @param string $url If provided, the CURLOPT_URL option will be set
+ * @param null|string $url If provided, the CURLOPT_URL option will be set
  * to its value. This can be set manually using the
  * curl_setopt function.
  *

--- a/generated/8.5/datetime.php
+++ b/generated/8.5/datetime.php
@@ -150,11 +150,11 @@ function date_parse_from_format(string $format, string $datetime): ?array
  *
  *
  *
- * @param float $latitude Defaults to North, pass in a negative value for South.
+ * @param float|null $latitude Defaults to North, pass in a negative value for South.
  * See also: date.default_latitude
- * @param float $longitude Defaults to East, pass in a negative value for West.
+ * @param float|null $longitude Defaults to East, pass in a negative value for West.
  * See also: date.default_longitude
- * @param float $zenith zenith is the angle between the center of the sun
+ * @param float|null $zenith zenith is the angle between the center of the sun
  * and a line perpendicular to earth's surface. It defaults to
  * date.sunrise_zenith
  *
@@ -186,7 +186,7 @@ function date_parse_from_format(string $format, string $datetime): ?array
  *
  *
  *
- * @param float $utcOffset Specified in hours.
+ * @param float|null $utcOffset Specified in hours.
  * The utcOffset is ignored, if
  * returnFormat is
  * SUNFUNCS_RET_TIMESTAMP.
@@ -253,11 +253,11 @@ function date_sunrise(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?
  *
  *
  *
- * @param float $latitude Defaults to North, pass in a negative value for South.
+ * @param float|null $latitude Defaults to North, pass in a negative value for South.
  * See also: date.default_latitude
- * @param float $longitude Defaults to East, pass in a negative value for West.
+ * @param float|null $longitude Defaults to East, pass in a negative value for West.
  * See also: date.default_longitude
- * @param float $zenith zenith is the angle between the center of the sun
+ * @param float|null $zenith zenith is the angle between the center of the sun
  * and a line perpendicular to earth's surface. It defaults to
  * date.sunset_zenith
  *
@@ -289,7 +289,7 @@ function date_sunrise(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?
  *
  *
  *
- * @param float $utcOffset Specified in hours.
+ * @param float|null $utcOffset Specified in hours.
  * The utcOffset is ignored, if
  * returnFormat is
  * SUNFUNCS_RET_TIMESTAMP.
@@ -329,7 +329,7 @@ function date_sunset(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?f
  * 01:00:00".
  *
  * @param string $format See description in strftime.
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -461,7 +461,7 @@ function gmstrftime(string $format, ?int $timestamp = null): string
  *
  *
  *
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -776,7 +776,7 @@ function idate(string $format, ?int $timestamp = null): int
  *
  * The %z and %Z modifiers both
  * return the time zone name instead of the offset or abbreviation.
- * @param int $timestamp The optional timestamp parameter is an
+ * @param int|null $timestamp The optional timestamp parameter is an
  * int Unix timestamp that defaults to the current
  * local time if timestamp is omitted or NULL. In other
  * words, it defaults to the value of time.
@@ -897,7 +897,7 @@ function strptime(string $timestamp, string $format): array
  * ways to define the default time zone.
  *
  * @param string $datetime A date/time string. Valid formats are explained in Date and Time Formats.
- * @param int $baseTimestamp The timestamp which is used as a base for the calculation of relative
+ * @param int|null $baseTimestamp The timestamp which is used as a base for the calculation of relative
  * dates.
  * @return int Returns a timestamp on success.
  * @throws DatetimeException

--- a/generated/8.5/eio.php
+++ b/generated/8.5/eio.php
@@ -13,7 +13,7 @@ use Safe\Exceptions\EioException;
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback This callback is called when all the group requests are done.
+ * @param callable|null $callback This callback is called when all the group requests are done.
  * @param mixed $data Arbitrary variable passed to callback.
  * @return resource eio_busy returns request resource on success.
  * @throws EioException
@@ -41,7 +41,7 @@ function eio_busy(int $delay, int $pri = EIO_PRI_DEFAULT, ?callable $callback = 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -93,7 +93,7 @@ function eio_chmod(string $path, int $mode, int $pri = EIO_PRI_DEFAULT, ?callabl
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -142,7 +142,7 @@ function eio_chown(string $path, int $uid, int $gid = -1, int $pri = EIO_PRI_DEF
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -250,7 +250,7 @@ function eio_custom(callable $execute, int $pri, callable $callback, $data = nul
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -322,7 +322,7 @@ function eio_event_loop(): void
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -372,7 +372,7 @@ function eio_fallocate($fd, int $mode, int $offset, int $length, int $pri = EIO_
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -423,7 +423,7 @@ function eio_fchmod($fd, int $mode, int $pri = EIO_PRI_DEFAULT, ?callable $callb
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -471,7 +471,7 @@ function eio_fchown($fd, int $uid, int $gid = -1, int $pri = EIO_PRI_DEFAULT, ?c
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -625,7 +625,7 @@ function eio_fstatvfs($fd, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -676,7 +676,7 @@ function eio_fsync($fd, int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -727,7 +727,7 @@ function eio_ftruncate($fd, int $offset = 0, int $pri = EIO_PRI_DEFAULT, ?callab
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -796,7 +796,7 @@ function eio_futime($fd, float $atime, float $mtime, int $pri = EIO_PRI_DEFAULT,
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_grp returns request group resource on success.
  * @throws EioException
  *
@@ -870,7 +870,7 @@ function eio_lstat(string $path, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -935,7 +935,7 @@ function eio_mkdir(string $path, int $mode, int $pri = EIO_PRI_DEFAULT, ?callabl
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -983,7 +983,7 @@ function eio_mknod(string $path, int $mode, int $dev, int $pri = EIO_PRI_DEFAULT
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1034,7 +1034,7 @@ function eio_nop(int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, $data =
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1111,7 +1111,7 @@ function eio_readahead($fd, int $offset, int $length, int $pri = EIO_PRI_DEFAULT
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_readdir returns request resource on success.
  * Sets result argument of
  * callback function according to
@@ -1411,7 +1411,7 @@ function eio_readdir(string $path, int $flags, int $pri, callable $callback, ?st
  * system call.
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
- * @param string $data is custom data passed to the request.
+ * @param null|string $data is custom data passed to the request.
  * @return resource eio_readlink returns request resource on success.
  * @throws EioException
  *
@@ -1435,7 +1435,7 @@ function eio_readlink(string $path, int $pri, callable $callback, ?string $data 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1483,7 +1483,7 @@ function eio_rename(string $path, string $new_path, int $pri = EIO_PRI_DEFAULT, 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1541,7 +1541,7 @@ function eio_rmdir(string $path, int $pri = EIO_PRI_DEFAULT, ?callable $callback
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1756,7 +1756,7 @@ function eio_statvfs(string $path, int $pri, callable $callback, $data = null)
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1815,7 +1815,7 @@ function eio_symlink(string $path, string $new_path, int $pri = EIO_PRI_DEFAULT,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1860,7 +1860,7 @@ function eio_sync_file_range($fd, int $offset, int $nbytes, int $flags, int $pri
  *
  *
  * @param int $pri
- * @param callable $callback
+ * @param callable|null $callback
  * @param mixed $data
  * @return resource eio_sync returns request resource on success.
  * @throws EioException
@@ -1884,7 +1884,7 @@ function eio_sync(int $pri = EIO_PRI_DEFAULT, ?callable $callback = null, $data 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1934,7 +1934,7 @@ function eio_syncfs($fd, int $pri = EIO_PRI_DEFAULT, ?callable $callback = null,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -1982,7 +1982,7 @@ function eio_truncate(string $path, int $offset = 0, int $pri = EIO_PRI_DEFAULT,
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -2032,7 +2032,7 @@ function eio_unlink(string $path, int $pri = EIO_PRI_DEFAULT, ?callable $callbac
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *
@@ -2085,7 +2085,7 @@ function eio_utime(string $path, float $atime, float $mtime, int $pri = EIO_PRI_
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX, or NULL.
  * If NULL passed, pri internally is set to
  * EIO_PRI_DEFAULT.
- * @param callable $callback
+ * @param callable|null $callback
  * callback function is called when the request is done.
  * It should match the following prototype:
  *

--- a/generated/8.5/errorfunc.php
+++ b/generated/8.5/errorfunc.php
@@ -57,9 +57,9 @@ use Safe\Exceptions\ErrorfuncException;
  *
  *
  *
- * @param string $destination The destination. Its meaning depends on the
+ * @param null|string $destination The destination. Its meaning depends on the
  * message_type parameter as described above.
- * @param string $additional_headers The extra headers. It's used when the message_type
+ * @param null|string $additional_headers The extra headers. It's used when the message_type
  * parameter is set to 1.
  * This message type uses the same internal function as
  * mail does.

--- a/generated/8.5/exec.php
+++ b/generated/8.5/exec.php
@@ -178,7 +178,7 @@ function proc_nice(int $priority): void
  * PHP process)
  * @param array|null $env_vars An array with the environment variables for the command that will be
  * run, or NULL to use the same environment as the current PHP process
- * @param array $options Allows you to specify additional options. Currently supported options
+ * @param array|null $options Allows you to specify additional options. Currently supported options
  * include:
  *
  *

--- a/generated/8.5/fileinfo.php
+++ b/generated/8.5/fileinfo.php
@@ -30,7 +30,7 @@ function finfo_close(\finfo $finfo): void
  *
  * @param int $flags One or disjunction of more Fileinfo
  * constants.
- * @param string $magic_database Name of a magic database file, usually something like
+ * @param null|string $magic_database Name of a magic database file, usually something like
  * /path/to/magic.mime. If not specified, the
  * MAGIC environment variable is used. If the
  * environment variable isn't set, then PHP's bundled magic database will

--- a/generated/8.5/filesystem.php
+++ b/generated/8.5/filesystem.php
@@ -253,7 +253,7 @@ function fflush($stream): void
  * Seeking (offset) is not supported with remote files.
  * Attempting to seek on non-local files may work with small offsets, but this
  * is unpredictable because it works on the buffered stream.
- * @param int $length Maximum length of data read. The default is to read until end
+ * @param int|null $length Maximum length of data read. The default is to read until end
  * of file is reached. Note that this parameter is applied to the
  * stream processed by the filters.
  * @return string The function returns the read data.
@@ -1037,7 +1037,7 @@ function ftruncate($stream, int $size): void
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
  * @param string $data The string that is to be written.
- * @param int $length If length is an integer, writing will stop
+ * @param int|null $length If length is an integer, writing will stop
  * after length bytes have been written or the
  * end of data is reached, whichever comes first.
  * @return int
@@ -1620,9 +1620,9 @@ function tmpfile()
  * If the file does not exist, it will be created.
  *
  * @param string $filename The name of the file being touched.
- * @param int $mtime The touch time. If mtime is NULL,
+ * @param int|null $mtime The touch time. If mtime is NULL,
  * the current system time is used.
- * @param int $atime If not NULL, the access time of the given filename is set to
+ * @param int|null $atime If not NULL, the access time of the given filename is set to
  * the value of atime. Otherwise, it is set to
  * the value passed to the mtime parameter.
  * If both are NULL, the current system time is used.

--- a/generated/8.5/gettext.php
+++ b/generated/8.5/gettext.php
@@ -9,7 +9,7 @@ use Safe\Exceptions\GettextException;
  * for a domain.
  *
  * @param string $domain The domain.
- * @param string $directory The directory path.
+ * @param null|string $directory The directory path.
  * An empty string means the current directory.
  * If NULL, the currently set directory is returned.
  * @return string The full pathname for the domain currently being set.

--- a/generated/8.5/ibase.php
+++ b/generated/8.5/ibase.php
@@ -112,7 +112,7 @@ function ibase_blob_cancel($blob_handle): void
  * ibase_blob_create creates a new BLOB for filling with
  * data.
  *
- * @param resource $link_identifier An InterBase link identifier. If omitted, the last opened link is
+ * @param null|resource $link_identifier An InterBase link identifier. If omitted, the last opened link is
  * assumed.
  * @return resource Returns a BLOB handle for later use with
  * ibase_blob_add.
@@ -161,7 +161,7 @@ function ibase_blob_get($blob_handle, int $len): string
  * Default transaction on link is committed, other transactions are
  * rolled back.
  *
- * @param resource $connection_id An InterBase link identifier returned from
+ * @param null|resource $connection_id An InterBase link identifier returned from
  * ibase_connect. If omitted, the last opened link
  * is assumed.
  * @throws IbaseException
@@ -184,7 +184,7 @@ function ibase_close($connection_id = null): void
 /**
  * Commits a transaction without closing it.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function commits the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function commits the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be committed. If the argument is a transaction identifier, the
@@ -211,7 +211,7 @@ function ibase_commit_ret($link_or_trans_identifier = null): void
 /**
  * Commits a transaction.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function commits the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function commits the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be committed. If the argument is a transaction identifier, the
@@ -317,7 +317,7 @@ function ibase_delete_user($service_handle, string $user_name): void
  * This functions drops a database that was opened by either ibase_connect
  * or ibase_pconnect. The database is closed and deleted from the server.
  *
- * @param resource $connection An InterBase link identifier. If omitted, the last opened link is
+ * @param null|resource $connection An InterBase link identifier. If omitted, the last opened link is
  * assumed.
  * @throws IbaseException
  *
@@ -573,7 +573,7 @@ function ibase_restore($service_handle, string $source_file, string $dest_db, in
 /**
  * Rolls back a transaction without closing it.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function rolls back the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function rolls back the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be rolled back. If the argument is a transaction identifier, the
@@ -600,7 +600,7 @@ function ibase_rollback_ret($link_or_trans_identifier = null): void
 /**
  * Rolls back a transaction.
  *
- * @param resource $link_or_trans_identifier If called without an argument, this function rolls back the default
+ * @param null|resource $link_or_trans_identifier If called without an argument, this function rolls back the default
  * transaction of the default link. If the argument is a connection
  * identifier, the default transaction of the corresponding connection
  * will be rolled back. If the argument is a transaction identifier, the

--- a/generated/8.5/iconv.php
+++ b/generated/8.5/iconv.php
@@ -76,7 +76,7 @@ function iconv_get_encoding(string $type = "all")
  *
  *
  *
- * @param string $encoding The optional encoding parameter specifies the
+ * @param null|string $encoding The optional encoding parameter specifies the
  * character set to represent the result by. If omitted or NULL,
  * iconv.internal_encoding
  * will be used.
@@ -249,7 +249,7 @@ function iconv_set_encoding(string $type, string $encoding): void
  * identical to the length of the string in bytes.
  *
  * @param string $string The string.
- * @param string $encoding If encoding parameter is omitted or NULL,
+ * @param null|string $encoding If encoding parameter is omitted or NULL,
  * string is assumed to be encoded in
  * iconv.internal_encoding.
  * @return int Returns the character count of string, as an integer,

--- a/generated/8.5/image.php
+++ b/generated/8.5/image.php
@@ -104,7 +104,7 @@ function image_type_to_extension(int $image_type, bool $include_dot = true): str
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param array $affine Array with keys 0 to 5.
- * @param array $clip Array with keys "x", "y", "width" and "height"; or NULL.
+ * @param array|null $clip Array with keys "x", "y", "width" and "height"; or NULL.
  * @return \GdImage Return affined image object on success.
  * @throws ImageException
  *
@@ -2098,8 +2098,8 @@ function imagerectangle(\GdImage $image, int $x1, int $y1, int $x2, int $y2, int
  *
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
- * @param int $resolution_x The horizontal resolution in DPI.
- * @param int $resolution_y The vertical resolution in DPI.
+ * @param int|null $resolution_x The horizontal resolution in DPI.
+ * @param int|null $resolution_y The vertical resolution in DPI.
  * @return mixed When used as getter,
  * it returns an indexed array of the horizontal and vertical resolution on
  * success.
@@ -2751,7 +2751,7 @@ function imagettftext(\GdImage $image, float $size, float $angle, int $x, int $y
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param null|resource|string $file The path or an open stream resource (which is automatically closed after this function returns) to save the file to. If not set or NULL, the raw image stream will be output directly.
- * @param int $foreground_color You can set the foreground color with this parameter by setting an
+ * @param int|null $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black.
  * @throws ImageException
@@ -2813,7 +2813,7 @@ function imagewebp(\GdImage $image, $file = null, int $quality = -1): void
  * alphanumeric characters of the current locale are substituted by
  * underscores. If filename is set to NULL,
  * image is used to build the C identifiers.
- * @param int $foreground_color You can set the foreground color with this parameter by setting an
+ * @param int|null $foreground_color You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black. All other colors are treated as
  * background.

--- a/generated/8.5/imap.php
+++ b/generated/8.5/imap.php
@@ -35,9 +35,9 @@ function imap_8bit(string $string): string
  * When talking to the Cyrus IMAP server, you must use "\r\n" as
  * your end-of-line terminator instead of "\n" or the operation will
  * fail
- * @param string $options If provided, the options will also be written
+ * @param null|string $options If provided, the options will also be written
  * to the folder
- * @param string $internal_date If this parameter is set, it will set the INTERNALDATE on the appended message.  The parameter should be a date string that conforms to the rfc2060 specifications for a date_time value.
+ * @param null|string $internal_date If this parameter is set, it will set the INTERNALDATE on the appended message.  The parameter should be a date string that conforms to the rfc2060 specifications for a date_time value.
  * @throws ImapException
  *
  */
@@ -1366,11 +1366,11 @@ function imap_mail_move(\IMAP\Connection $imap, string $message_nums, string $ma
  * @param string $to The receiver
  * @param string $subject The mail subject
  * @param string $message The mail body, see imap_mail_compose
- * @param string $additional_headers As string with additional headers to be set on the mail
- * @param string $cc
- * @param string $bcc The receivers specified in bcc will get the
+ * @param null|string $additional_headers As string with additional headers to be set on the mail
+ * @param null|string $cc
+ * @param null|string $bcc The receivers specified in bcc will get the
  * mail, but are excluded from the headers.
- * @param string $return_path Use this parameter to specify return path upon mail delivery failure.
+ * @param null|string $return_path Use this parameter to specify return path upon mail delivery failure.
  * This is useful when using PHP as a mail client for multiple users.
  * @throws ImapException
  *
@@ -1880,9 +1880,9 @@ function imap_setacl(\IMAP\Connection $imap, string $mailbox, string $user_id, s
  *
  *
  *
- * @param string $search_criteria IMAP2-format search criteria string. For details see
+ * @param null|string $search_criteria IMAP2-format search criteria string. For details see
  * imap_search.
- * @param string $charset MIME character set to use when sorting strings.
+ * @param null|string $charset MIME character set to use when sorting strings.
  * @return array Returns an array of message numbers sorted by the given
  * parameters.
  * @throws ImapException

--- a/generated/8.5/ldap.php
+++ b/generated/8.5/ldap.php
@@ -43,7 +43,7 @@ function ldap_8859_to_t61(string $value): string
  * ]]>
  *
  *
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -94,7 +94,7 @@ function ldap_bind(\LDAP\Connection $ldap, ?string $dn = null, ?string $password
  * @param string $dn The distinguished name of an LDAP entity.
  * @param string $attribute The attribute name.
  * @param string $value The compared value.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @return bool Returns TRUE if value matches otherwise returns
  * FALSE.
  * @throws LdapException
@@ -184,7 +184,7 @@ function ldap_count_entries(\LDAP\Connection $ldap, \LDAP\Result $result): int
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -229,7 +229,7 @@ function ldap_dn2ufn(string $dn): string
  * @param string $user dn of the user to change the password of.
  * @param string $old_password The old password of this user. May be ommited depending of server configuration.
  * @param string $new_password The new password for this user. May be omitted or empty to have a generated password.
- * @param array $controls If provided, a password policy request control is send with the request and this is
+ * @param array|null $controls If provided, a password policy request control is send with the request and this is
  * filled with an array of LDAP Controls
  * returned with the request.
  * @return bool|string Returns the generated password if new_password is empty or omitted.
@@ -274,7 +274,7 @@ function ldap_exop_whoami(\LDAP\Connection $ldap)
  *
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $request_oid The extended operation request OID. You may use one of LDAP_EXOP_START_TLS, LDAP_EXOP_MODIFY_PASSWD, LDAP_EXOP_REFRESH, LDAP_EXOP_WHO_AM_I, LDAP_EXOP_TURN, or a string with the OID of the operation you want to send.
- * @param string $request_data The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
+ * @param null|string $request_data The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
  * @param array|null $controls Array of LDAP Controls to send with the request.
  * @param null|string $response_data Will be filled with the extended operation response data if provided.
  * If not provided you may use ldap_parse_exop on the result object
@@ -730,7 +730,7 @@ function ldap_get_values(\LDAP\Connection $ldap, \LDAP\ResultEntry $entry, strin
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry An associative array listing the attirbute values to add. If an attribute was not existing yet it will be added. If an attribute is existing you can only add values to it if it supports multiple values.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -756,7 +756,7 @@ function ldap_mod_add(\LDAP\Connection $ldap, string $dn, array $entry, ?array $
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -781,7 +781,7 @@ function ldap_mod_del(\LDAP\Connection $ldap, string $dn, array $entry, ?array $
  * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param string $dn The distinguished name of an LDAP entity.
  * @param array $entry An associative array listing the attributes to replace. Sending an empty array as value will remove the attribute, while sending an attribute not existing yet on this entry will add it.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -878,7 +878,7 @@ function ldap_mod_replace(\LDAP\Connection $ldap, string $dn, array $entry, ?arr
  * value for values must be an array of strings, and
  * any value for modtype must be one of the
  * LDAP_MODIFY_BATCH_* constants listed above.
- * @param array $controls Each value specified through values is added (as
+ * @param array|null $controls Each value specified through values is added (as
  * an additional value) to the attribute named by
  * attrib.
  * @throws LdapException
@@ -979,7 +979,7 @@ function ldap_parse_result(\LDAP\Connection $ldap, \LDAP\Result $result, ?int &$
  * @param string $new_parent The new parent/superior entry.
  * @param bool $delete_old_rdn If TRUE the old RDN value(s) is removed, else the old RDN value(s)
  * is retained as non-distinguished values of the entry.
- * @param array $controls Array of LDAP Controls to send with the request.
+ * @param array|null $controls Array of LDAP Controls to send with the request.
  * @throws LdapException
  *
  */
@@ -1001,13 +1001,13 @@ function ldap_rename(\LDAP\Connection $ldap, string $dn, string $new_rdn, string
  *
  *
  * @param \LDAP\Connection $ldap
- * @param string $dn
- * @param string $password
- * @param string $mech
- * @param string $realm
- * @param string $authc_id
- * @param string $authz_id
- * @param string $props
+ * @param null|string $dn
+ * @param null|string $password
+ * @param null|string $mech
+ * @param null|string $realm
+ * @param null|string $authc_id
+ * @param null|string $authz_id
+ * @param null|string $props
  * @throws LdapException
  *
  */

--- a/generated/8.5/mbstring.php
+++ b/generated/8.5/mbstring.php
@@ -11,7 +11,7 @@ use Safe\Exceptions\MbstringException;
  * This function complements mb_ord.
  *
  * @param int $codepoint A Unicode codepoint value, e.g. 128024 for U+1F418 ELEPHANT
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return string A string containing the requested character, if it can be represented in the specified
@@ -77,7 +77,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * Sets the automatic character
  * encoding detection order to encoding.
  *
- * @param non-empty-array|non-falsy-string $encoding encoding is an array or
+ * @param non-empty-array|non-falsy-string|null $encoding encoding is an array or
  * comma separated list of character encoding. See supported encodings.
  *
  * If encoding is omitted or NULL, it returns
@@ -144,7 +144,7 @@ function mb_detect_order($encoding = null)
  * clutter the function namespace with a callback function's name
  * not used anywhere else.
  * @param string $string The string being checked.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -174,7 +174,7 @@ function mb_ereg_replace_callback(string $pattern, callable $callback, string $s
  * Multibyte characters may be used in pattern.
  * @param string $replacement The replacement text.
  * @param string $string The string being checked.
- * @param string $options
+ * @param null|string $options
  * @return null|string The resultant string on success.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -223,8 +223,8 @@ function mb_ereg_search_getregs(): array
  * mb_ereg_search_regs.
  *
  * @param string $string The search string.
- * @param string $pattern The search pattern.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $pattern The search pattern.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @throws MbstringException
  *
  */
@@ -247,8 +247,8 @@ function mb_ereg_search_init(string $string, ?string $pattern = null, ?string $o
 /**
  * Returns the matched part of a multibyte regular expression.
  *
- * @param string $pattern The search pattern.
- * @param string $options The search option. See mb_regex_set_options for explanation.
+ * @param null|string $pattern The search pattern.
+ * @param null|string $options The search option. See mb_regex_set_options for explanation.
  * @return array
  * @throws MbstringException
  *
@@ -293,7 +293,7 @@ function mb_ereg_search_setpos(int $offset): void
  * @param string $pattern The regular expression pattern.  Multibyte characters may be used. The case will be ignored.
  * @param string $replacement The replacement text.
  * @param string $string The searched string.
- * @param string $options
+ * @param null|string $options
  * @return string The resultant string.
  * If string is not valid for the current encoding, NULL
  * is returned.
@@ -357,7 +357,7 @@ function mb_get_info(string $type = "all")
  * Set/Get the HTTP output character encoding.
  * Output after this function is called will be converted from the set internal encoding to encoding.
  *
- * @param string $encoding If encoding is set,
+ * @param null|string $encoding If encoding is set,
  * mb_http_output sets the HTTP output character
  * encoding to encoding.
  *
@@ -389,7 +389,7 @@ function mb_http_output(?string $encoding = null)
 /**
  * Set/Get the internal character encoding
  *
- * @param string $encoding encoding is the character encoding name
+ * @param null|string $encoding encoding is the character encoding name
  * used for the HTTP input character encoding conversion, HTTP output
  * character encoding conversion, and the default character encoding
  * for string functions defined by the mbstring module.
@@ -423,7 +423,7 @@ function mb_internal_encoding(?string $encoding = null)
  * This function complements mb_chr.
  *
  * @param string $string A string
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return int The Unicode code point for the first character of string.
@@ -471,7 +471,7 @@ function mb_parse_str(string $string, ?array &$result): void
 /**
  * Set/Get character encoding for a multibyte regex.
  *
- * @param string $encoding The encoding
+ * @param null|string $encoding The encoding
  * parameter is the character encoding. If it is omitted or NULL, the internal character
  * encoding value will be used.
  * @return bool|string
@@ -530,7 +530,7 @@ function mb_regex_encoding(?string $encoding = null)
  * automatically (which leads to doubling CR if CRLF is used).
  * This should be a last resort, as it does not comply with
  * RFC 2822.
- * @param string $additional_params additional_params is a MTA command line
+ * @param null|string $additional_params additional_params is a MTA command line
  * parameter. It is useful when setting the correct Return-Path
  * header when using sendmail.
  *

--- a/generated/8.5/misc.php
+++ b/generated/8.5/misc.php
@@ -227,7 +227,7 @@ function sapi_windows_set_ctrl_handler(?callable $handler, bool $add = true): vo
  * They allow the modification of the terminal's output. On Windows these sequences are called Console Virtual Terminal Sequences.
  *
  * @param resource $stream The stream on which the function will operate.
- * @param bool $enable If bool, the VT100 feature will be enabled (if TRUE) or disabled (if FALSE).
+ * @param bool|null $enable If bool, the VT100 feature will be enabled (if TRUE) or disabled (if FALSE).
  * @throws MiscException
  *
  */

--- a/generated/8.5/mysql.php
+++ b/generated/8.5/mysql.php
@@ -18,7 +18,7 @@ use Safe\Exceptions\MysqlException;
  * improve performance. For related information, see
  * freeing resources
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no connection is found or
  * established, an E_WARNING level error is
@@ -102,7 +102,7 @@ function mysql_connect(?string $server = null, ?string $username = null, ?string
  * identifier.
  *
  * @param string $database_name The name of the database being created.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -184,7 +184,7 @@ function mysql_db_name($result, int $row, $field = null): string
  * @param string $query The MySQL query.
  *
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -215,7 +215,7 @@ function mysql_db_query(string $database, string $query, $link_identifier = null
  * DROP DATABASE statement instead.
  *
  * @param string $database_name The name of the database that will be deleted.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -407,7 +407,7 @@ function mysql_free_result($result): void
  * Describes the type of connection in use for the connection, including the
  * server host name.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -432,7 +432,7 @@ function mysql_get_host_info($link_identifier = null): string
 /**
  * Retrieves the MySQL protocol.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -456,7 +456,7 @@ function mysql_get_proto_info($link_identifier = null): int
 /**
  * Retrieves the MySQL server version.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -480,7 +480,7 @@ function mysql_get_server_info($link_identifier = null): string
 /**
  * Returns detailed information about the last query.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -507,7 +507,7 @@ function mysql_info($link_identifier = null): string
  * Returns a result pointer containing the databases available from the
  * current mysql daemon.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -539,7 +539,7 @@ function mysql_list_dbs($link_identifier = null)
  *
  * @param string $database_name The name of the database that's being queried.
  * @param string $table_name The name of the table that's being queried.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -568,7 +568,7 @@ function mysql_list_fields(string $database_name, string $table_name, $link_iden
 /**
  * Retrieves the current MySQL server threads.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -597,7 +597,7 @@ function mysql_list_processes($link_identifier = null)
  * [FROM db_name] [LIKE 'pattern'] statement instead.
  *
  * @param string $database The name of the database
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -678,7 +678,7 @@ function mysql_num_rows($result): int
  *
  * The query string should not end with a semicolon.
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -734,7 +734,7 @@ function mysql_query(string $query, $link_identifier = null)
  * safe before sending a query to MySQL.
  *
  * @param string $unescaped_string The string that is to be escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -798,7 +798,7 @@ function mysql_result($result, int $row, $field = 0): string
  * mysql_query will be made on the active database.
  *
  * @param string $database_name The name of the database that is to be selected.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -821,7 +821,7 @@ function mysql_select_db(string $database_name, $link_identifier = null): void
  * Sets the default character set for the current connection.
  *
  * @param string $charset A valid character set name.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -874,7 +874,7 @@ function mysql_tablename($result, int $i): string
  * with mysql_ping is executed, the thread ID will
  * change. This means only retrieve the thread ID when needed.
  *
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called
@@ -912,7 +912,7 @@ function mysql_thread_id($link_identifier = null): int
  * @param string $query The SQL query to execute.
  *
  * Data inside the query should be properly escaped.
- * @param resource $link_identifier The MySQL connection. If the
+ * @param null|resource $link_identifier The MySQL connection. If the
  * link identifier is not specified, the last link opened by
  * mysql_connect is assumed. If no such link is found, it
  * will try to create one as if mysql_connect had been called

--- a/generated/8.5/network.php
+++ b/generated/8.5/network.php
@@ -258,7 +258,7 @@ function dns_get_record(string $hostname, int $type = DNS_ANY, ?array &$authorit
  * connect() call. This is most likely due to a
  * problem initializing the socket.
  * @param null|string $error_message The error message as a string.
- * @param float $timeout The connection timeout, in seconds. When NULL, the
+ * @param float|null $timeout The connection timeout, in seconds. When NULL, the
  * default_socket_timeout php.ini setting is used.
  *
  * If you need to set a timeout for reading/writing data over the
@@ -553,7 +553,7 @@ function net_get_interfaces(): array
  * @param int $port
  * @param int|null $error_code
  * @param null|string $error_message
- * @param float $timeout
+ * @param float|null $timeout
  * @return resource pfsockopen returns a file pointer which may be used
  * together with the other file functions (such as
  * fgets, fgetss,

--- a/generated/8.5/oci8.php
+++ b/generated/8.5/oci8.php
@@ -386,7 +386,7 @@ function oci_commit($connection): void
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from
@@ -774,7 +774,7 @@ function oci_free_statement($statement): void
  * @param resource $connection An Oracle connection identifier, returned by
  * oci_connect or oci_pconnect.
  * @param string $type_name Should be a valid named type (uppercase).
- * @param string $schema Should point to the scheme, where the named type was created. The name
+ * @param null|string $schema Should point to the scheme, where the named type was created. The name
  * of the current user is used when NULL is passed.
  * @return \OCI-Collection Returns a new OCICollection object.
  * @throws Oci8Exception
@@ -806,7 +806,7 @@ function oci_new_collection($connection, string $type_name, ?string $schema = nu
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from
@@ -1009,7 +1009,7 @@ function oci_parse($connection, string $sql)
  *
  * @param string $username The Oracle user name.
  * @param string $password The password for username.
- * @param string $connection_string Contains
+ * @param null|string $connection_string Contains
  * the Oracle instance to connect to. It can be
  * an Easy Connect
  * string, or a Connect Name from

--- a/generated/8.5/openssl.php
+++ b/generated/8.5/openssl.php
@@ -301,7 +301,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  * generated based on the supplied options and
  * assigned to supplied variable. The corresponding public portion of the
  * key will be used to sign the CSR.
- * @param array $options By default, the information in your system openssl.conf
+ * @param array|null $options By default, the information in your system openssl.conf
  * is used to initialize the request; you can specify a configuration file
  * section by setting the config_section_section key in
  * options.  You can also specify an alternative
@@ -392,7 +392,7 @@ function openssl_csr_get_subject($csr, bool $short_names = true): array
  *
  *
  *
- * @param array $extra_attributes extra_attributes is used to specify additional
+ * @param array|null $extra_attributes extra_attributes is used to specify additional
  * attributes for the CSR. It is an associative arrays
  * where the keys are converted to OIDs and applied as
  * CSR attributes.
@@ -433,7 +433,7 @@ function openssl_csr_new(array $distinguished_names, ?\OpenSSLAsymmetricKey &$pr
  * ca_certificate.
  * @param int $days days specifies the length of time for which the
  * generated certificate will be valid, in days.
- * @param array $options You can finetune the CSR signing by options.
+ * @param array|null $options You can finetune the CSR signing by options.
  * See openssl_csr_new for more information about
  * options.
  * @param int $serial An optional the serial number of issued certificate. If not specified
@@ -482,7 +482,7 @@ function openssl_csr_sign($csr, $ca_certificate, $private_key, int $days, ?array
  * @param string $iv A non-NULL Initialization Vector. If the IV is shorter than expected, it is padded with
  * NUL characters and warning is emitted; if the passphrase is longer
  * than expected, it is truncated and warning is emitted.
- * @param string $tag The authentication tag in AEAD cipher mode. If it is incorrect, the authentication fails and the function returns FALSE.
+ * @param null|string $tag The authentication tag in AEAD cipher mode. If it is incorrect, the authentication fails and the function returns FALSE.
  * @param string $aad Additional authenticated data.
  * @return string The decrypted string on success.
  * @throws OpensslException
@@ -633,7 +633,7 @@ function openssl_get_curve_names(): array
  * method.
  *
  *
- * @param string $iv The initialization vector used for decryption of data. It is required
+ * @param null|string $iv The initialization vector used for decryption of data. It is required
  * if the cipher method requires IV. This can be found out by calling
  * openssl_cipher_iv_length with cipher_algo.
  * @throws OpensslException
@@ -886,7 +886,7 @@ function openssl_pkcs7_read(string $data, ?array &$certificates): void
  * openssl_pkcs7_encrypt for more information about
  * the format of this parameter).
  * @param int $flags flags can be used to alter the output - see PKCS7 constants.
- * @param string $untrusted_certificates_filename untrusted_certificates_filename specifies the name of a file containing
+ * @param null|string $untrusted_certificates_filename untrusted_certificates_filename specifies the name of a file containing
  * a bunch of extra certificates to include in the signature which can for
  * example be used to help the recipient to verify the certificate that you used.
  * @throws OpensslException
@@ -939,7 +939,7 @@ function openssl_pkey_derive($public_key, $private_key, int $key_length = 0): st
  * @param string $output_filename Path to the output file.
  * @param null|string $passphrase The key can be optionally protected by a
  * passphrase.
- * @param array $options options can be used to fine-tune the export
+ * @param array|null $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file. See openssl_csr_new for more
  * information about options.
@@ -970,7 +970,7 @@ function openssl_pkey_export_to_file($key, string $output_filename, ?string $pas
  * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $key
  * @param null|string $output
  * @param null|string $passphrase The key is optionally protected by passphrase.
- * @param array $options options can be used to fine-tune the export
+ * @param array|null $options options can be used to fine-tune the export
  * process by specifying and/or overriding options for the openssl
  * configuration file.  See openssl_csr_new for more
  * information about options.
@@ -1096,7 +1096,7 @@ function openssl_pkey_get_public($public_key): \OpenSSLAsymmetricKey
  * key.
  * How to obtain the public component of the key is shown in an example below.
  *
- * @param array $options It is possible to fine-tune the key generation (e.g. specifying the number of
+ * @param array|null $options It is possible to fine-tune the key generation (e.g. specifying the number of
  * bits or parameters) using the options parameter.
  * These options can either be algorithm-specific parameters used for key generation,
  * or generic options used also in CSRgeneration if not specified.
@@ -1811,7 +1811,7 @@ function openssl_verify(string $data, string $signature, $public_key, $algorithm
  * @param array $ca_info ca_info should be an array of trusted CA files/dirs
  * as described in Certificate
  * Verification.
- * @param string $untrusted_certificates_file If specified, this should be the name of a PEM encoded file holding
+ * @param null|string $untrusted_certificates_file If specified, this should be the name of a PEM encoded file holding
  * certificates that can be used to help verify the certificate, although
  * no trust is placed in the certificates that come from that file.
  * @return bool|int Returns TRUE if the certificate can be used for the intended purpose,

--- a/generated/8.5/pcntl.php
+++ b/generated/8.5/pcntl.php
@@ -33,7 +33,7 @@ function pcntl_getcpuaffinity(?int $pid = null)
  * system types and kernel versions, please see your system's getpriority(2)
  * man page for specific details.
  *
- * @param int $process_id If NULL, the process id of the current process is used.
+ * @param int|null $process_id If NULL, the process id of the current process is used.
  * @param int $mode One of PRIO_PGRP, PRIO_USER,
  * PRIO_PROCESS,
  * PRIO_DARWIN_BG or PRIO_DARWIN_THREAD.
@@ -93,7 +93,7 @@ function pcntl_setcpuaffinity(?int $pid = null, ?array $hmask = null): void
  * favorable scheduling.  Because priority levels can differ between
  * system types and kernel versions, please see your system's setpriority(2)
  * man page for specific details.
- * @param int $process_id If NULL, the process id of the current process is used.
+ * @param int|null $process_id If NULL, the process id of the current process is used.
  * @param int $mode One of PRIO_PGRP, PRIO_USER,
  * PRIO_PROCESS,
  * PRIO_DARWIN_BG or PRIO_DARWIN_THREAD.

--- a/generated/8.5/pgsql.php
+++ b/generated/8.5/pgsql.php
@@ -765,7 +765,7 @@ function pg_lo_unlink(\PgSql\Connection $connection, int $oid): void
  * @param string $data The data to be written to the large object.  If length is
  * an int and is less than the length of data, only
  * length bytes will be written.
- * @param int $length An optional maximum number of bytes to write.  Must be greater than zero
+ * @param int|null $length An optional maximum number of bytes to write.  Must be greater than zero
  * and no greater than the length of data.  Defaults to
  * the length of data.
  * @return int The number of bytes written to the large object.

--- a/generated/8.5/readline.php
+++ b/generated/8.5/readline.php
@@ -26,7 +26,7 @@ function readline_completion_function(callable $callback): void
 /**
  * This function reads a command history from a file.
  *
- * @param string $filename Path to the filename containing the command history.
+ * @param null|string $filename Path to the filename containing the command history.
  * @throws ReadlineException
  *
  */
@@ -47,7 +47,7 @@ function readline_read_history(?string $filename = null): void
 /**
  * This function writes the command history to a file.
  *
- * @param string $filename Path to the saved file.
+ * @param null|string $filename Path to the saved file.
  * @throws ReadlineException
  *
  */

--- a/generated/8.5/sem.php
+++ b/generated/8.5/sem.php
@@ -434,7 +434,7 @@ function sem_remove(\SysvSemaphore $semaphore): void
  * permissions will be ignored.
  *
  * @param int $key A numeric shared memory segment ID
- * @param int $size The memory size. If not provided, default to the
+ * @param int|null $size The memory size. If not provided, default to the
  * sysvshm.init_mem in the php.ini, otherwise 10000
  * bytes.
  * @param int $permissions The optional permission bits. Default to 0666.

--- a/generated/8.5/session.php
+++ b/generated/8.5/session.php
@@ -135,7 +135,7 @@ function session_encode(): string
  * adding to URLs. See also Session
  * handling.
  *
- * @param string $id If id is specified and not NULL, it will replace the current
+ * @param null|string $id If id is specified and not NULL, it will replace the current
  * session id. session_id needs to be called before
  * session_start for that purpose. Depending on the
  * session handler, not all characters are allowed within the session id.
@@ -168,7 +168,7 @@ function session_id(?string $id = null): string
  * session module, which is also known as
  * session.save_handler.
  *
- * @param string $module If module is specified and not NULL, that module will be
+ * @param null|string $module If module is specified and not NULL, that module will be
  * used instead.
  * Passing "user" to this parameter is forbidden. Instead
  * session_set_save_handler has to be called to set a user
@@ -212,7 +212,7 @@ function session_module_name(?string $module = null): string
  * call session_name for every request (and before
  * session_start is called).
  *
- * @param string $name The session name references the name of the session, which is
+ * @param null|string $name The session name references the name of the session, which is
  * used in cookies and URLs (e.g. PHPSESSID). It
  * should contain only alphanumeric characters; it should be short and
  * descriptive (i.e. for users with enabled cookie warnings).
@@ -296,7 +296,7 @@ function session_reset(): void
  * session_save_path returns the path of the current
  * directory used to save session data.
  *
- * @param string $path Session data path. If specified and not NULL, the path to which data is saved will
+ * @param null|string $path Session data path. If specified and not NULL, the path to which data is saved will
  * be changed. session_save_path needs to be called
  * before session_start for that purpose.
  *

--- a/generated/8.5/sockets.php
+++ b/generated/8.5/sockets.php
@@ -178,7 +178,7 @@ function socket_bind(\Socket $socket, string $address, int $port = 0): void
  * socket is AF_INET6
  * or the pathname of a Unix domain socket, if the socket family is
  * AF_UNIX.
- * @param int $port The port parameter is only used and is mandatory
+ * @param int|null $port The port parameter is only used and is mandatory
  * when connecting to an AF_INET or an
  * AF_INET6 socket, and designates
  * the port on the remote host to which a connection should be made.
@@ -663,7 +663,7 @@ function socket_sendmsg(\Socket $socket, array $message, int $flags = 0): int
  *
  *
  * @param string $address IP address of the remote host.
- * @param int $port port is the remote port number at which the data
+ * @param int|null $port port is the remote port number at which the data
  * will be sent.
  * @return int socket_sendto returns the number of bytes sent to the
  * remote host.

--- a/generated/8.5/spl.php
+++ b/generated/8.5/spl.php
@@ -87,7 +87,7 @@ function class_uses($object_or_class, bool $autoload = true): array
  * runs through each of them in the order they are defined. By contrast,
  * __autoload may only be defined once.
  *
- * @param callable(string):void $callback The autoload function being registered.
+ * @param callable(string):void|null $callback The autoload function being registered.
  * If NULL, then the default implementation of
  * spl_autoload will be registered.
  *

--- a/generated/8.5/ssh2.php
+++ b/generated/8.5/ssh2.php
@@ -717,7 +717,7 @@ function ssh2_sftp($session)
  * ssh2_connect.
  * @param string $termtype termtype should correspond to one of the
  * entries in the target system's /etc/termcap file.
- * @param array $env env may be passed as an associative array of
+ * @param array|null $env env may be passed as an associative array of
  * name/value pairs to set in the target environment.
  * @param int $width Width of the virtual terminal.
  * @param int $height Height of the virtual terminal.

--- a/generated/8.5/stream.php
+++ b/generated/8.5/stream.php
@@ -59,7 +59,7 @@ function stream_context_set_params($context, array $params): void
  *
  * @param resource $from The source stream
  * @param resource $to The destination stream
- * @param int $length Maximum bytes to copy. By default all bytes left are copied.
+ * @param int|null $length Maximum bytes to copy. By default all bytes left are copied.
  * @param int $offset The offset where to start to copy data
  * @return int Returns the total count of bytes copied.
  * @throws StreamException
@@ -236,7 +236,7 @@ function stream_filter_remove($stream_filter): void
  * offset.
  *
  * @param resource $stream A stream resource (e.g. returned from fopen)
- * @param int $length The maximum bytes to read. Defaults to NULL (read all the remaining
+ * @param int|null $length The maximum bytes to read. Defaults to NULL (read all the remaining
  * buffer).
  * @param int $offset Seek to the specified offset before reading. If this number is negative,
  * no seeking will occur and reading will start from the current position.
@@ -390,7 +390,7 @@ function stream_set_timeout($stream, int $seconds, int $microseconds = 0): void
  * stream_socket_server.
  *
  * @param resource $socket The server socket to accept a connection from.
- * @param float $timeout Override the default socket accept timeout. Time should be given in
+ * @param float|null $timeout Override the default socket accept timeout. Time should be given in
  * seconds. By default, default_socket_timeout
  * is used.
  * @param null|string $peer_name Will be set to the name (address) of the client which connected, if
@@ -433,7 +433,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * @param string $address Address to the socket to connect to.
  * @param int|null $error_code Will be set to the system level error number if connection fails.
  * @param null|string $error_message Will be set to the system level error message if the connection fails.
- * @param float $timeout Number of seconds until the connect() system call
+ * @param float|null $timeout Number of seconds until the connect() system call
  * should timeout. By default, default_socket_timeout
  * is used.
  *

--- a/generated/8.5/uodbc.php
+++ b/generated/8.5/uodbc.php
@@ -12,7 +12,7 @@ use Safe\Exceptions\UodbcException;
  *
  * @param \Odbc\Connection $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param bool $enable If enable is TRUE, auto-commit is enabled, if
+ * @param bool|null $enable If enable is TRUE, auto-commit is enabled, if
  * it is FALSE auto-commit is disabled.
  * If NULL is passed, this function returns the auto-commit status for
  * odbc.
@@ -64,11 +64,11 @@ function odbc_commit(\Odbc\Connection $odbc): void
  *
  * @param string $dsn The database source name for the connection. Alternatively, a
  * DSN-less connection string can be used.
- * @param string $user The username.
+ * @param null|string $user The username.
  * This parameter is ignored if dsn contains uid.
  * To connect without specifying a user,
  * use NULL.
- * @param string $password The password.
+ * @param null|string $password The password.
  * This parameter is ignored if dsn contains pwd.
  * To connect without specifying a password,
  * use NULL.
@@ -217,7 +217,7 @@ function odbc_execute(\Odbc\Result $statement, array $params = []): void
  * that can be of any type since it will be converted to type
  * array. The array will contain the column values starting at array
  * index 0.
- * @param int $row The row number.
+ * @param int|null $row The row number.
  * @return int Returns the number of columns in the result;
  * FALSE on error.
  * @throws UodbcException
@@ -376,8 +376,8 @@ function odbc_num_fields(\Odbc\Result $statement): int
  * connection.
  *
  * @param string $dsn
- * @param string $user
- * @param string $password
+ * @param null|string $user
+ * @param null|string $password
  * @param int $cursor_option
  * @return \Odbc\Connection Returns an ODBC connection.
  * @throws UodbcException
@@ -435,12 +435,12 @@ function odbc_prepare(\Odbc\Connection $odbc, string $query): \Odbc\Result
  *
  * @param  $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $procedure The name.
+ * @param null|string $procedure The name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
@@ -629,16 +629,16 @@ function odbc_setoption($odbc, int $which, int $option, int $value): void
  *
  * @param \Odbc\Connection $odbc The ODBC connection object,
  * see odbc_connect for details.
- * @param string $catalog The catalog ('qualifier' in ODBC 2 parlance).
- * @param string $schema The schema ('owner' in ODBC 2 parlance).
+ * @param null|string $catalog The catalog ('qualifier' in ODBC 2 parlance).
+ * @param null|string $schema The schema ('owner' in ODBC 2 parlance).
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $table The name.
+ * @param null|string $table The name.
  * This parameter accepts the following search patterns:
  * % to match zero or more characters,
  * and _ to match a single character.
- * @param string $types If table_type is not an empty string, it
+ * @param null|string $types If table_type is not an empty string, it
  * must contain a list of comma-separated values for the types of
  * interest; each value may be enclosed in single quotes (') or
  * unquoted. For example, 'TABLE','VIEW' or TABLE, VIEW.  If the

--- a/generated/8.5/yaml.php
+++ b/generated/8.5/yaml.php
@@ -12,7 +12,7 @@ use Safe\Exceptions\YamlException;
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * details.
@@ -50,7 +50,7 @@ function yaml_parse_file(string $filename, int $pos = 0, ?int &$ndocs = null, ?a
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more details.
  * @return mixed Returns the value encoded in url in appropriate
@@ -83,7 +83,7 @@ function yaml_parse_url(string $url, int $pos = 0, ?int &$ndocs = null, ?array $
  * documents, 0 for first document, ...).
  * @param int|null $ndocs If ndocs is provided, then it is filled with the
  * number of documents found in stream.
- * @param array $callbacks Content handlers for YAML nodes. Associative array of YAML
+ * @param array|null $callbacks Content handlers for YAML nodes. Associative array of YAML
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * details.

--- a/generated/8.5/zlib.php
+++ b/generated/8.5/zlib.php
@@ -293,7 +293,7 @@ function gzfile(string $filename, int $use_include_path = 0): array
  *
  * @param resource $stream The gz-file pointer. It must be valid, and must point to a file
  * successfully opened by gzopen.
- * @param int $length The length of data to get.
+ * @param int|null $length The length of data to get.
  * @return string The uncompressed string.
  * @throws ZlibException
  *
@@ -469,7 +469,7 @@ function gzuncompress(string $data, int $max_length = 0): string
  * @param resource $stream The gz-file pointer. It must be valid, and must point to a file
  * successfully opened by gzopen.
  * @param string $data The string to write.
- * @param int $length The number of uncompressed bytes to write. If supplied, writing will
+ * @param int|null $length The number of uncompressed bytes to write. If supplied, writing will
  * stop after length (uncompressed) bytes have been
  * written or the end of data is reached,
  * whichever comes first.

--- a/generator/src/Generator/WritePhpFunction.php
+++ b/generator/src/Generator/WritePhpFunction.php
@@ -145,10 +145,6 @@ class WritePhpFunction
 
             if ($paramAsString !== '') {
                 $paramAsString .= ' ';
-                if ($param->isNullable() && $paramAsString[0] !== "?") {
-                    $paramAsString = "?" . $paramAsString;
-                }
-
                 $typeDetected = true;
             }
 

--- a/generator/src/PhpStanFunctions/PhpStanType.php
+++ b/generator/src/PhpStanFunctions/PhpStanType.php
@@ -210,11 +210,6 @@ class PhpStanType
         return ($nullable !== false ? '?' : '').$finalType;
     }
 
-    public function isNullable(): bool
-    {
-        return $this->nullable;
-    }
-
     /**
      * @return array<string>
      */

--- a/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
@@ -57,22 +57,18 @@ class PhpStanTypeTest extends TestCase
     public function testNullable(): void
     {
         $param = new PhpStanType('array|null');
-        $this->assertEquals(true, $param->isNullable());
         $this->assertEquals('array|null', $param->getDocBlockType());
         $this->assertEquals('?array', $param->getSignatureType());
 
         $param = new PhpStanType('?int|?string');
-        $this->assertEquals(true, $param->isNullable());
         $this->assertEquals('int|null|string', $param->getDocBlockType());
         $this->assertEquals('', $param->getSignatureType());
 
         $param = new PhpStanType('?string');
-        $this->assertEquals(true, $param->isNullable());
         $this->assertEquals('null|string', $param->getDocBlockType());
         $this->assertEquals('?string', $param->getSignatureType());
 
         $param = new PhpStanType('?HashContext');
-        $this->assertEquals(true, $param->isNullable());
         $this->assertEquals('\HashContext|null', $param->getDocBlockType());
         $this->assertEquals('?\HashContext', $param->getSignatureType());
     }
@@ -80,7 +76,6 @@ class PhpStanTypeTest extends TestCase
     public function testParenthesisOutsideOfCallable(): void
     {
         $param = new PhpStanType('(?int)|(?string)');
-        $this->assertEquals(true, $param->isNullable());
         $this->assertEquals('int|null|string', $param->getDocBlockType());
         $this->assertEquals('', $param->getSignatureType());
     }


### PR DESCRIPTION

Before:
- When scanning for unsafe functions, check phpdoc type and phpstan type
- When writing wrappers, _occasionally_ check if default value is `null` and infer nullability at the last minute

After:
- When scanning for unsafe functions, check phpdoc type, phpstan type, and default value
