### PR TITLE
Add `openssl_pkey_get_details` function missing in PHP < 8.4

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -678,6 +678,7 @@ return [
     'openssl_pkey_derive',
     'openssl_pkey_export',
     'openssl_pkey_export_to_file',
+    'openssl_pkey_get_details',
     'openssl_pkey_get_private',
     'openssl_pkey_get_public',
     'openssl_pkey_new',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -686,6 +686,7 @@ return static function (RectorConfig $rectorConfig): void {
             'openssl_pkey_derive' => 'Safe\openssl_pkey_derive',
             'openssl_pkey_export' => 'Safe\openssl_pkey_export',
             'openssl_pkey_export_to_file' => 'Safe\openssl_pkey_export_to_file',
+            'openssl_pkey_get_details' => 'Safe\openssl_pkey_get_details',
             'openssl_pkey_get_private' => 'Safe\openssl_pkey_get_private',
             'openssl_pkey_get_public' => 'Safe\openssl_pkey_get_public',
             'openssl_pkey_new' => 'Safe\openssl_pkey_new',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -676,6 +676,7 @@ return [
     'openssl_pkey_derive',
     'openssl_pkey_export',
     'openssl_pkey_export_to_file',
+    'openssl_pkey_get_details',
     'openssl_pkey_get_private',
     'openssl_pkey_get_public',
     'openssl_pkey_new',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -684,6 +684,7 @@ return static function (RectorConfig $rectorConfig): void {
             'openssl_pkey_derive' => 'Safe\openssl_pkey_derive',
             'openssl_pkey_export' => 'Safe\openssl_pkey_export',
             'openssl_pkey_export_to_file' => 'Safe\openssl_pkey_export_to_file',
+            'openssl_pkey_get_details' => 'Safe\openssl_pkey_get_details',
             'openssl_pkey_get_private' => 'Safe\openssl_pkey_get_private',
             'openssl_pkey_get_public' => 'Safe\openssl_pkey_get_public',
             'openssl_pkey_new' => 'Safe\openssl_pkey_new',

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -676,6 +676,7 @@ return [
     'openssl_pkey_derive',
     'openssl_pkey_export',
     'openssl_pkey_export_to_file',
+    'openssl_pkey_get_details',
     'openssl_pkey_get_private',
     'openssl_pkey_get_public',
     'openssl_pkey_new',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -684,6 +684,7 @@ return static function (RectorConfig $rectorConfig): void {
             'openssl_pkey_derive' => 'Safe\openssl_pkey_derive',
             'openssl_pkey_export' => 'Safe\openssl_pkey_export',
             'openssl_pkey_export_to_file' => 'Safe\openssl_pkey_export_to_file',
+            'openssl_pkey_get_details' => 'Safe\openssl_pkey_get_details',
             'openssl_pkey_get_private' => 'Safe\openssl_pkey_get_private',
             'openssl_pkey_get_public' => 'Safe\openssl_pkey_get_public',
             'openssl_pkey_new' => 'Safe\openssl_pkey_new',

--- a/generated/8.4/openssl.php
+++ b/generated/8.4/openssl.php
@@ -986,35 +986,6 @@ function openssl_pkey_export($key, ?string &$output, ?string $passphrase = null,
 
 
 /**
- * This function returns the key details (bits, key, type).
- *
- * @param \OpenSSLAsymmetricKey $key Resource holding the key.
- * @return array Returns an array with the key details on success.
- * Returned array has indexes bits (number of bits),
- * key (string representation of the public key) and
- * type (type of the key which is one of
- * OPENSSL_KEYTYPE_RSA,
- * OPENSSL_KEYTYPE_DSA,
- * OPENSSL_KEYTYPE_DH,
- * OPENSSL_KEYTYPE_EC or -1 meaning unknown).
- *
- * Depending on the key type used, additional details may be returned. Note that
- * some elements may not always be available.
- * @throws OpensslException
- *
- */
-function openssl_pkey_get_details(\OpenSSLAsymmetricKey $key): array
-{
-    error_clear_last();
-    $safeResult = \openssl_pkey_get_details($key);
-    if ($safeResult === false) {
-        throw OpensslException::createFromPhpError();
-    }
-    return $safeResult;
-}
-
-
-/**
  * openssl_pkey_get_private parses
  * private_key and prepares it for use by other functions.
  *

--- a/generated/8.5/openssl.php
+++ b/generated/8.5/openssl.php
@@ -994,40 +994,6 @@ function openssl_pkey_export($key, ?string &$output, ?string $passphrase = null,
 
 
 /**
- * This function returns the key details (bits, key, type).
- *
- * @param \OpenSSLAsymmetricKey $key Resource holding the key.
- * @return array Returns an array with the key details on success.
- * Returned array has indexes bits (number of bits),
- * key (string representation of the public key) and
- * type (type of the key which is one of
- * OPENSSL_KEYTYPE_RSA,
- * OPENSSL_KEYTYPE_DSA,
- * OPENSSL_KEYTYPE_DH,
- * OPENSSL_KEYTYPE_EC,
- * OPENSSL_KEYTYPE_X25519,
- * OPENSSL_KEYTYPE_ED25519,
- * OPENSSL_KEYTYPE_X448,
- * OPENSSL_KEYTYPE_ED448,
- * or -1 meaning unknown).
- *
- * Depending on the key type used, additional details may be returned. Note that
- * some elements may not always be available.
- * @throws OpensslException
- *
- */
-function openssl_pkey_get_details(\OpenSSLAsymmetricKey $key): array
-{
-    error_clear_last();
-    $safeResult = \openssl_pkey_get_details($key);
-    if ($safeResult === false) {
-        throw OpensslException::createFromPhpError();
-    }
-    return $safeResult;
-}
-
-
-/**
  * openssl_pkey_get_private parses
  * private_key and prepares it for use by other functions.
  *

--- a/generator/config/CustomPhpStanFunctionMap.php
+++ b/generator/config/CustomPhpStanFunctionMap.php
@@ -19,6 +19,7 @@ return [
     'openssl_random_pseudo_bytes' => ['string', 'length'=>'int', '&strong_result='=>'bool'],
 
     // theses replace resource by OpenSSLAsymmetricKey
+    'openssl_pkey_get_details' => ['array|false', 'key'=>'OpenSSLAsymmetricKey'],
     'openssl_pkey_get_private' => ['OpenSSLAsymmetricKey|false', 'private_key'=>'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string', 'passphrase='=>'null|string'],
     'openssl_pkey_get_public' => ['OpenSSLAsymmetricKey|false', 'public_key'=>'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string'],
     'openssl_csr_sign' => ['resource|false', 'csr'=>'string|OpenSSLCertificateSigningRequest', 'ca_certificate'=>'string|OpenSSLCertificate|null', 'private_key'=>'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string', 'days'=>'int', 'options='=>'array', 'serial='=>'int', 'serial_hex='=>'string|null'],

--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -181,6 +181,34 @@ function openssl_encrypt(string $data, string $method, string $key, int $options
 }
 
 /**
+ * This function returns the key details (bits, key, type).
+ *
+ * @param \OpenSSLAsymmetricKey $key Resource holding the key.
+ * @return array Returns an array with the key details on success.
+ * Returned array has indexes bits (number of bits),
+ * key (string representation of the public key) and
+ * type (type of the key which is one of
+ * OPENSSL_KEYTYPE_RSA,
+ * OPENSSL_KEYTYPE_DSA,
+ * OPENSSL_KEYTYPE_DH,
+ * OPENSSL_KEYTYPE_EC or -1 meaning unknown).
+ *
+ * Depending on the key type used, additional details may be returned. Note that
+ * some elements may not always be available.
+ * @throws OpensslException
+ *
+ */
+function openssl_pkey_get_details(\OpenSSLAsymmetricKey $key): array
+{
+    error_clear_last();
+    $safeResult = \openssl_pkey_get_details($key);
+    if ($safeResult === false) {
+        throw OpensslException::createFromPhpError();
+    }
+    return $safeResult;
+}
+
+/**
  * The function socket_write writes to the
  * socket from the given
  * buffer.


### PR DESCRIPTION
The `openssl_pkey_get_details()` function is not generated in PHP < 8.4.

I hope adding it in this file will make it available for all PHP versions.