### PR TITLE
[generator] use libxml internal errors

### DIFF
--- a/generator/src/XmlDocParser/DocPage.php
+++ b/generator/src/XmlDocParser/DocPage.php
@@ -126,6 +126,7 @@ class DocPage
             .'<!DOCTYPE refentry SYSTEM "'.$path.'">'
             .\substr($content, $strpos+1);
 
+        libxml_use_internal_errors(true);
         $elem = \simplexml_load_string($content, \SimpleXMLElement::class, LIBXML_DTDLOAD | LIBXML_NOENT);
         if ($elem === false) {
             throw new \RuntimeException('Invalid XML file for '.$this->path);


### PR DESCRIPTION

printing huuuuge warning stack traces to stdout is unhelpful
