### PR TITLE
Hide a couple of parameters from stack traces

### DIFF
--- a/generator/src/Commands/GenerateCommand.php
+++ b/generator/src/Commands/GenerateCommand.php
@@ -25,9 +25,12 @@ class GenerateCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-
+    protected function execute(
+        // These aren't actually sensitive, they just fill the
+        // stack traces with tons of useless information.
+        #[\SensitiveParameter] InputInterface $input,
+        #[\SensitiveParameter] OutputInterface $output
+    ): int {
         $this->rmGenerated();
 
         // Let's build the DTD necessary to load the XML files.

--- a/generator/src/Generator/FileCreator.php
+++ b/generator/src/Generator/FileCreator.php
@@ -19,8 +19,13 @@ class FileCreator
      * @param Method[] $functions
      * @param Method[] $missingFunctions
      */
-    public function generatePhpFile(array $functions, array $missingFunctions, string $path): void
-    {
+    public function generatePhpFile(
+        // These aren't actually sensitive, they just fill the
+        // stack traces with tons of useless information.
+        #[\SensitiveParameter] array $functions,
+        #[\SensitiveParameter] array $missingFunctions,
+        string $path
+    ): void {
         $path = rtrim($path, '/').'/';
         $phpFunctionsByModule = [];
         foreach ($functions as $function) {


### PR DESCRIPTION

When something goes wrong, the stack trace contains ~10,000 lines of spam, often repeated several times over, which makes it hard to find the actual error
