### PR TITLE
[generator] remove some redundant edge-cases

### DIFF
--- a/generator/src/Generator/WritePhpFunction.php
+++ b/generator/src/Generator/WritePhpFunction.php
@@ -135,13 +135,8 @@ class WritePhpFunction
         $optDetected = false;
 
         foreach ($params as $param) {
-            $paramAsString = '';
             $typeDetected = false;
-
-            // parameters can not have type void
-            if ($param->getSignatureType() !== 'void') {
-                $paramAsString = $param->getSignatureType();
-            }
+            $paramAsString = $param->getSignatureType();
 
             if ($paramAsString !== '') {
                 $paramAsString .= ' ';
@@ -157,7 +152,6 @@ class WritePhpFunction
                 }
                 $paramAsString .= '$'.$paramName;
             }
-
 
             if ($param->hasDefaultValue() || $param->isOptionalWithNoDefault()) {
                 $optDetected = true;

--- a/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
@@ -105,11 +105,7 @@ class PhpStanTypeTest extends TestCase
     {
         $param = new PhpStanType('');
         $this->assertEquals('', $param->getDocBlockType());
-        if (PHP_VERSION_ID >= 80200) {
-            $this->assertEquals('void', $param->getSignatureType());
-        } else {
-            $this->assertEquals('', $param->getSignatureType());
-        }
+        $this->assertEquals('', $param->getSignatureType());
 
         $param = new PhpStanType('void');
         $this->assertEquals('void', $param->getDocBlockType());


### PR DESCRIPTION

Special-cases to handle 7.X-era bugs are no longer needed

Evidence that these cases are redundant: removing them doesn't affect the generated code
