### PR TITLE
[generator] defer nullable/falsable handling

### DIFF
--- a/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
@@ -84,7 +84,7 @@ class PhpStanTypeTest extends TestCase
     {
         $param = new PhpStanType('string|false');
         $this->assertEquals('false|string', $param->getDocBlockType());
-        $this->assertEquals('string', $param->getSignatureType());
+        $this->assertEquals('', $param->getSignatureType());
     }
 
     public function testResource(): void


### PR DESCRIPTION

Rather than "always strip false/null from return types, and then add them back when the function is non-nullsy / non-falsy", we can reduce complexity by "leave return types alone, strip them only when needed"

This results in no chanes to generated files, but makes future development simpler
