### PR TITLE
Hide the already safe `pack()` function

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -701,7 +701,6 @@ return [
     'openssl_x509_read',
     'output_add_rewrite_var',
     'output_reset_rewrite_vars',
-    'pack',
     'parse_ini_file',
     'parse_ini_string',
     'parse_url',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -709,7 +709,6 @@ return static function (RectorConfig $rectorConfig): void {
             'openssl_x509_read' => 'Safe\openssl_x509_read',
             'output_add_rewrite_var' => 'Safe\output_add_rewrite_var',
             'output_reset_rewrite_vars' => 'Safe\output_reset_rewrite_vars',
-            'pack' => 'Safe\pack',
             'parse_ini_file' => 'Safe\parse_ini_file',
             'parse_ini_string' => 'Safe\parse_ini_string',
             'parse_url' => 'Safe\parse_url',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -698,7 +698,6 @@ return [
     'openssl_x509_read',
     'output_add_rewrite_var',
     'output_reset_rewrite_vars',
-    'pack',
     'parse_ini_file',
     'parse_ini_string',
     'parse_url',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -706,7 +706,6 @@ return static function (RectorConfig $rectorConfig): void {
             'openssl_x509_read' => 'Safe\openssl_x509_read',
             'output_add_rewrite_var' => 'Safe\output_add_rewrite_var',
             'output_reset_rewrite_vars' => 'Safe\output_reset_rewrite_vars',
-            'pack' => 'Safe\pack',
             'parse_ini_file' => 'Safe\parse_ini_file',
             'parse_ini_string' => 'Safe\parse_ini_string',
             'parse_url' => 'Safe\parse_url',

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -698,7 +698,6 @@ return [
     'openssl_x509_read',
     'output_add_rewrite_var',
     'output_reset_rewrite_vars',
-    'pack',
     'parse_ini_file',
     'parse_ini_string',
     'parse_url',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -706,7 +706,6 @@ return static function (RectorConfig $rectorConfig): void {
             'openssl_x509_read' => 'Safe\openssl_x509_read',
             'output_add_rewrite_var' => 'Safe\output_add_rewrite_var',
             'output_reset_rewrite_vars' => 'Safe\output_reset_rewrite_vars',
-            'pack' => 'Safe\pack',
             'parse_ini_file' => 'Safe\parse_ini_file',
             'parse_ini_string' => 'Safe\parse_ini_string',
             'parse_url' => 'Safe\parse_url',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -10,4 +10,5 @@ return [
     'array_all', // false is not an error
     'sodium_crypto_auth_verify', // boolean return value is expected from verify
     'sodium_crypto_sign_verify_detached', // boolean return value is expected from verify
+    'pack', // this function no longer returns false since PHP 8.0, but the doc has only been updated since PHP 8.4
 ];


### PR DESCRIPTION
The `pack()` function is already safe since PHP 8.0, but its documentation has only been fixed in PHP 8.4.

With the current state of the generated code, PHPStan results differs depending on the PHP version. In PHP < 8.4, it considers the usage of `pack` as unsafe while it does not consider it is an issue in PHP 8.4. This requires to create a specific PHPStan baseline for PHP < 8.4 when the target project PHPStan checks are expected to pass on every supported PHP version.
