### PR TITLE
[array_combine] override phpstan's incorrect function map, fixes #646

### DIFF
--- a/generated/8.2/array.php
+++ b/generated/8.2/array.php
@@ -12,10 +12,10 @@ use Safe\Exceptions\ArrayException;
  * @param array $keys Array of keys to be used. Illegal values for key will be
  * converted to string.
  * @param array $values Array of values to be used
- * @return array|false Returns the combined array.
+ * @return array Returns the combined array.
  *
  */
-function array_combine(array $keys, array $values)
+function array_combine(array $keys, array $values): array
 {
     error_clear_last();
     $safeResult = \array_combine($keys, $values);

--- a/generated/8.3/array.php
+++ b/generated/8.3/array.php
@@ -12,10 +12,10 @@ use Safe\Exceptions\ArrayException;
  * @param array $keys Array of keys to be used. Illegal values for key will be
  * converted to string.
  * @param array $values Array of values to be used
- * @return array|false Returns the combined array.
+ * @return array Returns the combined array.
  *
  */
-function array_combine(array $keys, array $values)
+function array_combine(array $keys, array $values): array
 {
     error_clear_last();
     $safeResult = \array_combine($keys, $values);

--- a/generated/8.4/array.php
+++ b/generated/8.4/array.php
@@ -38,10 +38,10 @@ function array_all(array $array, callable $callback): void
  * @param array $keys Array of keys to be used. Illegal values for key will be
  * converted to string.
  * @param array $values Array of values to be used
- * @return array|false Returns the combined array.
+ * @return array Returns the combined array.
  *
  */
-function array_combine(array $keys, array $values)
+function array_combine(array $keys, array $values): array
 {
     error_clear_last();
     $safeResult = \array_combine($keys, $values);

--- a/generated/8.5/array.php
+++ b/generated/8.5/array.php
@@ -38,10 +38,10 @@ function array_all(array $array, callable $callback): void
  * @param array $keys Array of keys to be used. Illegal values for key will be
  * converted to string.
  * @param array $values Array of values to be used
- * @return array|false Returns the combined array.
+ * @return array Returns the combined array.
  *
  */
-function array_combine(array $keys, array $values)
+function array_combine(array $keys, array $values): array
 {
     error_clear_last();
     $safeResult = \array_combine($keys, $values);

--- a/generator/config/CustomPhpStanFunctionMap.php
+++ b/generator/config/CustomPhpStanFunctionMap.php
@@ -7,6 +7,7 @@
  */
 
 return [
+    'array_combine' => ['array', 'keys'=>'array', 'values'=>'array'], // doesn't return false
     'base64_decode' => ['string|false', 'str'=>'string', 'strict='=>'bool'], // base64_decode returns false only in strict mode https://github.com/phpstan/phpstan-src/commit/cee66721266ae05f3cc052f82391d2645d74d55f
     'com_load_typelib' => ['bool', 'typelib_name'=>'string', 'case_insensitive='=>'bool'], // case_insensitive is a bool
     'sem_get' => ['resource|false', 'key'=>'int', 'max_acquire='=>'int', 'perm='=>'int', 'auto_release='=>'bool'], // auto_release is a bool


### PR DESCRIPTION

`array_combine` throws an exception on error, no longer returning false
