### PR TITLE
Ignore the already safe `date()` function

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -108,7 +108,6 @@ return [
     'curl_share_errno',
     'curl_share_setopt',
     'curl_unescape',
-    'date',
     'date_parse',
     'date_parse_from_format',
     'date_sunrise',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -116,7 +116,6 @@ return static function (RectorConfig $rectorConfig): void {
             'curl_share_errno' => 'Safe\curl_share_errno',
             'curl_share_setopt' => 'Safe\curl_share_setopt',
             'curl_unescape' => 'Safe\curl_unescape',
-            'date' => 'Safe\date',
             'date_parse' => 'Safe\date_parse',
             'date_parse_from_format' => 'Safe\date_parse_from_format',
             'date_sunrise' => 'Safe\date_sunrise',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -105,7 +105,6 @@ return [
     'curl_share_setopt',
     'curl_unescape',
     'curl_upkeep',
-    'date',
     'date_parse',
     'date_parse_from_format',
     'date_sunrise',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -113,7 +113,6 @@ return static function (RectorConfig $rectorConfig): void {
             'curl_share_setopt' => 'Safe\curl_share_setopt',
             'curl_unescape' => 'Safe\curl_unescape',
             'curl_upkeep' => 'Safe\curl_upkeep',
-            'date' => 'Safe\date',
             'date_parse' => 'Safe\date_parse',
             'date_parse_from_format' => 'Safe\date_parse_from_format',
             'date_sunrise' => 'Safe\date_sunrise',

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -105,7 +105,6 @@ return [
     'curl_share_setopt',
     'curl_unescape',
     'curl_upkeep',
-    'date',
     'date_parse',
     'date_parse_from_format',
     'date_sunrise',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -113,7 +113,6 @@ return static function (RectorConfig $rectorConfig): void {
             'curl_share_setopt' => 'Safe\curl_share_setopt',
             'curl_unescape' => 'Safe\curl_unescape',
             'curl_upkeep' => 'Safe\curl_upkeep',
-            'date' => 'Safe\date',
             'date_parse' => 'Safe\date_parse',
             'date_parse_from_format' => 'Safe\date_parse_from_format',
             'date_sunrise' => 'Safe\date_sunrise',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -9,6 +9,7 @@
 return [
     'array_all', // false is not an error
     'array_walk_recursive', // actually returns always true, see https://github.com/php/doc-en/commit/cec5275f23d2db648df30a5702b378044431be97
+    'date', // this function throws an error instead of returning false PHP 8.0, but the doc has only been updated since PHP 8.4
     'getallheaders', // always return an array since PHP 7, see https://github.com/php/doc-en/commit/68e52ef14de33f6752a8fdda1ae83c861c5babdb
     'pack', // this function no longer returns false since PHP 8.0, but the doc has only been updated since PHP 8.4
     'imagesx', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/0462f49fb00dd5abaec3aa322009f2eb40a3279d


### PR DESCRIPTION
In PHP < 8.0, passing an invalid `timestamp` parameter value to the `date()` function was triggering a warning and a `false` value was returned.

```php
// PHP 7.4

var_dump(date('Y-m-d', 'not-a-date'));
// Warning: date() expects parameter 2 to be int, string given in Command line code on line 1
// bool(false)
```

Since PHP 8.0, an error is thrown in this specific case.
```php
// PHP 8.0

var_dump(date('Y-m-d', 'not-a-date'));
// Fatal error: Uncaught TypeError: date(): Argument #2 ($timestamp) must be of type ?int, string given in Command line code:1
```

Still, the corresponding PHP doc has only been fixed in PHP 8.4 and remained `Returns a formatted date string. If a non-numeric value is used for <parameter>timestamp</parameter>, &false; is returned and an <constant>E_WARNING</constant> level error is emitted.` in previous PHP 8.x version.
