### PR TITLE
`openssl_random_pseudo_bytes` always returns string (closes #654)

### DIFF
--- a/generated/8.2/openssl.php
+++ b/generated/8.2/openssl.php
@@ -1191,10 +1191,10 @@ function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_
  * @param bool|null $strong_result If passed into the function, this will hold a bool value that determines
  * if the algorithm used was "cryptographically strong", e.g., safe for usage with GPG,
  * passwords, etc. TRUE if it did, otherwise FALSE
- * @return false|string Returns the generated string of bytes.
+ * @return string Returns the generated string of bytes.
  *
  */
-function openssl_random_pseudo_bytes(int $length, ?bool &$strong_result = null)
+function openssl_random_pseudo_bytes(int $length, ?bool &$strong_result = null): string
 {
     error_clear_last();
     $safeResult = \openssl_random_pseudo_bytes($length, $strong_result);

--- a/generated/8.3/openssl.php
+++ b/generated/8.3/openssl.php
@@ -1191,10 +1191,10 @@ function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_
  * @param bool|null $strong_result If passed into the function, this will hold a bool value that determines
  * if the algorithm used was "cryptographically strong", e.g., safe for usage with GPG,
  * passwords, etc. TRUE if it did, otherwise FALSE
- * @return false|string Returns the generated string of bytes.
+ * @return string Returns the generated string of bytes.
  *
  */
-function openssl_random_pseudo_bytes(int $length, ?bool &$strong_result = null)
+function openssl_random_pseudo_bytes(int $length, ?bool &$strong_result = null): string
 {
     error_clear_last();
     $safeResult = \openssl_random_pseudo_bytes($length, $strong_result);

--- a/generated/8.4/openssl.php
+++ b/generated/8.4/openssl.php
@@ -1240,10 +1240,10 @@ function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_
  * @param bool|null $strong_result If passed into the function, this will hold a bool value that determines
  * if the algorithm used was "cryptographically strong", e.g., safe for usage with GPG,
  * passwords, etc. TRUE if it did, otherwise FALSE
- * @return false|string Returns the generated string of bytes.
+ * @return string Returns the generated string of bytes.
  *
  */
-function openssl_random_pseudo_bytes(int $length, ?bool &$strong_result = null)
+function openssl_random_pseudo_bytes(int $length, ?bool &$strong_result = null): string
 {
     error_clear_last();
     $safeResult = \openssl_random_pseudo_bytes($length, $strong_result);

--- a/generated/8.5/openssl.php
+++ b/generated/8.5/openssl.php
@@ -1587,10 +1587,10 @@ function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_
  * @param bool|null $strong_result If passed into the function, this will hold a bool value that determines
  * if the algorithm used was "cryptographically strong", e.g., safe for usage with GPG,
  * passwords, etc. TRUE if it did, otherwise FALSE
- * @return false|string Returns the generated string of bytes.
+ * @return string Returns the generated string of bytes.
  *
  */
-function openssl_random_pseudo_bytes(int $length, ?bool &$strong_result = null)
+function openssl_random_pseudo_bytes(int $length, ?bool &$strong_result = null): string
 {
     error_clear_last();
     $safeResult = \openssl_random_pseudo_bytes($length, $strong_result);

--- a/generator/config/CustomPhpStanFunctionMap.php
+++ b/generator/config/CustomPhpStanFunctionMap.php
@@ -15,6 +15,7 @@ return [
     'imagerotate' => ['resource|false', 'src_im'=>'resource', 'angle'=>'float', 'bgdcolor'=>'int', 'ignoretransparent='=>'bool'], //ignoretransparent is a bool instead of a int
     'get_headers' => ['array|false', 'url'=>'string', 'format='=>'bool', 'context='=>'resource'], // format is a bool instead of int
     'imagegrabwindow' => ['GdImage|false', 'handle'=>'int', 'client_area'=>'bool'], // client_area is a bool instead of an int
+    'openssl_random_pseudo_bytes' => ['string', 'length'=>'int', '&strong_result='=>'bool'],
 
     // theses replace resource by OpenSSLAsymmetricKey
     'openssl_pkey_get_private' => ['OpenSSLAsymmetricKey|false', 'private_key'=>'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string', 'passphrase='=>'null|string'],


### PR DESCRIPTION
Closes #654