### PR TITLE
Remove another redundant "bugfix" (and in doing so, fix `pg_copy_from`)

### DIFF
--- a/generated/8.1/pgsql.php
+++ b/generated/8.1/pgsql.php
@@ -149,7 +149,7 @@ function pg_convert(\PgSql\Connection $connection, string $table_name, array $va
  * @throws PgsqlException
  *
  */
-function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $rows, string $separator = "\t", string $null_as = "\\N"): void
+function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $rows, string $separator = "\t", string $null_as = "\\\\N"): void
 {
     error_clear_last();
     $safeResult = \pg_copy_from($connection, $table_name, $rows, $separator, $null_as);
@@ -174,7 +174,7 @@ function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $
  * @throws PgsqlException
  *
  */
-function pg_copy_to(\PgSql\Connection $connection, string $table_name, string $separator = "\t", string $null_as = "\\N"): array
+function pg_copy_to(\PgSql\Connection $connection, string $table_name, string $separator = "\t", string $null_as = "\\\\N"): array
 {
     error_clear_last();
     $safeResult = \pg_copy_to($connection, $table_name, $separator, $null_as);

--- a/generated/8.2/pgsql.php
+++ b/generated/8.2/pgsql.php
@@ -149,7 +149,7 @@ function pg_convert(\PgSql\Connection $connection, string $table_name, array $va
  * @throws PgsqlException
  *
  */
-function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $rows, string $separator = "\t", string $null_as = "\\N"): void
+function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $rows, string $separator = "\t", string $null_as = "\\\\N"): void
 {
     error_clear_last();
     $safeResult = \pg_copy_from($connection, $table_name, $rows, $separator, $null_as);
@@ -174,7 +174,7 @@ function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $
  * @throws PgsqlException
  *
  */
-function pg_copy_to(\PgSql\Connection $connection, string $table_name, string $separator = "\t", string $null_as = "\\N"): array
+function pg_copy_to(\PgSql\Connection $connection, string $table_name, string $separator = "\t", string $null_as = "\\\\N"): array
 {
     error_clear_last();
     $safeResult = \pg_copy_to($connection, $table_name, $separator, $null_as);

--- a/generated/8.3/pgsql.php
+++ b/generated/8.3/pgsql.php
@@ -149,7 +149,7 @@ function pg_convert(\PgSql\Connection $connection, string $table_name, array $va
  * @throws PgsqlException
  *
  */
-function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $rows, string $separator = "\t", string $null_as = "\\N"): void
+function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $rows, string $separator = "\t", string $null_as = "\\\\N"): void
 {
     error_clear_last();
     $safeResult = \pg_copy_from($connection, $table_name, $rows, $separator, $null_as);
@@ -174,7 +174,7 @@ function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $
  * @throws PgsqlException
  *
  */
-function pg_copy_to(\PgSql\Connection $connection, string $table_name, string $separator = "\t", string $null_as = "\\N"): array
+function pg_copy_to(\PgSql\Connection $connection, string $table_name, string $separator = "\t", string $null_as = "\\\\N"): array
 {
     error_clear_last();
     $safeResult = \pg_copy_to($connection, $table_name, $separator, $null_as);

--- a/generated/8.4/pgsql.php
+++ b/generated/8.4/pgsql.php
@@ -149,7 +149,7 @@ function pg_convert(\PgSql\Connection $connection, string $table_name, array $va
  * @throws PgsqlException
  *
  */
-function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $rows, string $separator = "\t", string $null_as = "\\N"): void
+function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $rows, string $separator = "\t", string $null_as = "\\\\N"): void
 {
     error_clear_last();
     $safeResult = \pg_copy_from($connection, $table_name, $rows, $separator, $null_as);
@@ -174,7 +174,7 @@ function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $
  * @throws PgsqlException
  *
  */
-function pg_copy_to(\PgSql\Connection $connection, string $table_name, string $separator = "\t", string $null_as = "\\N"): array
+function pg_copy_to(\PgSql\Connection $connection, string $table_name, string $separator = "\t", string $null_as = "\\\\N"): array
 {
     error_clear_last();
     $safeResult = \pg_copy_to($connection, $table_name, $separator, $null_as);

--- a/generated/8.5/pgsql.php
+++ b/generated/8.5/pgsql.php
@@ -149,7 +149,7 @@ function pg_convert(\PgSql\Connection $connection, string $table_name, array $va
  * @throws PgsqlException
  *
  */
-function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $rows, string $separator = "\t", string $null_as = "\\N"): void
+function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $rows, string $separator = "\t", string $null_as = "\\\\N"): void
 {
     error_clear_last();
     $safeResult = \pg_copy_from($connection, $table_name, $rows, $separator, $null_as);
@@ -174,7 +174,7 @@ function pg_copy_from(\PgSql\Connection $connection, string $table_name, array $
  * @throws PgsqlException
  *
  */
-function pg_copy_to(\PgSql\Connection $connection, string $table_name, string $separator = "\t", string $null_as = "\\N"): array
+function pg_copy_to(\PgSql\Connection $connection, string $table_name, string $separator = "\t", string $null_as = "\\\\N"): array
 {
     error_clear_last();
     $safeResult = \pg_copy_to($connection, $table_name, $separator, $null_as);

--- a/generator/src/Generator/WritePhpFunction.php
+++ b/generator/src/Generator/WritePhpFunction.php
@@ -173,7 +173,7 @@ class WritePhpFunction
             $paramsAsString[] = $paramAsString;
         }
 
-        return str_replace('\\\\', '\\', implode(', ', $paramsAsString));
+        return implode(', ', $paramsAsString);
     }
 
     private function printFunctionCall(Method $function): string


### PR DESCRIPTION
There used to be a case where class names were being prefixed with double-backslash instead of single-backslash, and a quick and dirty fix was put in place to remove the doubled-slashes. Now, we generate class names correctly to begin with.