### PR TITLE
Be consistent in using more-specific types in docblocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,8 @@ Intentional changes:
 * If the function returned `true` on success and `false` on error, and we have
   removed the `false`, then the signature gets changed from `bool` to `void` to
   stop people from accidentally writing `if(function()) {...}`
+* PHPDoc comments use the more specific type hints from PHPStan, eg `array<string>` rather than
+  `array`, or `0|1` rather than `int`
 
 Necessary changes / side effects:
 * Functions which have optional parameters without defaults (eg `cubrid_bind()` has

--- a/generated/8.1/dir.php
+++ b/generated/8.1/dir.php
@@ -131,7 +131,7 @@ function opendir(string $directory, $context = null)
  * directory.
  *
  * @param string $directory The directory that will be scanned.
- * @param int $sorting_order By default, the sorted order is alphabetical in ascending order.  If
+ * @param SCANDIR_SORT_ASCENDING|SCANDIR_SORT_DESCENDING|SCANDIR_SORT_NONE $sorting_order By default, the sorted order is alphabetical in ascending order.  If
  * the optional sorting_order is set to
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
@@ -139,7 +139,7 @@ function opendir(string $directory, $context = null)
  * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
- * @return array Returns an array of filenames on success. If directory is not a directory, then
+ * @return list Returns an array of filenames on success. If directory is not a directory, then
  * boolean FALSE is returned, and an error of level
  * E_WARNING is generated.
  * @throws DirException

--- a/generated/8.1/errorfunc.php
+++ b/generated/8.1/errorfunc.php
@@ -8,7 +8,7 @@ use Safe\Exceptions\ErrorfuncException;
  * Sends an error message to the web server's error log or to a file.
  *
  * @param string $message The error message that should be logged.
- * @param int $message_type Says where the error should go. The possible message types are as
+ * @param 0|1|2|3|4 $message_type Says where the error should go. The possible message types are as
  * follows:
  *
  *

--- a/generated/8.1/filesystem.php
+++ b/generated/8.1/filesystem.php
@@ -253,7 +253,7 @@ function fflush($stream): void
  * Seeking (offset) is not supported with remote files.
  * Attempting to seek on non-local files may work with small offsets, but this
  * is unpredictable because it works on the buffered stream.
- * @param int $length Maximum length of data read. The default is to read until end
+ * @param 0|positive-int $length Maximum length of data read. The default is to read until end
  * of file is reached. Note that this parameter is applied to the
  * stream processed by the filters.
  * @return string The function returns the read data.
@@ -349,7 +349,7 @@ function file_get_contents(string $filename, bool $use_include_path = false, $co
  *
  * @param null|resource $context A valid context resource created with
  * stream_context_create.
- * @return int This function returns the number of bytes that were written to the file.
+ * @return 0|positive-int This function returns the number of bytes that were written to the file.
  * @throws FilesystemException
  *
  */
@@ -372,7 +372,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  * Reads an entire file into an array.
  *
  * @param string $filename Path to the file.
- * @param int $flags The optional parameter flags can be one, or
+ * @param int-mask $flags The optional parameter flags can be one, or
  * more, of the following constants:
  *
  *
@@ -407,7 +407,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  *
  *
  * @param resource $context
- * @return array Returns the file in an array. Each element of the array corresponds to a
+ * @return list Returns the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns FALSE.
  * @throws FilesystemException
@@ -567,7 +567,7 @@ function fileperms(string $filename): int
  * Gets the size for the given file.
  *
  * @param string $filename Path to the file.
- * @return int Returns the size of the file in bytes, or FALSE (and generates an error
+ * @return 0|positive-int Returns the size of the file in bytes, or FALSE (and generates an error
  * of level E_WARNING) in case of an error.
  * @throws FilesystemException
  *
@@ -622,7 +622,7 @@ function filetype(string $filename): string
  *
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
- * @param int $operation operation is one of the following:
+ * @param int-mask $operation operation is one of the following:
  *
  *
  *
@@ -644,7 +644,7 @@ function filetype(string $filename): string
  * It is also possible to add LOCK_NB as a bitmask to one
  * of the above operations, if flock should not
  * block during the locking attempt.
- * @param int|null $would_block The optional third argument is set to 1 if the lock would block
+ * @param 0|1|null $would_block The optional third argument is set to 1 if the lock would block
  * (EWOULDBLOCK errno condition).
  * @throws FilesystemException
  *
@@ -907,7 +907,7 @@ function fopen(string $filename, string $mode, bool $use_include_path = false, $
  *
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
- * @param int $length Up to length number of bytes read.
+ * @param positive-int $length Up to length number of bytes read.
  * @return string Returns the read string.
  * @throws FilesystemException
  *
@@ -1001,7 +1001,7 @@ function ftell($stream): int
  * @param resource $stream The file pointer.
  *
  * The stream must be open for writing.
- * @param int $size The size to truncate to.
+ * @param 0|positive-int $size The size to truncate to.
  *
  * If size is larger than the file then the file
  * is extended with null bytes.
@@ -1027,11 +1027,11 @@ function ftruncate($stream, int $size): void
  * @param resource $handle A file system pointer resource
  * that is typically created using fopen.
  * @param string $string The string that is to be written.
- * @param int $length If the length argument is given, writing will
+ * @param 0|positive-int $length If the length argument is given, writing will
  * stop after length bytes have been written or
  * the end of string is reached, whichever comes
  * first.
- * @return int
+ * @return 0|positive-int
  * @throws FilesystemException
  *
  */
@@ -1135,7 +1135,7 @@ function fwrite($handle, string $string, ?int $length = null): int
  * systems, like Solaris or Alpine Linux.
  *
  *
- * @return array Returns an array containing the matched files/directories, an empty array
+ * @return list Returns an array containing the matched files/directories, an empty array
  * if no file matched.
  * @throws FilesystemException
  *
@@ -1417,7 +1417,7 @@ function popen(string $command, string $mode)
  * you want to search for the file in the include_path, too.
  * @param resource $context A context stream
  * resource.
- * @return int Returns the number of bytes read from the file on success
+ * @return 0|positive-int Returns the number of bytes read from the file on success
  * @throws FilesystemException
  *
  */

--- a/generated/8.1/ftp.php
+++ b/generated/8.1/ftp.php
@@ -31,7 +31,7 @@ function ftp_alloc(\FTP\Connection $ftp, int $size, ?string &$response = null): 
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename
  * @param string $local_filename
- * @param int $mode
+ * @param FTP_ASCII|FTP_BINARY $mode
  * @throws FtpException
  *
  */
@@ -173,7 +173,7 @@ function ftp_delete(\FTP\Connection $ftp, string $filename): void
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param resource $stream An open file pointer in which we store the data.
  * @param string $remote_filename The remote file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start downloading from.
  * @throws FtpException
@@ -196,7 +196,7 @@ function ftp_fget(\FTP\Connection $ftp, $stream, string $remote_filename, int $m
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param resource $stream An open file pointer on the local file. Reading stops at end of file.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @throws FtpException
@@ -219,7 +219,7 @@ function ftp_fput(\FTP\Connection $ftp, string $remote_filename, $stream, int $m
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $local_filename The local file path (will be overwritten if the file already exists).
  * @param string $remote_filename The remote file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start downloading from.
  * @throws FtpException
@@ -304,7 +304,7 @@ function ftp_mlsd(\FTP\Connection $ftp, string $directory): array
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param string $local_filename The local file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @return int Returns FTP_FAILED or FTP_FINISHED
@@ -376,7 +376,7 @@ function ftp_pasv(\FTP\Connection $ftp, bool $enable): void
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param string $local_filename The local file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @throws FtpException

--- a/generated/8.1/iconv.php
+++ b/generated/8.1/iconv.php
@@ -252,7 +252,7 @@ function iconv_set_encoding(string $type, string $encoding): void
  * @param null|string $encoding If encoding parameter is omitted or NULL,
  * string is assumed to be encoded in
  * iconv.internal_encoding.
- * @return int Returns the character count of string, as an integer,
+ * @return 0|positive-int Returns the character count of string, as an integer,
  * or FALSE if an error occurs during the encoding.
  * @throws IconvException
  *

--- a/generated/8.1/image.php
+++ b/generated/8.1/image.php
@@ -479,12 +479,12 @@ function imagecolorset(\GdImage $image, int $color, int $red, int $green, int $b
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param int $color The color index.
- * @return int Returns an associative array with red, green, blue and alpha keys that
+ * @return array{red: int, green: int, blue: int, alpha: int} Returns an associative array with red, green, blue and alpha keys that
  * contain the appropriate values for the specified color index.
  * @throws ImageException
  *
  */
-function imagecolorsforindex(\GdImage $image, int $color): int
+function imagecolorsforindex(\GdImage $image, int $color): array
 {
     error_clear_last();
     $safeResult = \imagecolorsforindex($image, $color);

--- a/generated/8.1/json.php
+++ b/generated/8.1/json.php
@@ -37,7 +37,7 @@ use Safe\Exceptions\JsonException;
  * JSON_THROW_ON_ERROR.
  * The behaviour of these constants is described on the
  * JSON constants page.
- * @param int $depth Set the maximum depth. Must be greater than zero.
+ * @param positive-int $depth Set the maximum depth. Must be greater than zero.
  * @return non-empty-string Returns a JSON encoded string on success.
  * @throws JsonException
  *

--- a/generated/8.1/mbstring.php
+++ b/generated/8.1/mbstring.php
@@ -74,7 +74,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * Sets the automatic character
  * encoding detection order to encoding.
  *
- * @param non-empty-array|non-falsy-string|null $encoding encoding is an array or
+ * @param non-empty-list|non-falsy-string|null $encoding encoding is an array or
  * comma separated list of character encoding. See supported encodings.
  *
  * If encoding is omitted or NULL, it returns
@@ -93,7 +93,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * For UTF-16, UTF-32,
  * UCS2 and UCS4, encoding
  * detection will fail always.
- * @return array|bool When setting the encoding detection order, TRUE is returned on success.
+ * @return bool|list When setting the encoding detection order, TRUE is returned on success.
  *
  * When getting the encoding detection order, an ordered array of the encodings is returned.
  * @throws MbstringException
@@ -118,7 +118,7 @@ function mb_detect_order($encoding = null)
  * Returns an array of aliases for a known encoding type.
  *
  * @param string $encoding The encoding type being checked, for aliases.
- * @return array Returns a numerically indexed array of encoding aliases on success
+ * @return list Returns a numerically indexed array of encoding aliases on success
  * @throws MbstringException
  *
  */
@@ -586,7 +586,7 @@ function mb_send_mail(string $to, string $subject, string $message, $additional_
  * @param string $pattern The regular expression pattern.
  * @param string $string The string being split.
  * @param int $limit
- * @return array The result as an array.
+ * @return list The result as an array.
  * @throws MbstringException
  *
  */

--- a/generated/8.1/network.php
+++ b/generated/8.1/network.php
@@ -63,7 +63,7 @@ function closelog(): void
  * (the DNS_* constants cannot be used).
  * The return value will contain a data key, which needs
  * to be manually parsed.
- * @return array This function returns an array of associative arrays. Each associative array contains
+ * @return list This function returns an array of associative arrays. Each associative array contains
  * at minimum the following keys:
  *
  * Basic DNS attributes

--- a/generated/8.1/oci8.php
+++ b/generated/8.1/oci8.php
@@ -955,7 +955,7 @@ function oci_new_descriptor($connection, int $type = OCI_DTYPE_LOB)
  * Gets the number of rows affected during statement execution.
  *
  * @param resource $statement A valid OCI statement identifier.
- * @return int Returns the number of rows affected as an integer
+ * @return 0|positive-int Returns the number of rows affected as an integer
  * @throws Oci8Exception
  *
  */

--- a/generated/8.1/openssl.php
+++ b/generated/8.1/openssl.php
@@ -551,7 +551,7 @@ function openssl_digest(string $data, string $digest_algo, bool $binary = false)
  * NIST
  * recommends using ECC curves with at least 256 bits.
  *
- * @return array An array of available curve names.
+ * @return list An array of available curve names.
  * @throws OpensslException
  *
  */
@@ -1347,7 +1347,7 @@ function openssl_spki_verify(string $spki): void
  * @param int|string $algorithm int - one of these Signature Algorithms.
  *
  * string - a valid string returned by openssl_get_md_methods example, "sha1WithRSAEncryption" or "sha512".
- * @return int Returns 1 if the signature is correct, 0 if it is incorrect, and
+ * @return -1|0|1 Returns 1 if the signature is correct, 0 if it is incorrect, and
  * -1.
  * @throws OpensslException
  *

--- a/generated/8.1/pcre.php
+++ b/generated/8.1/pcre.php
@@ -369,7 +369,7 @@ function preg_grep(string $pattern, array $array, int $flags = 0): array
  *
  *
  * The above example will output:
- * @return int Returns the number of full pattern matches (which might be zero).
+ * @return 0|positive-int Returns the number of full pattern matches (which might be zero).
  * @throws PcreException
  *
  */
@@ -605,7 +605,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  *
  *
  * The above example will output:
- * @return int preg_match returns 1 if the pattern
+ * @return 0|1 preg_match returns 1 if the pattern
  * matches given subject, 0 if it does not.
  * @throws PcreException
  *
@@ -772,7 +772,7 @@ function preg_replace_callback($pattern, callable $callback, $subject, int $limi
  * value in an array where every element is an array consisting of the
  * matched string at offset 0 and its string offset
  * into subject at offset 1.
- * @return array Returns an array containing substrings of subject
+ * @return list Returns an array containing substrings of subject
  * split along boundaries matched by pattern.
  * @throws PcreException
  *

--- a/generated/8.1/posix.php
+++ b/generated/8.1/posix.php
@@ -34,7 +34,7 @@ function posix_access(string $filename, int $flags = 0): void
  * Gets information about a group provided its id.
  *
  * @param int $group_id The group id.
- * @return array{name: string, passwd: string, gid: int, members: array} The array elements returned are:
+ * @return array{name: string, passwd: string, gid: int, members: list} The array elements returned are:
  *
  * The group information array
  *
@@ -98,7 +98,7 @@ function posix_getgrgid(int $group_id): array
  * Gets information about a group provided its name.
  *
  * @param string $name The name of the group
- * @return array{name: string, passwd: string, gid: int, members: array} Returns an array on success.
+ * @return array{name: string, passwd: string, gid: int, members: list} Returns an array on success.
  * The array elements returned are:
  *
  * The group information array
@@ -161,7 +161,7 @@ function posix_getgrnam(string $name): array
 /**
  * Gets the group set of the current process.
  *
- * @return array Returns an array of integers containing the numeric group ids of the group
+ * @return list Returns an array of integers containing the numeric group ids of the group
  * set of the current process.
  * @throws PosixException
  *

--- a/generated/8.1/stream.php
+++ b/generated/8.1/stream.php
@@ -423,7 +423,7 @@ function stream_socket_accept($server_socket, ?float $timeout = null, ?string &$
  * stream_set_timeout, as the
  * timeout only applies while making connecting
  * the socket.
- * @param int $flags Bitmask field which may be set to any combination of connection flags.
+ * @param int-mask $flags Bitmask field which may be set to any combination of connection flags.
  * Currently the select of connection flags is limited to
  * STREAM_CLIENT_CONNECT (default),
  * STREAM_CLIENT_ASYNC_CONNECT and

--- a/generated/8.1/zlib.php
+++ b/generated/8.1/zlib.php
@@ -271,7 +271,7 @@ function gzencode(string $data, int $level = -1, int $encoding = ZLIB_ENCODING_G
  * @param string $filename The file name.
  * @param int $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
- * @return array An array containing the file, one line per cell, empty lines included, and with newlines still attached.
+ * @return list An array containing the file, one line per cell, empty lines included, and with newlines still attached.
  * @throws ZlibException
  *
  */
@@ -678,7 +678,7 @@ function inflate_init(int $encoding, array $options = []): \InflateContext
  * contents written to standard output.
  * @param int $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
- * @return int Returns the number of (uncompressed) bytes read from the file on success
+ * @return 0|positive-int Returns the number of (uncompressed) bytes read from the file on success
  * @throws ZlibException
  *
  */

--- a/generated/8.2/dir.php
+++ b/generated/8.2/dir.php
@@ -131,7 +131,7 @@ function opendir(string $directory, $context = null)
  * directory.
  *
  * @param string $directory The directory that will be scanned.
- * @param int $sorting_order By default, the sorted order is alphabetical in ascending order.  If
+ * @param SCANDIR_SORT_ASCENDING|SCANDIR_SORT_DESCENDING|SCANDIR_SORT_NONE $sorting_order By default, the sorted order is alphabetical in ascending order.  If
  * the optional sorting_order is set to
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
@@ -139,7 +139,7 @@ function opendir(string $directory, $context = null)
  * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
- * @return array Returns an array of filenames on success. If directory is not a directory, then
+ * @return list Returns an array of filenames on success. If directory is not a directory, then
  * boolean FALSE is returned, and an error of level
  * E_WARNING is generated.
  * @throws DirException

--- a/generated/8.2/errorfunc.php
+++ b/generated/8.2/errorfunc.php
@@ -8,7 +8,7 @@ use Safe\Exceptions\ErrorfuncException;
  * Sends an error message to the web server's error log or to a file.
  *
  * @param string $message The error message that should be logged.
- * @param int $message_type Says where the error should go. The possible message types are as
+ * @param 0|1|2|3|4 $message_type Says where the error should go. The possible message types are as
  * follows:
  *
  *

--- a/generated/8.2/filesystem.php
+++ b/generated/8.2/filesystem.php
@@ -253,7 +253,7 @@ function fflush($stream): void
  * Seeking (offset) is not supported with remote files.
  * Attempting to seek on non-local files may work with small offsets, but this
  * is unpredictable because it works on the buffered stream.
- * @param int|null $length Maximum length of data read. The default is to read until end
+ * @param 0|null|positive-int $length Maximum length of data read. The default is to read until end
  * of file is reached. Note that this parameter is applied to the
  * stream processed by the filters.
  * @return string The function returns the read data.
@@ -349,7 +349,7 @@ function file_get_contents(string $filename, bool $use_include_path = false, $co
  *
  * @param null|resource $context A valid context resource created with
  * stream_context_create.
- * @return int This function returns the number of bytes that were written to the file.
+ * @return 0|positive-int This function returns the number of bytes that were written to the file.
  * @throws FilesystemException
  *
  */
@@ -372,7 +372,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  * Reads an entire file into an array.
  *
  * @param string $filename Path to the file.
- * @param int $flags The optional parameter flags can be one, or
+ * @param int-mask $flags The optional parameter flags can be one, or
  * more, of the following constants:
  *
  *
@@ -407,7 +407,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  *
  *
  * @param null|resource $context
- * @return array Returns the file in an array. Each element of the array corresponds to a
+ * @return list Returns the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns FALSE.
  * @throws FilesystemException
@@ -567,7 +567,7 @@ function fileperms(string $filename): int
  * Gets the size for the given file.
  *
  * @param string $filename Path to the file.
- * @return int Returns the size of the file in bytes, or FALSE (and generates an error
+ * @return 0|positive-int Returns the size of the file in bytes, or FALSE (and generates an error
  * of level E_WARNING) in case of an error.
  * @throws FilesystemException
  *
@@ -622,7 +622,7 @@ function filetype(string $filename): string
  *
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
- * @param int $operation operation is one of the following:
+ * @param int-mask $operation operation is one of the following:
  *
  *
  *
@@ -644,7 +644,7 @@ function filetype(string $filename): string
  * It is also possible to add LOCK_NB as a bitmask to one
  * of the above operations, if flock should not
  * block during the locking attempt.
- * @param int|null $would_block The optional third argument is set to 1 if the lock would block
+ * @param 0|1|null $would_block The optional third argument is set to 1 if the lock would block
  * (EWOULDBLOCK errno condition).
  * @throws FilesystemException
  *
@@ -907,7 +907,7 @@ function fopen(string $filename, string $mode, bool $use_include_path = false, $
  *
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
- * @param int $length Up to length number of bytes read.
+ * @param positive-int $length Up to length number of bytes read.
  * @return string Returns the read string.
  * @throws FilesystemException
  *
@@ -1001,7 +1001,7 @@ function ftell($stream): int
  * @param resource $stream The file pointer.
  *
  * The stream must be open for writing.
- * @param int $size The size to truncate to.
+ * @param 0|positive-int $size The size to truncate to.
  *
  * If size is larger than the file then the file
  * is extended with null bytes.
@@ -1027,10 +1027,10 @@ function ftruncate($stream, int $size): void
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
  * @param string $data The string that is to be written.
- * @param int|null $length If length is an integer, writing will stop
+ * @param 0|null|positive-int $length If length is an integer, writing will stop
  * after length bytes have been written or the
  * end of data is reached, whichever comes first.
- * @return int
+ * @return 0|positive-int
  * @throws FilesystemException
  *
  */
@@ -1134,7 +1134,7 @@ function fwrite($stream, string $data, ?int $length = null): int
  * systems, like Solaris or Alpine Linux.
  *
  *
- * @return array Returns an array containing the matched files/directories, an empty array
+ * @return list Returns an array containing the matched files/directories, an empty array
  * if no file matched.
  * @throws FilesystemException
  *
@@ -1423,7 +1423,7 @@ function popen(string $command, string $mode)
  * you want to search for the file in the include_path, too.
  * @param null|resource $context A context stream
  * resource.
- * @return int Returns the number of bytes read from the file on success
+ * @return 0|positive-int Returns the number of bytes read from the file on success
  * @throws FilesystemException
  *
  */

--- a/generated/8.2/fpm.php
+++ b/generated/8.2/fpm.php
@@ -30,11 +30,11 @@ function fastcgi_finish_request(): void
  *
  * Note that this function will only be defined if FPM is being used to serve the script.
  *
- * @return int Associative array containing the full FPM pool status.
+ * @return array{pool: string, process-manager: 'dynamic'|'ondemand'|'static', start-time: int, start-since: int, accepted-conn: int, listen-queue: int, max-listen-queue: int, listen-queue-len: int, idle-processes: int, active-processes: int, total-processes: int, max-active-processes: int, max-children-reached: 0|1, slow-requests: int, procs: array} Associative array containing the full FPM pool status.
  * @throws FpmException
  *
  */
-function fpm_get_status(): int
+function fpm_get_status(): array
 {
     error_clear_last();
     $safeResult = \fpm_get_status();

--- a/generated/8.2/ftp.php
+++ b/generated/8.2/ftp.php
@@ -31,7 +31,7 @@ function ftp_alloc(\FTP\Connection $ftp, int $size, ?string &$response = null): 
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename
  * @param string $local_filename
- * @param int $mode
+ * @param FTP_ASCII|FTP_BINARY $mode
  * @throws FtpException
  *
  */
@@ -173,7 +173,7 @@ function ftp_delete(\FTP\Connection $ftp, string $filename): void
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param resource $stream An open file pointer in which we store the data.
  * @param string $remote_filename The remote file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start downloading from.
  * @throws FtpException
@@ -196,7 +196,7 @@ function ftp_fget(\FTP\Connection $ftp, $stream, string $remote_filename, int $m
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param resource $stream An open file pointer on the local file. Reading stops at end of file.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @throws FtpException
@@ -219,7 +219,7 @@ function ftp_fput(\FTP\Connection $ftp, string $remote_filename, $stream, int $m
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $local_filename The local file path (will be overwritten if the file already exists).
  * @param string $remote_filename The remote file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start downloading from.
  * @throws FtpException
@@ -304,7 +304,7 @@ function ftp_mlsd(\FTP\Connection $ftp, string $directory): array
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param string $local_filename The local file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @return int Returns FTP_FAILED or FTP_FINISHED
@@ -376,7 +376,7 @@ function ftp_pasv(\FTP\Connection $ftp, bool $enable): void
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param string $local_filename The local file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @throws FtpException

--- a/generated/8.2/iconv.php
+++ b/generated/8.2/iconv.php
@@ -252,7 +252,7 @@ function iconv_set_encoding(string $type, string $encoding): void
  * @param null|string $encoding If encoding parameter is omitted or NULL,
  * string is assumed to be encoded in
  * iconv.internal_encoding.
- * @return int Returns the character count of string, as an integer,
+ * @return 0|positive-int Returns the character count of string, as an integer,
  * or FALSE if an error occurs during the encoding.
  * @throws IconvException
  *

--- a/generated/8.2/image.php
+++ b/generated/8.2/image.php
@@ -479,11 +479,11 @@ function imagecolorset(\GdImage $image, int $color, int $red, int $green, int $b
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param int $color The color index.
- * @return int Returns an associative array with red, green, blue and alpha keys that
+ * @return array{red: int, green: int, blue: int, alpha: int} Returns an associative array with red, green, blue and alpha keys that
  * contain the appropriate values for the specified color index.
  *
  */
-function imagecolorsforindex(\GdImage $image, int $color): int
+function imagecolorsforindex(\GdImage $image, int $color): array
 {
     error_clear_last();
     $safeResult = \imagecolorsforindex($image, $color);

--- a/generated/8.2/json.php
+++ b/generated/8.2/json.php
@@ -42,7 +42,7 @@ use Safe\Exceptions\JsonException;
  * JSON_THROW_ON_ERROR.
  * The behaviour of these constants is described on the
  * JSON constants page.
- * @param int $depth Set the maximum depth. Must be greater than zero.
+ * @param positive-int $depth Set the maximum depth. Must be greater than zero.
  * @return non-empty-string Returns a JSON encoded string on success.
  * @throws JsonException
  *

--- a/generated/8.2/mbstring.php
+++ b/generated/8.2/mbstring.php
@@ -77,7 +77,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * Sets the automatic character
  * encoding detection order to encoding.
  *
- * @param non-empty-array|non-falsy-string|null $encoding encoding is an array or
+ * @param non-empty-list|non-falsy-string|null $encoding encoding is an array or
  * comma separated list of character encoding. See supported encodings.
  *
  * If encoding is omitted or NULL, it returns
@@ -96,7 +96,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * For UTF-16, UTF-32,
  * UCS2 and UCS4, encoding
  * detection will fail always.
- * @return array|bool When setting the encoding detection order, TRUE is returned on success.
+ * @return bool|list When setting the encoding detection order, TRUE is returned on success.
  *
  * When getting the encoding detection order, an ordered array of the encodings is returned.
  * @throws MbstringException
@@ -121,7 +121,7 @@ function mb_detect_order($encoding = null)
  * Returns an array of aliases for a known encoding type.
  *
  * @param string $encoding The encoding type being checked, for aliases.
- * @return array Returns a numerically indexed array of encoding aliases on success
+ * @return list Returns a numerically indexed array of encoding aliases on success
  * @throws MbstringException
  *
  */
@@ -589,7 +589,7 @@ function mb_send_mail(string $to, string $subject, string $message, $additional_
  * @param string $pattern The regular expression pattern.
  * @param string $string The string being split.
  * @param int $limit
- * @return array The result as an array.
+ * @return list The result as an array.
  * @throws MbstringException
  *
  */

--- a/generated/8.2/network.php
+++ b/generated/8.2/network.php
@@ -63,7 +63,7 @@ function closelog(): void
  * (the DNS_* constants cannot be used).
  * The return value will contain a data key, which needs
  * to be manually parsed.
- * @return array This function returns an array of associative arrays. Each associative array contains
+ * @return list This function returns an array of associative arrays. Each associative array contains
  * at minimum the following keys:
  *
  * Basic DNS attributes

--- a/generated/8.2/oci8.php
+++ b/generated/8.2/oci8.php
@@ -955,7 +955,7 @@ function oci_new_descriptor($connection, int $type = OCI_DTYPE_LOB)
  * Gets the number of rows affected during statement execution.
  *
  * @param resource $statement A valid OCI statement identifier.
- * @return int Returns the number of rows affected as an integer
+ * @return 0|positive-int Returns the number of rows affected as an integer
  * @throws Oci8Exception
  *
  */

--- a/generated/8.2/openssl.php
+++ b/generated/8.2/openssl.php
@@ -576,7 +576,7 @@ function openssl_digest(string $data, string $digest_algo, bool $binary = false)
  * NIST
  * recommends using ECC curves with at least 256 bits.
  *
- * @return array An array of available curve names.
+ * @return list An array of available curve names.
  * @throws OpensslException
  *
  */
@@ -1368,7 +1368,7 @@ function openssl_spki_verify(string $spki): void
  * @param int|string $algorithm int - one of these Signature Algorithms.
  *
  * string - a valid string returned by openssl_get_md_methods example, "sha1WithRSAEncryption" or "sha512".
- * @return int Returns 1 if the signature is correct, 0 if it is incorrect, and
+ * @return -1|0|1 Returns 1 if the signature is correct, 0 if it is incorrect, and
  * -1.
  * @throws OpensslException
  *

--- a/generated/8.2/pcre.php
+++ b/generated/8.2/pcre.php
@@ -369,7 +369,7 @@ function preg_grep(string $pattern, array $array, int $flags = 0): array
  *
  *
  * The above example will output:
- * @return int Returns the number of full pattern matches (which might be zero).
+ * @return 0|positive-int Returns the number of full pattern matches (which might be zero).
  * @throws PcreException
  *
  */
@@ -605,7 +605,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  *
  *
  * The above example will output:
- * @return int preg_match returns 1 if the pattern
+ * @return 0|1 preg_match returns 1 if the pattern
  * matches given subject, 0 if it does not.
  * @throws PcreException
  *
@@ -772,7 +772,7 @@ function preg_replace_callback($pattern, callable $callback, $subject, int $limi
  * value in an array where every element is an array consisting of the
  * matched string at offset 0 and its string offset
  * into subject at offset 1.
- * @return array Returns an array containing substrings of subject
+ * @return list Returns an array containing substrings of subject
  * split along boundaries matched by pattern.
  * @throws PcreException
  *

--- a/generated/8.2/posix.php
+++ b/generated/8.2/posix.php
@@ -34,7 +34,7 @@ function posix_access(string $filename, int $flags = 0): void
  * Gets information about a group provided its id.
  *
  * @param int $group_id The group id.
- * @return array{name: string, passwd: string, gid: int, members: array} The array elements returned are:
+ * @return array{name: string, passwd: string, gid: int, members: list} The array elements returned are:
  *
  * The group information array
  *
@@ -98,7 +98,7 @@ function posix_getgrgid(int $group_id): array
  * Gets information about a group provided its name.
  *
  * @param string $name The name of the group
- * @return array{name: string, passwd: string, gid: int, members: array} Returns an array on success.
+ * @return array{name: string, passwd: string, gid: int, members: list} Returns an array on success.
  * The array elements returned are:
  *
  * The group information array
@@ -161,7 +161,7 @@ function posix_getgrnam(string $name): array
 /**
  * Gets the group set of the current process.
  *
- * @return array Returns an array of integers containing the numeric group ids of the group
+ * @return list Returns an array of integers containing the numeric group ids of the group
  * set of the current process.
  * @throws PosixException
  *

--- a/generated/8.2/stream.php
+++ b/generated/8.2/stream.php
@@ -429,7 +429,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * stream_set_timeout, as the
  * timeout only applies while making connecting
  * the socket.
- * @param int $flags Bitmask field which may be set to any combination of connection flags.
+ * @param int-mask $flags Bitmask field which may be set to any combination of connection flags.
  * Currently the select of connection flags is limited to
  * STREAM_CLIENT_CONNECT (default),
  * STREAM_CLIENT_ASYNC_CONNECT and

--- a/generated/8.2/zlib.php
+++ b/generated/8.2/zlib.php
@@ -271,7 +271,7 @@ function gzencode(string $data, int $level = -1, int $encoding = ZLIB_ENCODING_G
  * @param string $filename The file name.
  * @param int $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
- * @return array An array containing the file, one line per cell, empty lines included, and with newlines still attached.
+ * @return list An array containing the file, one line per cell, empty lines included, and with newlines still attached.
  * @throws ZlibException
  *
  */
@@ -678,7 +678,7 @@ function inflate_init(int $encoding, array $options = []): \InflateContext
  * contents written to standard output.
  * @param int $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
- * @return int Returns the number of (uncompressed) bytes read from the file on success
+ * @return 0|positive-int Returns the number of (uncompressed) bytes read from the file on success
  * @throws ZlibException
  *
  */

--- a/generated/8.3/dir.php
+++ b/generated/8.3/dir.php
@@ -131,7 +131,7 @@ function opendir(string $directory, $context = null)
  * directory.
  *
  * @param string $directory The directory that will be scanned.
- * @param int $sorting_order By default, the sorted order is alphabetical in ascending order.  If
+ * @param SCANDIR_SORT_ASCENDING|SCANDIR_SORT_DESCENDING|SCANDIR_SORT_NONE $sorting_order By default, the sorted order is alphabetical in ascending order.  If
  * the optional sorting_order is set to
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
@@ -139,7 +139,7 @@ function opendir(string $directory, $context = null)
  * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
- * @return array Returns an array of filenames on success. If directory is not a directory, then
+ * @return list Returns an array of filenames on success. If directory is not a directory, then
  * boolean FALSE is returned, and an error of level
  * E_WARNING is generated.
  * @throws DirException

--- a/generated/8.3/errorfunc.php
+++ b/generated/8.3/errorfunc.php
@@ -8,7 +8,7 @@ use Safe\Exceptions\ErrorfuncException;
  * Sends an error message to the web server's error log or to a file.
  *
  * @param string $message The error message that should be logged.
- * @param int $message_type Says where the error should go. The possible message types are as
+ * @param 0|1|2|3|4 $message_type Says where the error should go. The possible message types are as
  * follows:
  *
  *

--- a/generated/8.3/filesystem.php
+++ b/generated/8.3/filesystem.php
@@ -253,7 +253,7 @@ function fflush($stream): void
  * Seeking (offset) is not supported with remote files.
  * Attempting to seek on non-local files may work with small offsets, but this
  * is unpredictable because it works on the buffered stream.
- * @param int|null $length Maximum length of data read. The default is to read until end
+ * @param 0|null|positive-int $length Maximum length of data read. The default is to read until end
  * of file is reached. Note that this parameter is applied to the
  * stream processed by the filters.
  * @return string The function returns the read data.
@@ -349,7 +349,7 @@ function file_get_contents(string $filename, bool $use_include_path = false, $co
  *
  * @param null|resource $context A valid context resource created with
  * stream_context_create.
- * @return int This function returns the number of bytes that were written to the file.
+ * @return 0|positive-int This function returns the number of bytes that were written to the file.
  * @throws FilesystemException
  *
  */
@@ -372,7 +372,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  * Reads an entire file into an array.
  *
  * @param string $filename Path to the file.
- * @param int $flags The optional parameter flags can be one, or
+ * @param int-mask $flags The optional parameter flags can be one, or
  * more, of the following constants:
  *
  *
@@ -407,7 +407,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  *
  *
  * @param null|resource $context
- * @return array Returns the file in an array. Each element of the array corresponds to a
+ * @return list Returns the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns FALSE.
  * @throws FilesystemException
@@ -567,7 +567,7 @@ function fileperms(string $filename): int
  * Gets the size for the given file.
  *
  * @param string $filename Path to the file.
- * @return int Returns the size of the file in bytes, or FALSE (and generates an error
+ * @return 0|positive-int Returns the size of the file in bytes, or FALSE (and generates an error
  * of level E_WARNING) in case of an error.
  * @throws FilesystemException
  *
@@ -622,7 +622,7 @@ function filetype(string $filename): string
  *
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
- * @param int $operation operation is one of the following:
+ * @param int-mask $operation operation is one of the following:
  *
  *
  *
@@ -644,7 +644,7 @@ function filetype(string $filename): string
  * It is also possible to add LOCK_NB as a bitmask to one
  * of the above operations, if flock should not
  * block during the locking attempt.
- * @param int|null $would_block The optional third argument is set to 1 if the lock would block
+ * @param 0|1|null $would_block The optional third argument is set to 1 if the lock would block
  * (EWOULDBLOCK errno condition).
  * @throws FilesystemException
  *
@@ -907,7 +907,7 @@ function fopen(string $filename, string $mode, bool $use_include_path = false, $
  *
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
- * @param int $length Up to length number of bytes read.
+ * @param positive-int $length Up to length number of bytes read.
  * @return string Returns the read string.
  * @throws FilesystemException
  *
@@ -1001,7 +1001,7 @@ function ftell($stream): int
  * @param resource $stream The file pointer.
  *
  * The stream must be open for writing.
- * @param int $size The size to truncate to.
+ * @param 0|positive-int $size The size to truncate to.
  *
  * If size is larger than the file then the file
  * is extended with null bytes.
@@ -1027,10 +1027,10 @@ function ftruncate($stream, int $size): void
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
  * @param string $data The string that is to be written.
- * @param int|null $length If length is an integer, writing will stop
+ * @param 0|null|positive-int $length If length is an integer, writing will stop
  * after length bytes have been written or the
  * end of data is reached, whichever comes first.
- * @return int
+ * @return 0|positive-int
  * @throws FilesystemException
  *
  */
@@ -1134,7 +1134,7 @@ function fwrite($stream, string $data, ?int $length = null): int
  * systems, like Solaris or Alpine Linux.
  *
  *
- * @return array Returns an array containing the matched files/directories, an empty array
+ * @return list Returns an array containing the matched files/directories, an empty array
  * if no file matched.
  * @throws FilesystemException
  *
@@ -1423,7 +1423,7 @@ function popen(string $command, string $mode)
  * you want to search for the file in the include_path, too.
  * @param null|resource $context A context stream
  * resource.
- * @return int Returns the number of bytes read from the file on success
+ * @return 0|positive-int Returns the number of bytes read from the file on success
  * @throws FilesystemException
  *
  */

--- a/generated/8.3/fpm.php
+++ b/generated/8.3/fpm.php
@@ -30,11 +30,11 @@ function fastcgi_finish_request(): void
  *
  * Note that this function will only be defined if FPM is being used to serve the script.
  *
- * @return int Associative array containing the full FPM pool status.
+ * @return array{pool: string, process-manager: 'dynamic'|'ondemand'|'static', start-time: int, start-since: int, accepted-conn: int, listen-queue: int, max-listen-queue: int, listen-queue-len: int, idle-processes: int, active-processes: int, total-processes: int, max-active-processes: int, max-children-reached: 0|1, slow-requests: int, procs: array} Associative array containing the full FPM pool status.
  * @throws FpmException
  *
  */
-function fpm_get_status(): int
+function fpm_get_status(): array
 {
     error_clear_last();
     $safeResult = \fpm_get_status();

--- a/generated/8.3/ftp.php
+++ b/generated/8.3/ftp.php
@@ -31,7 +31,7 @@ function ftp_alloc(\FTP\Connection $ftp, int $size, ?string &$response = null): 
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename
  * @param string $local_filename
- * @param int $mode
+ * @param FTP_ASCII|FTP_BINARY $mode
  * @throws FtpException
  *
  */
@@ -173,7 +173,7 @@ function ftp_delete(\FTP\Connection $ftp, string $filename): void
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param resource $stream An open file pointer in which we store the data.
  * @param string $remote_filename The remote file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start downloading from.
  * @throws FtpException
@@ -196,7 +196,7 @@ function ftp_fget(\FTP\Connection $ftp, $stream, string $remote_filename, int $m
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param resource $stream An open file pointer on the local file. Reading stops at end of file.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @throws FtpException
@@ -219,7 +219,7 @@ function ftp_fput(\FTP\Connection $ftp, string $remote_filename, $stream, int $m
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $local_filename The local file path (will be overwritten if the file already exists).
  * @param string $remote_filename The remote file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start downloading from.
  * @throws FtpException
@@ -304,7 +304,7 @@ function ftp_mlsd(\FTP\Connection $ftp, string $directory): array
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param string $local_filename The local file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @return int Returns FTP_FAILED or FTP_FINISHED
@@ -376,7 +376,7 @@ function ftp_pasv(\FTP\Connection $ftp, bool $enable): void
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param string $local_filename The local file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @throws FtpException

--- a/generated/8.3/iconv.php
+++ b/generated/8.3/iconv.php
@@ -252,7 +252,7 @@ function iconv_set_encoding(string $type, string $encoding): void
  * @param null|string $encoding If encoding parameter is omitted or NULL,
  * string is assumed to be encoded in
  * iconv.internal_encoding.
- * @return int Returns the character count of string, as an integer,
+ * @return 0|positive-int Returns the character count of string, as an integer,
  * or FALSE if an error occurs during the encoding.
  * @throws IconvException
  *

--- a/generated/8.3/image.php
+++ b/generated/8.3/image.php
@@ -479,11 +479,11 @@ function imagecolorset(\GdImage $image, int $color, int $red, int $green, int $b
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param int $color The color index.
- * @return int Returns an associative array with red, green, blue and alpha keys that
+ * @return array{red: int, green: int, blue: int, alpha: int} Returns an associative array with red, green, blue and alpha keys that
  * contain the appropriate values for the specified color index.
  *
  */
-function imagecolorsforindex(\GdImage $image, int $color): int
+function imagecolorsforindex(\GdImage $image, int $color): array
 {
     error_clear_last();
     $safeResult = \imagecolorsforindex($image, $color);

--- a/generated/8.3/json.php
+++ b/generated/8.3/json.php
@@ -42,7 +42,7 @@ use Safe\Exceptions\JsonException;
  * JSON_THROW_ON_ERROR.
  * The behaviour of these constants is described on the
  * JSON constants page.
- * @param int $depth Set the maximum depth. Must be greater than zero.
+ * @param positive-int $depth Set the maximum depth. Must be greater than zero.
  * @return non-empty-string Returns a JSON encoded string on success.
  * @throws JsonException
  *

--- a/generated/8.3/mbstring.php
+++ b/generated/8.3/mbstring.php
@@ -77,7 +77,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * Sets the automatic character
  * encoding detection order to encoding.
  *
- * @param non-empty-array|non-falsy-string|null $encoding encoding is an array or
+ * @param non-empty-list|non-falsy-string|null $encoding encoding is an array or
  * comma separated list of character encoding. See supported encodings.
  *
  * If encoding is omitted or NULL, it returns
@@ -96,7 +96,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * For UTF-16, UTF-32,
  * UCS2 and UCS4, encoding
  * detection will fail always.
- * @return array|bool When setting the encoding detection order, TRUE is returned on success.
+ * @return bool|list When setting the encoding detection order, TRUE is returned on success.
  *
  * When getting the encoding detection order, an ordered array of the encodings is returned.
  * @throws MbstringException
@@ -121,7 +121,7 @@ function mb_detect_order($encoding = null)
  * Returns an array of aliases for a known encoding type.
  *
  * @param string $encoding The encoding type being checked, for aliases.
- * @return array Returns a numerically indexed array of encoding aliases on success
+ * @return list Returns a numerically indexed array of encoding aliases on success
  * @throws MbstringException
  *
  */
@@ -589,7 +589,7 @@ function mb_send_mail(string $to, string $subject, string $message, $additional_
  * @param string $pattern The regular expression pattern.
  * @param string $string The string being split.
  * @param int $limit
- * @return array The result as an array.
+ * @return list The result as an array.
  * @throws MbstringException
  *
  */

--- a/generated/8.3/network.php
+++ b/generated/8.3/network.php
@@ -63,7 +63,7 @@ function closelog(): void
  * (the DNS_* constants cannot be used).
  * The return value will contain a data key, which needs
  * to be manually parsed.
- * @return array This function returns an array of associative arrays. Each associative array contains
+ * @return list This function returns an array of associative arrays. Each associative array contains
  * at minimum the following keys:
  *
  * Basic DNS attributes

--- a/generated/8.3/oci8.php
+++ b/generated/8.3/oci8.php
@@ -955,7 +955,7 @@ function oci_new_descriptor($connection, int $type = OCI_DTYPE_LOB)
  * Gets the number of rows affected during statement execution.
  *
  * @param resource $statement A valid OCI statement identifier.
- * @return int Returns the number of rows affected as an integer
+ * @return 0|positive-int Returns the number of rows affected as an integer
  * @throws Oci8Exception
  *
  */

--- a/generated/8.3/openssl.php
+++ b/generated/8.3/openssl.php
@@ -576,7 +576,7 @@ function openssl_digest(string $data, string $digest_algo, bool $binary = false)
  * NIST
  * recommends using ECC curves with at least 256 bits.
  *
- * @return array An array of available curve names.
+ * @return list An array of available curve names.
  * @throws OpensslException
  *
  */
@@ -1368,7 +1368,7 @@ function openssl_spki_verify(string $spki): void
  * @param int|string $algorithm int - one of these Signature Algorithms.
  *
  * string - a valid string returned by openssl_get_md_methods example, "sha1WithRSAEncryption" or "sha512".
- * @return int Returns 1 if the signature is correct, 0 if it is incorrect, and
+ * @return -1|0|1 Returns 1 if the signature is correct, 0 if it is incorrect, and
  * -1.
  * @throws OpensslException
  *

--- a/generated/8.3/pcre.php
+++ b/generated/8.3/pcre.php
@@ -369,7 +369,7 @@ function preg_grep(string $pattern, array $array, int $flags = 0): array
  *
  *
  * The above example will output:
- * @return int Returns the number of full pattern matches (which might be zero).
+ * @return 0|positive-int Returns the number of full pattern matches (which might be zero).
  * @throws PcreException
  *
  */
@@ -605,7 +605,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  *
  *
  * The above example will output:
- * @return int preg_match returns 1 if the pattern
+ * @return 0|1 preg_match returns 1 if the pattern
  * matches given subject, 0 if it does not.
  * @throws PcreException
  *
@@ -772,7 +772,7 @@ function preg_replace_callback($pattern, callable $callback, $subject, int $limi
  * value in an array where every element is an array consisting of the
  * matched string at offset 0 and its string offset
  * into subject at offset 1.
- * @return array Returns an array containing substrings of subject
+ * @return list Returns an array containing substrings of subject
  * split along boundaries matched by pattern.
  * @throws PcreException
  *

--- a/generated/8.3/posix.php
+++ b/generated/8.3/posix.php
@@ -34,7 +34,7 @@ function posix_access(string $filename, int $flags = 0): void
  * Gets information about a group provided its id.
  *
  * @param int $group_id The group id.
- * @return array{name: string, passwd: string, gid: int, members: array} The array elements returned are:
+ * @return array{name: string, passwd: string, gid: int, members: list} The array elements returned are:
  *
  * The group information array
  *
@@ -98,7 +98,7 @@ function posix_getgrgid(int $group_id): array
  * Gets information about a group provided its name.
  *
  * @param string $name The name of the group
- * @return array{name: string, passwd: string, gid: int, members: array} Returns an array on success.
+ * @return array{name: string, passwd: string, gid: int, members: list} Returns an array on success.
  * The array elements returned are:
  *
  * The group information array
@@ -161,7 +161,7 @@ function posix_getgrnam(string $name): array
 /**
  * Gets the group set of the current process.
  *
- * @return array Returns an array of integers containing the numeric group ids of the group
+ * @return list Returns an array of integers containing the numeric group ids of the group
  * set of the current process.
  * @throws PosixException
  *

--- a/generated/8.3/stream.php
+++ b/generated/8.3/stream.php
@@ -429,7 +429,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * stream_set_timeout, as the
  * timeout only applies while making connecting
  * the socket.
- * @param int $flags Bitmask field which may be set to any combination of connection flags.
+ * @param int-mask $flags Bitmask field which may be set to any combination of connection flags.
  * Currently the select of connection flags is limited to
  * STREAM_CLIENT_CONNECT (default),
  * STREAM_CLIENT_ASYNC_CONNECT and

--- a/generated/8.3/zlib.php
+++ b/generated/8.3/zlib.php
@@ -271,7 +271,7 @@ function gzencode(string $data, int $level = -1, int $encoding = ZLIB_ENCODING_G
  * @param string $filename The file name.
  * @param int $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
- * @return array An array containing the file, one line per cell, empty lines included, and with newlines still attached.
+ * @return list An array containing the file, one line per cell, empty lines included, and with newlines still attached.
  * @throws ZlibException
  *
  */
@@ -678,7 +678,7 @@ function inflate_init(int $encoding, array $options = []): \InflateContext
  * contents written to standard output.
  * @param int $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
- * @return int Returns the number of (uncompressed) bytes read from the file on success
+ * @return 0|positive-int Returns the number of (uncompressed) bytes read from the file on success
  * @throws ZlibException
  *
  */

--- a/generated/8.4/dir.php
+++ b/generated/8.4/dir.php
@@ -131,7 +131,7 @@ function opendir(string $directory, $context = null)
  * directory.
  *
  * @param string $directory The directory that will be scanned.
- * @param int $sorting_order By default, the sorted order is alphabetical in ascending order.  If
+ * @param SCANDIR_SORT_ASCENDING|SCANDIR_SORT_DESCENDING|SCANDIR_SORT_NONE $sorting_order By default, the sorted order is alphabetical in ascending order.  If
  * the optional sorting_order is set to
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
@@ -139,7 +139,7 @@ function opendir(string $directory, $context = null)
  * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
- * @return array Returns an array of filenames on success. If directory is not a directory, then
+ * @return list Returns an array of filenames on success. If directory is not a directory, then
  * boolean FALSE is returned, and an error of level
  * E_WARNING is generated.
  * @throws DirException

--- a/generated/8.4/errorfunc.php
+++ b/generated/8.4/errorfunc.php
@@ -8,7 +8,7 @@ use Safe\Exceptions\ErrorfuncException;
  * Sends an error message to the web server's error log or to a file.
  *
  * @param string $message The error message that should be logged.
- * @param int $message_type Says where the error should go. The possible message types are as
+ * @param 0|1|2|3|4 $message_type Says where the error should go. The possible message types are as
  * follows:
  *
  *

--- a/generated/8.4/filesystem.php
+++ b/generated/8.4/filesystem.php
@@ -253,7 +253,7 @@ function fflush($stream): void
  * Seeking (offset) is not supported with remote files.
  * Attempting to seek on non-local files may work with small offsets, but this
  * is unpredictable because it works on the buffered stream.
- * @param int|null $length Maximum length of data read. The default is to read until end
+ * @param 0|null|positive-int $length Maximum length of data read. The default is to read until end
  * of file is reached. Note that this parameter is applied to the
  * stream processed by the filters.
  * @return string The function returns the read data.
@@ -349,7 +349,7 @@ function file_get_contents(string $filename, bool $use_include_path = false, $co
  *
  * @param null|resource $context A valid context resource created with
  * stream_context_create.
- * @return int This function returns the number of bytes that were written to the file.
+ * @return 0|positive-int This function returns the number of bytes that were written to the file.
  * @throws FilesystemException
  *
  */
@@ -372,7 +372,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  * Reads an entire file into an array.
  *
  * @param string $filename Path to the file.
- * @param int $flags The optional parameter flags can be one, or
+ * @param int-mask $flags The optional parameter flags can be one, or
  * more, of the following constants:
  *
  *
@@ -417,7 +417,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  *
  *
  * @param null|resource $context
- * @return array Returns the file in an array. Each element of the array corresponds to a
+ * @return list Returns the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns FALSE.
  * @throws FilesystemException
@@ -577,7 +577,7 @@ function fileperms(string $filename): int
  * Gets the size for the given file.
  *
  * @param string $filename Path to the file.
- * @return int Returns the size of the file in bytes, or FALSE (and generates an error
+ * @return 0|positive-int Returns the size of the file in bytes, or FALSE (and generates an error
  * of level E_WARNING) in case of an error.
  * @throws FilesystemException
  *
@@ -632,7 +632,7 @@ function filetype(string $filename): string
  *
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
- * @param int $operation operation is one of the following:
+ * @param int-mask $operation operation is one of the following:
  *
  *
  *
@@ -654,7 +654,7 @@ function filetype(string $filename): string
  * It is also possible to add LOCK_NB as a bitmask to one
  * of the above operations, if flock should not
  * block during the locking attempt.
- * @param int|null $would_block The optional third argument is set to 1 if the lock would block
+ * @param 0|1|null $would_block The optional third argument is set to 1 if the lock would block
  * (EWOULDBLOCK errno condition).
  * @throws FilesystemException
  *
@@ -917,7 +917,7 @@ function fopen(string $filename, string $mode, bool $use_include_path = false, $
  *
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
- * @param int $length Up to length number of bytes read.
+ * @param positive-int $length Up to length number of bytes read.
  * @return string Returns the read string.
  * @throws FilesystemException
  *
@@ -1011,7 +1011,7 @@ function ftell($stream): int
  * @param resource $stream The file pointer.
  *
  * The stream must be open for writing.
- * @param int $size The size to truncate to.
+ * @param 0|positive-int $size The size to truncate to.
  *
  * If size is larger than the file then the file
  * is extended with null bytes.
@@ -1037,10 +1037,10 @@ function ftruncate($stream, int $size): void
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
  * @param string $data The string that is to be written.
- * @param int|null $length If length is an integer, writing will stop
+ * @param 0|null|positive-int $length If length is an integer, writing will stop
  * after length bytes have been written or the
  * end of data is reached, whichever comes first.
- * @return int
+ * @return 0|positive-int
  * @throws FilesystemException
  *
  */
@@ -1094,7 +1094,7 @@ function fwrite($stream, string $data, ?int $length = null): int
  *
  *
  * @param int $flags Any of the GLOB_* constants.
- * @return array Returns an array containing the matched files/directories, an empty array
+ * @return list Returns an array containing the matched files/directories, an empty array
  * if no file matched.
  * Unless GLOB_NOSORT was used, the names will
  * be sorted alphanumerically.
@@ -1385,7 +1385,7 @@ function popen(string $command, string $mode)
  * you want to search for the file in the include_path, too.
  * @param null|resource $context A context stream
  * resource.
- * @return int Returns the number of bytes read from the file on success
+ * @return 0|positive-int Returns the number of bytes read from the file on success
  * @throws FilesystemException
  *
  */

--- a/generated/8.4/fpm.php
+++ b/generated/8.4/fpm.php
@@ -30,11 +30,11 @@ function fastcgi_finish_request(): void
  *
  * Note that this function will only be defined if FPM is being used to serve the script.
  *
- * @return int Associative array containing the full FPM pool status.
+ * @return array{pool: string, process-manager: 'dynamic'|'ondemand'|'static', start-time: int, start-since: int, accepted-conn: int, listen-queue: int, max-listen-queue: int, listen-queue-len: int, idle-processes: int, active-processes: int, total-processes: int, max-active-processes: int, max-children-reached: 0|1, slow-requests: int, procs: array} Associative array containing the full FPM pool status.
  * @throws FpmException
  *
  */
-function fpm_get_status(): int
+function fpm_get_status(): array
 {
     error_clear_last();
     $safeResult = \fpm_get_status();

--- a/generated/8.4/ftp.php
+++ b/generated/8.4/ftp.php
@@ -31,7 +31,7 @@ function ftp_alloc(\FTP\Connection $ftp, int $size, ?string &$response = null): 
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename
  * @param string $local_filename
- * @param int $mode
+ * @param FTP_ASCII|FTP_BINARY $mode
  * @throws FtpException
  *
  */
@@ -173,7 +173,7 @@ function ftp_delete(\FTP\Connection $ftp, string $filename): void
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param resource $stream An open file pointer in which we store the data.
  * @param string $remote_filename The remote file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start downloading from.
  * @throws FtpException
@@ -196,7 +196,7 @@ function ftp_fget(\FTP\Connection $ftp, $stream, string $remote_filename, int $m
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param resource $stream An open file pointer on the local file. Reading stops at end of file.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @throws FtpException
@@ -219,7 +219,7 @@ function ftp_fput(\FTP\Connection $ftp, string $remote_filename, $stream, int $m
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $local_filename The local file path (will be overwritten if the file already exists).
  * @param string $remote_filename The remote file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start downloading from.
  * @throws FtpException
@@ -305,7 +305,7 @@ function ftp_mlsd(\FTP\Connection $ftp, string $directory): array
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $local_filename The local file path (will be overwritten if the file already exists).
  * @param string $remote_filename The remote file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start downloading from.
  * @return int Returns FTP_FAILED or FTP_FINISHED
@@ -334,7 +334,7 @@ function ftp_nb_get(\FTP\Connection $ftp, string $local_filename, string $remote
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param string $local_filename The local file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @return int Returns FTP_FAILED or FTP_FINISHED
@@ -406,7 +406,7 @@ function ftp_pasv(\FTP\Connection $ftp, bool $enable): void
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param string $local_filename The local file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @throws FtpException

--- a/generated/8.4/ibmDb2.php
+++ b/generated/8.4/ibmDb2.php
@@ -522,7 +522,7 @@ function db2_get_option($resource, string $option): string
  * and branch if the fetch function returns FALSE.
  *
  * @param resource $stmt A valid stmt resource containing a result set.
- * @return int Returns the number of rows affected by the last SQL statement issued by
+ * @return 0|positive-int Returns the number of rows affected by the last SQL statement issued by
  * the specified statement handle
  * @throws IbmDb2Exception
  *

--- a/generated/8.4/iconv.php
+++ b/generated/8.4/iconv.php
@@ -252,7 +252,7 @@ function iconv_set_encoding(string $type, string $encoding): void
  * @param null|string $encoding If encoding parameter is omitted or NULL,
  * string is assumed to be encoded in
  * iconv.internal_encoding.
- * @return int Returns the character count of string, as an integer,
+ * @return 0|positive-int Returns the character count of string, as an integer,
  * or FALSE if an error occurs during the encoding.
  * @throws IconvException
  *

--- a/generated/8.4/image.php
+++ b/generated/8.4/image.php
@@ -479,11 +479,11 @@ function imagecolorset(\GdImage $image, int $color, int $red, int $green, int $b
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param int $color The color index.
- * @return int Returns an associative array with red, green, blue and alpha keys that
+ * @return array{red: int, green: int, blue: int, alpha: int} Returns an associative array with red, green, blue and alpha keys that
  * contain the appropriate values for the specified color index.
  *
  */
-function imagecolorsforindex(\GdImage $image, int $color): int
+function imagecolorsforindex(\GdImage $image, int $color): array
 {
     error_clear_last();
     $safeResult = \imagecolorsforindex($image, $color);

--- a/generated/8.4/json.php
+++ b/generated/8.4/json.php
@@ -42,7 +42,7 @@ use Safe\Exceptions\JsonException;
  * JSON_THROW_ON_ERROR.
  * The behaviour of these constants is described on the
  * JSON constants page.
- * @param int $depth Set the maximum depth. Must be greater than zero.
+ * @param positive-int $depth Set the maximum depth. Must be greater than zero.
  * @return non-empty-string Returns a JSON encoded string on success.
  * @throws JsonException
  *

--- a/generated/8.4/mbstring.php
+++ b/generated/8.4/mbstring.php
@@ -77,7 +77,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * Sets the automatic character
  * encoding detection order to encoding.
  *
- * @param non-empty-array|non-falsy-string|null $encoding encoding is an array or
+ * @param non-empty-list|non-falsy-string|null $encoding encoding is an array or
  * comma separated list of character encoding. See supported encodings.
  *
  * If encoding is omitted or NULL, it returns
@@ -96,7 +96,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * For UTF-16, UTF-32,
  * UCS2 and UCS4, encoding
  * detection will fail always.
- * @return array|bool When setting the encoding detection order, TRUE is returned on success.
+ * @return bool|list When setting the encoding detection order, TRUE is returned on success.
  *
  * When getting the encoding detection order, an ordered array of the encodings is returned.
  * @throws MbstringException
@@ -121,7 +121,7 @@ function mb_detect_order($encoding = null)
  * Returns an array of aliases for a known encoding type.
  *
  * @param string $encoding The encoding type being checked, for aliases.
- * @return array|false Returns a numerically indexed array of encoding aliases.
+ * @return false|list Returns a numerically indexed array of encoding aliases.
  *
  */
 function mb_encoding_aliases(string $encoding)
@@ -585,7 +585,7 @@ function mb_send_mail(string $to, string $subject, string $message, $additional_
  * @param string $pattern The regular expression pattern.
  * @param string $string The string being split.
  * @param int $limit
- * @return array The result as an array.
+ * @return list The result as an array.
  * @throws MbstringException
  *
  */

--- a/generated/8.4/network.php
+++ b/generated/8.4/network.php
@@ -46,7 +46,7 @@ function closelog(): bool
  * (the DNS_* constants cannot be used).
  * The return value will contain a data key, which needs
  * to be manually parsed.
- * @return array This function returns an array of associative arrays. Each associative array contains
+ * @return list This function returns an array of associative arrays. Each associative array contains
  * at minimum the following keys:
  *
  * Basic DNS attributes

--- a/generated/8.4/oci8.php
+++ b/generated/8.4/oci8.php
@@ -949,7 +949,7 @@ function oci_new_descriptor($connection, int $type = OCI_DTYPE_LOB)
  * Gets the number of rows affected during statement execution.
  *
  * @param resource $statement A valid OCI statement identifier.
- * @return int Returns the number of rows affected as an integer
+ * @return 0|positive-int Returns the number of rows affected as an integer
  * @throws Oci8Exception
  *
  */

--- a/generated/8.4/openssl.php
+++ b/generated/8.4/openssl.php
@@ -589,7 +589,7 @@ function openssl_digest(string $data, string $digest_algo, bool $binary = false)
  * NIST
  * recommends using ECC curves with at least 256 bits.
  *
- * @return array An array of available curve names.
+ * @return list An array of available curve names.
  * @throws OpensslException
  *
  */
@@ -1419,7 +1419,7 @@ function openssl_spki_verify(string $spki): void
  * @param int|string $algorithm int - one of these Signature Algorithms.
  *
  * string - a valid string returned by openssl_get_md_methods example, "sha1WithRSAEncryption" or "sha512".
- * @return int Returns 1 if the signature is correct, 0 if it is incorrect, and
+ * @return -1|0|1 Returns 1 if the signature is correct, 0 if it is incorrect, and
  * -1.
  * @throws OpensslException
  *

--- a/generated/8.4/pcre.php
+++ b/generated/8.4/pcre.php
@@ -369,7 +369,7 @@ function preg_grep(string $pattern, array $array, int $flags = 0): array
  *
  *
  * The above example will output:
- * @return int Returns the number of full pattern matches (which might be zero).
+ * @return 0|positive-int Returns the number of full pattern matches (which might be zero).
  * @throws PcreException
  *
  */
@@ -605,7 +605,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  *
  *
  * The above example will output:
- * @return int preg_match returns 1 if the pattern
+ * @return 0|1 preg_match returns 1 if the pattern
  * matches given subject, 0 if it does not.
  * @throws PcreException
  *
@@ -772,7 +772,7 @@ function preg_replace_callback($pattern, callable $callback, $subject, int $limi
  * value in an array where every element is an array consisting of the
  * matched string at offset 0 and its string offset
  * into subject at offset 1.
- * @return array Returns an array containing substrings of subject
+ * @return list Returns an array containing substrings of subject
  * split along boundaries matched by pattern.
  * @throws PcreException
  *

--- a/generated/8.4/posix.php
+++ b/generated/8.4/posix.php
@@ -60,7 +60,7 @@ function posix_eaccess(string $filename, int $flags = 0): void
  * Gets information about a group provided its id.
  *
  * @param int $group_id The group id.
- * @return array{name: string, passwd: string, gid: int, members: array} The array elements returned are:
+ * @return array{name: string, passwd: string, gid: int, members: list} The array elements returned are:
  *
  * The group information array
  *
@@ -124,7 +124,7 @@ function posix_getgrgid(int $group_id): array
  * Gets information about a group provided its name.
  *
  * @param string $name The name of the group
- * @return array{name: string, passwd: string, gid: int, members: array} Returns an array on success.
+ * @return array{name: string, passwd: string, gid: int, members: list} Returns an array on success.
  * The array elements returned are:
  *
  * The group information array
@@ -187,7 +187,7 @@ function posix_getgrnam(string $name): array
 /**
  * Gets the group set of the current process.
  *
- * @return array Returns an array of integers containing the numeric group ids of the group
+ * @return list Returns an array of integers containing the numeric group ids of the group
  * set of the current process.
  * @throws PosixException
  *

--- a/generated/8.4/stream.php
+++ b/generated/8.4/stream.php
@@ -455,7 +455,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * stream_set_timeout, as the
  * timeout only applies while making connecting
  * the socket.
- * @param int $flags Bitmask field which may be set to any combination of connection flags.
+ * @param int-mask $flags Bitmask field which may be set to any combination of connection flags.
  * Currently the select of connection flags is limited to
  * STREAM_CLIENT_CONNECT (default),
  * STREAM_CLIENT_ASYNC_CONNECT and

--- a/generated/8.4/zlib.php
+++ b/generated/8.4/zlib.php
@@ -271,7 +271,7 @@ function gzencode(string $data, int $level = -1, int $encoding = ZLIB_ENCODING_G
  * @param string $filename The file name.
  * @param int $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
- * @return array An array containing the file, one line per cell, empty lines included, and with newlines still attached.
+ * @return list An array containing the file, one line per cell, empty lines included, and with newlines still attached.
  * @throws ZlibException
  *
  */
@@ -670,7 +670,7 @@ function inflate_init(int $encoding, array $options = []): \InflateContext
  * contents written to standard output.
  * @param int $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
- * @return int Returns the number of (uncompressed) bytes read from the file on success
+ * @return 0|positive-int Returns the number of (uncompressed) bytes read from the file on success
  * @throws ZlibException
  *
  */

--- a/generated/8.5/dir.php
+++ b/generated/8.5/dir.php
@@ -131,7 +131,7 @@ function opendir(string $directory, $context = null)
  * directory.
  *
  * @param string $directory The directory that will be scanned.
- * @param int $sorting_order By default, the sorted order is alphabetical in ascending order.  If
+ * @param SCANDIR_SORT_ASCENDING|SCANDIR_SORT_DESCENDING|SCANDIR_SORT_NONE $sorting_order By default, the sorted order is alphabetical in ascending order.  If
  * the optional sorting_order is set to
  * SCANDIR_SORT_DESCENDING, then the sort order is
  * alphabetical in descending order. If it is set to
@@ -139,7 +139,7 @@ function opendir(string $directory, $context = null)
  * @param null|resource $context For a description of the context parameter,
  * refer to the streams section of
  * the manual.
- * @return array Returns an array of filenames on success. If directory is not a directory, then
+ * @return list Returns an array of filenames on success. If directory is not a directory, then
  * boolean FALSE is returned, and an error of level
  * E_WARNING is generated.
  * @throws DirException

--- a/generated/8.5/errorfunc.php
+++ b/generated/8.5/errorfunc.php
@@ -8,7 +8,7 @@ use Safe\Exceptions\ErrorfuncException;
  * Sends an error message to the web server's error log or to a file.
  *
  * @param string $message The error message that should be logged.
- * @param int $message_type Says where the error should go. The possible message types are as
+ * @param 0|1|2|3|4 $message_type Says where the error should go. The possible message types are as
  * follows:
  *
  *

--- a/generated/8.5/filesystem.php
+++ b/generated/8.5/filesystem.php
@@ -253,7 +253,7 @@ function fflush($stream): void
  * Seeking (offset) is not supported with remote files.
  * Attempting to seek on non-local files may work with small offsets, but this
  * is unpredictable because it works on the buffered stream.
- * @param int|null $length Maximum length of data read. The default is to read until end
+ * @param 0|null|positive-int $length Maximum length of data read. The default is to read until end
  * of file is reached. Note that this parameter is applied to the
  * stream processed by the filters.
  * @return string The function returns the read data.
@@ -349,7 +349,7 @@ function file_get_contents(string $filename, bool $use_include_path = false, $co
  *
  * @param null|resource $context A valid context resource created with
  * stream_context_create.
- * @return int This function returns the number of bytes that were written to the file.
+ * @return 0|positive-int This function returns the number of bytes that were written to the file.
  * @throws FilesystemException
  *
  */
@@ -372,7 +372,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  * Reads an entire file into an array.
  *
  * @param string $filename Path to the file.
- * @param int $flags The optional parameter flags can be one, or
+ * @param int-mask $flags The optional parameter flags can be one, or
  * more, of the following constants:
  *
  *
@@ -417,7 +417,7 @@ function file_put_contents(string $filename, $data, int $flags = 0, $context = n
  *
  *
  * @param null|resource $context
- * @return array Returns the file in an array. Each element of the array corresponds to a
+ * @return list Returns the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns FALSE.
  * @throws FilesystemException
@@ -577,7 +577,7 @@ function fileperms(string $filename): int
  * Gets the size for the given file.
  *
  * @param string $filename Path to the file.
- * @return int Returns the size of the file in bytes, or FALSE (and generates an error
+ * @return 0|positive-int Returns the size of the file in bytes, or FALSE (and generates an error
  * of level E_WARNING) in case of an error.
  * @throws FilesystemException
  *
@@ -632,7 +632,7 @@ function filetype(string $filename): string
  *
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
- * @param int $operation operation is one of the following:
+ * @param int-mask $operation operation is one of the following:
  *
  *
  *
@@ -654,7 +654,7 @@ function filetype(string $filename): string
  * It is also possible to add LOCK_NB as a bitmask to one
  * of the above operations, if flock should not
  * block during the locking attempt.
- * @param int|null $would_block The optional third argument is set to 1 if the lock would block
+ * @param 0|1|null $would_block The optional third argument is set to 1 if the lock would block
  * (EWOULDBLOCK errno condition).
  * @throws FilesystemException
  *
@@ -917,7 +917,7 @@ function fopen(string $filename, string $mode, bool $use_include_path = false, $
  *
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
- * @param int $length Up to length number of bytes read.
+ * @param positive-int $length Up to length number of bytes read.
  * @return string Returns the read string.
  * @throws FilesystemException
  *
@@ -1011,7 +1011,7 @@ function ftell($stream): int
  * @param resource $stream The file pointer.
  *
  * The stream must be open for writing.
- * @param int $size The size to truncate to.
+ * @param 0|positive-int $size The size to truncate to.
  *
  * If size is larger than the file then the file
  * is extended with null bytes.
@@ -1037,10 +1037,10 @@ function ftruncate($stream, int $size): void
  * @param resource $stream A file system pointer resource
  * that is typically created using fopen.
  * @param string $data The string that is to be written.
- * @param int|null $length If length is an integer, writing will stop
+ * @param 0|null|positive-int $length If length is an integer, writing will stop
  * after length bytes have been written or the
  * end of data is reached, whichever comes first.
- * @return int
+ * @return 0|positive-int
  * @throws FilesystemException
  *
  */
@@ -1094,7 +1094,7 @@ function fwrite($stream, string $data, ?int $length = null): int
  *
  *
  * @param int $flags Any of the GLOB_* constants.
- * @return array Returns an array containing the matched files/directories, an empty array
+ * @return list Returns an array containing the matched files/directories, an empty array
  * if no file matched.
  * Unless GLOB_NOSORT was used, the names will
  * be sorted alphanumerically.
@@ -1385,7 +1385,7 @@ function popen(string $command, string $mode)
  * you want to search for the file in the include_path, too.
  * @param null|resource $context A context stream
  * resource.
- * @return int Returns the number of bytes read from the file on success
+ * @return 0|positive-int Returns the number of bytes read from the file on success
  * @throws FilesystemException
  *
  */

--- a/generated/8.5/fpm.php
+++ b/generated/8.5/fpm.php
@@ -30,11 +30,11 @@ function fastcgi_finish_request(): void
  *
  * Note that this function will only be defined if FPM is being used to serve the script.
  *
- * @return int Associative array containing the full FPM pool status.
+ * @return array{pool: string, process-manager: 'dynamic'|'ondemand'|'static', start-time: int, start-since: int, accepted-conn: int, listen-queue: int, max-listen-queue: int, listen-queue-len: int, idle-processes: int, active-processes: int, total-processes: int, max-active-processes: int, max-children-reached: 0|1, slow-requests: int, procs: array} Associative array containing the full FPM pool status.
  * @throws FpmException
  *
  */
-function fpm_get_status(): int
+function fpm_get_status(): array
 {
     error_clear_last();
     $safeResult = \fpm_get_status();

--- a/generated/8.5/ftp.php
+++ b/generated/8.5/ftp.php
@@ -31,7 +31,7 @@ function ftp_alloc(\FTP\Connection $ftp, int $size, ?string &$response = null): 
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename
  * @param string $local_filename
- * @param int $mode
+ * @param FTP_ASCII|FTP_BINARY $mode
  * @throws FtpException
  *
  */
@@ -173,7 +173,7 @@ function ftp_delete(\FTP\Connection $ftp, string $filename): void
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param resource $stream An open file pointer in which we store the data.
  * @param string $remote_filename The remote file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start downloading from.
  * @throws FtpException
@@ -196,7 +196,7 @@ function ftp_fget(\FTP\Connection $ftp, $stream, string $remote_filename, int $m
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param resource $stream An open file pointer on the local file. Reading stops at end of file.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @throws FtpException
@@ -219,7 +219,7 @@ function ftp_fput(\FTP\Connection $ftp, string $remote_filename, $stream, int $m
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $local_filename The local file path (will be overwritten if the file already exists).
  * @param string $remote_filename The remote file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start downloading from.
  * @throws FtpException
@@ -305,7 +305,7 @@ function ftp_mlsd(\FTP\Connection $ftp, string $directory): array
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $local_filename The local file path (will be overwritten if the file already exists).
  * @param string $remote_filename The remote file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start downloading from.
  * @return int Returns FTP_FAILED or FTP_FINISHED
@@ -334,7 +334,7 @@ function ftp_nb_get(\FTP\Connection $ftp, string $local_filename, string $remote
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param string $local_filename The local file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @return int Returns FTP_FAILED or FTP_FINISHED
@@ -406,7 +406,7 @@ function ftp_pasv(\FTP\Connection $ftp, bool $enable): void
  * @param \FTP\Connection $ftp An FTP\Connection instance.
  * @param string $remote_filename The remote file path.
  * @param string $local_filename The local file path.
- * @param int $mode The transfer mode. Must be either FTP_ASCII or
+ * @param FTP_ASCII|FTP_BINARY $mode The transfer mode. Must be either FTP_ASCII or
  * FTP_BINARY.
  * @param int $offset The position in the remote file to start uploading to.
  * @throws FtpException

--- a/generated/8.5/ibmDb2.php
+++ b/generated/8.5/ibmDb2.php
@@ -522,7 +522,7 @@ function db2_get_option($resource, string $option): string
  * and branch if the fetch function returns FALSE.
  *
  * @param resource $stmt A valid stmt resource containing a result set.
- * @return int Returns the number of rows affected by the last SQL statement issued by
+ * @return 0|positive-int Returns the number of rows affected by the last SQL statement issued by
  * the specified statement handle
  * @throws IbmDb2Exception
  *

--- a/generated/8.5/iconv.php
+++ b/generated/8.5/iconv.php
@@ -252,7 +252,7 @@ function iconv_set_encoding(string $type, string $encoding): void
  * @param null|string $encoding If encoding parameter is omitted or NULL,
  * string is assumed to be encoded in
  * iconv.internal_encoding.
- * @return int Returns the character count of string, as an integer,
+ * @return 0|positive-int Returns the character count of string, as an integer,
  * or FALSE if an error occurs during the encoding.
  * @throws IconvException
  *

--- a/generated/8.5/image.php
+++ b/generated/8.5/image.php
@@ -479,11 +479,11 @@ function imagecolorset(\GdImage $image, int $color, int $red, int $green, int $b
  * @param \GdImage $image A GdImage object, returned by one of the image creation functions,
  * such as imagecreatetruecolor.
  * @param int $color The color index.
- * @return int Returns an associative array with red, green, blue and alpha keys that
+ * @return array{red: int, green: int, blue: int, alpha: int} Returns an associative array with red, green, blue and alpha keys that
  * contain the appropriate values for the specified color index.
  *
  */
-function imagecolorsforindex(\GdImage $image, int $color): int
+function imagecolorsforindex(\GdImage $image, int $color): array
 {
     error_clear_last();
     $safeResult = \imagecolorsforindex($image, $color);

--- a/generated/8.5/json.php
+++ b/generated/8.5/json.php
@@ -42,7 +42,7 @@ use Safe\Exceptions\JsonException;
  * JSON_THROW_ON_ERROR.
  * The behaviour of these constants is described on the
  * JSON constants page.
- * @param int $depth Set the maximum depth. Must be greater than zero.
+ * @param positive-int $depth Set the maximum depth. Must be greater than zero.
  * @return non-empty-string Returns a JSON encoded string on success.
  * @throws JsonException
  *

--- a/generated/8.5/mbstring.php
+++ b/generated/8.5/mbstring.php
@@ -77,7 +77,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * Sets the automatic character
  * encoding detection order to encoding.
  *
- * @param non-empty-array|non-falsy-string|null $encoding encoding is an array or
+ * @param non-empty-list|non-falsy-string|null $encoding encoding is an array or
  * comma separated list of character encoding. See supported encodings.
  *
  * If encoding is omitted or NULL, it returns
@@ -96,7 +96,7 @@ function mb_convert_encoding($string, string $to_encoding, $from_encoding = null
  * For UTF-16, UTF-32,
  * UCS2 and UCS4, encoding
  * detection will fail always.
- * @return array|bool When setting the encoding detection order, TRUE is returned on success.
+ * @return bool|list When setting the encoding detection order, TRUE is returned on success.
  *
  * When getting the encoding detection order, an ordered array of the encodings is returned.
  * @throws MbstringException
@@ -121,7 +121,7 @@ function mb_detect_order($encoding = null)
  * Returns an array of aliases for a known encoding type.
  *
  * @param string $encoding The encoding type being checked, for aliases.
- * @return array|false Returns a numerically indexed array of encoding aliases.
+ * @return false|list Returns a numerically indexed array of encoding aliases.
  *
  */
 function mb_encoding_aliases(string $encoding)
@@ -585,7 +585,7 @@ function mb_send_mail(string $to, string $subject, string $message, $additional_
  * @param string $pattern The regular expression pattern.
  * @param string $string The string being split.
  * @param int $limit
- * @return array The result as an array.
+ * @return list The result as an array.
  * @throws MbstringException
  *
  */

--- a/generated/8.5/network.php
+++ b/generated/8.5/network.php
@@ -46,7 +46,7 @@ function closelog(): bool
  * (the DNS_* constants cannot be used).
  * The return value will contain a data key, which needs
  * to be manually parsed.
- * @return array This function returns an array of associative arrays. Each associative array contains
+ * @return list This function returns an array of associative arrays. Each associative array contains
  * at minimum the following keys:
  *
  * Basic DNS attributes

--- a/generated/8.5/oci8.php
+++ b/generated/8.5/oci8.php
@@ -949,7 +949,7 @@ function oci_new_descriptor($connection, int $type = OCI_DTYPE_LOB)
  * Gets the number of rows affected during statement execution.
  *
  * @param resource $statement A valid OCI statement identifier.
- * @return int Returns the number of rows affected as an integer
+ * @return 0|positive-int Returns the number of rows affected as an integer
  * @throws Oci8Exception
  *
  */

--- a/generated/8.5/openssl.php
+++ b/generated/8.5/openssl.php
@@ -597,7 +597,7 @@ function openssl_digest(string $data, string $digest_algo, bool $binary = false)
  * NIST
  * recommends using ECC curves with at least 256 bits.
  *
- * @return array An array of available curve names.
+ * @return list An array of available curve names.
  * @throws OpensslException
  *
  */
@@ -1766,7 +1766,7 @@ function openssl_spki_verify(string $spki): void
  * @param int|string $algorithm int - one of these Signature Algorithms.
  *
  * string - a valid string returned by openssl_get_md_methods example, "sha1WithRSAEncryption" or "sha512".
- * @return int Returns 1 if the signature is correct, 0 if it is incorrect, and
+ * @return -1|0|1 Returns 1 if the signature is correct, 0 if it is incorrect, and
  * -1.
  * @throws OpensslException
  *

--- a/generated/8.5/pcre.php
+++ b/generated/8.5/pcre.php
@@ -369,7 +369,7 @@ function preg_grep(string $pattern, array $array, int $flags = 0): array
  *
  *
  * The above example will output:
- * @return int Returns the number of full pattern matches (which might be zero).
+ * @return 0|positive-int Returns the number of full pattern matches (which might be zero).
  * @throws PcreException
  *
  */
@@ -605,7 +605,7 @@ function preg_match_all(string $pattern, string $subject, ?array &$matches = nul
  *
  *
  * The above example will output:
- * @return int preg_match returns 1 if the pattern
+ * @return 0|1 preg_match returns 1 if the pattern
  * matches given subject, 0 if it does not.
  * @throws PcreException
  *
@@ -772,7 +772,7 @@ function preg_replace_callback($pattern, callable $callback, $subject, int $limi
  * value in an array where every element is an array consisting of the
  * matched string at offset 0 and its string offset
  * into subject at offset 1.
- * @return array Returns an array containing substrings of subject
+ * @return list Returns an array containing substrings of subject
  * split along boundaries matched by pattern.
  * @throws PcreException
  *

--- a/generated/8.5/posix.php
+++ b/generated/8.5/posix.php
@@ -60,7 +60,7 @@ function posix_eaccess(string $filename, int $flags = 0): void
  * Gets information about a group provided its id.
  *
  * @param int $group_id The group id.
- * @return array{name: string, passwd: string, gid: int, members: array} The array elements returned are:
+ * @return array{name: string, passwd: string, gid: int, members: list} The array elements returned are:
  *
  * The group information array
  *
@@ -124,7 +124,7 @@ function posix_getgrgid(int $group_id): array
  * Gets information about a group provided its name.
  *
  * @param string $name The name of the group
- * @return array{name: string, passwd: string, gid: int, members: array} Returns an array on success.
+ * @return array{name: string, passwd: string, gid: int, members: list} Returns an array on success.
  * The array elements returned are:
  *
  * The group information array
@@ -187,7 +187,7 @@ function posix_getgrnam(string $name): array
 /**
  * Gets the group set of the current process.
  *
- * @return array Returns an array of integers containing the numeric group ids of the group
+ * @return list Returns an array of integers containing the numeric group ids of the group
  * set of the current process.
  * @throws PosixException
  *

--- a/generated/8.5/stream.php
+++ b/generated/8.5/stream.php
@@ -455,7 +455,7 @@ function stream_socket_accept($socket, ?float $timeout = null, ?string &$peer_na
  * stream_set_timeout, as the
  * timeout only applies while making connecting
  * the socket.
- * @param int $flags Bitmask field which may be set to any combination of connection flags.
+ * @param int-mask $flags Bitmask field which may be set to any combination of connection flags.
  * Currently the select of connection flags is limited to
  * STREAM_CLIENT_CONNECT (default),
  * STREAM_CLIENT_ASYNC_CONNECT and

--- a/generated/8.5/zlib.php
+++ b/generated/8.5/zlib.php
@@ -271,7 +271,7 @@ function gzencode(string $data, int $level = -1, int $encoding = ZLIB_ENCODING_G
  * @param string $filename The file name.
  * @param int $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
- * @return array An array containing the file, one line per cell, empty lines included, and with newlines still attached.
+ * @return list An array containing the file, one line per cell, empty lines included, and with newlines still attached.
  * @throws ZlibException
  *
  */
@@ -670,7 +670,7 @@ function inflate_init(int $encoding, array $options = []): \InflateContext
  * contents written to standard output.
  * @param int $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
- * @return int Returns the number of (uncompressed) bytes read from the file on success
+ * @return 0|positive-int Returns the number of (uncompressed) bytes read from the file on success
  * @throws ZlibException
  *
  */

--- a/generator/src/XmlDocParser/Type.php
+++ b/generator/src/XmlDocParser/Type.php
@@ -15,6 +15,15 @@ class Type
             return false;
         }
 
+        // phpstan allows literals as type hints, these shouldn't be namespaced
+        if (is_numeric($type)) {
+            return false;
+        }
+        // constants like FTP_ASCII, FTP_BINARY
+        if (defined($type) && is_numeric(constant($type))) {
+            return false;
+        }
+
         // Non-standard lowercase classes
         if (in_array($type, ['stdClass', 'finfo'])) {
             return true;

--- a/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
+++ b/generator/tests/PhpStanFunctions/PhpStanTypeTest.php
@@ -166,24 +166,29 @@ class PhpStanTypeTest extends TestCase
         $this->assertEquals('string', $param->getSignatureType(ErrorType::FALSY));
     }
 
-    public function testPositiveIntBecomingInt(): void
-    {
-        $param = new PhpStanType('positive-int');
-        $this->assertEquals('int', $param->getDocBlockType());
-        $this->assertEquals('int', $param->getSignatureType());
-    }
-
     public function testListBecomingArray(): void
     {
         $param = new PhpStanType('list<string>|false');
-        $this->assertEquals('array<string>', $param->getDocBlockType(ErrorType::FALSY));
+        $this->assertEquals('list<string>', $param->getDocBlockType(ErrorType::FALSY));
         $this->assertEquals('array', $param->getSignatureType(ErrorType::FALSY));
     }
 
-    public function testNumbersAreRemoved(): void
+    public function testIntGeneralisation(): void
     {
+        // PHP only supports "int" rather than specific values or ranges,
+        // but being specific in the docblock brings significant benefits
+        // when combined with tools like phpstan, see:
+        // https://github.com/thecodingmachine/phpstan-safe-rule/issues/52
+        $param = new PhpStanType('positive-int');
+        $this->assertEquals('positive-int', $param->getDocBlockType());
+        $this->assertEquals('int', $param->getSignatureType());
+
         $param = new PhpStanType('0|positive-int');
-        $this->assertEquals('int', $param->getDocBlockType());
+        $this->assertEquals('0|positive-int', $param->getDocBlockType());
+        $this->assertEquals('int', $param->getSignatureType());
+
+        $param = new PhpStanType('0|1');
+        $this->assertEquals('0|1', $param->getDocBlockType());
         $this->assertEquals('int', $param->getSignatureType());
     }
 


### PR DESCRIPTION

We're already using PHPStan's more-specific-types _some_ of the time - let's do it consistently?

See also: https://github.com/thecodingmachine/phpstan-safe-rule/issues/52
