### PR TITLE
Ignore the already safe `array_walk_recursive()` function

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -17,7 +17,6 @@ return [
     'array_flip',
     'array_replace',
     'array_replace_recursive',
-    'array_walk_recursive',
     'assert_options',
     'base64_decode',
     'bindtextdomain',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -25,7 +25,6 @@ return static function (RectorConfig $rectorConfig): void {
             'array_flip' => 'Safe\array_flip',
             'array_replace' => 'Safe\array_replace',
             'array_replace_recursive' => 'Safe\array_replace_recursive',
-            'array_walk_recursive' => 'Safe\array_walk_recursive',
             'assert_options' => 'Safe\assert_options',
             'base64_decode' => 'Safe\base64_decode',
             'bindtextdomain' => 'Safe\bindtextdomain',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -13,7 +13,6 @@ return [
     'apcu_fetch',
     'apcu_inc',
     'apcu_sma_info',
-    'array_walk_recursive',
     'assert_options',
     'base64_decode',
     'bindtextdomain',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -21,7 +21,6 @@ return static function (RectorConfig $rectorConfig): void {
             'apcu_fetch' => 'Safe\apcu_fetch',
             'apcu_inc' => 'Safe\apcu_inc',
             'apcu_sma_info' => 'Safe\apcu_sma_info',
-            'array_walk_recursive' => 'Safe\array_walk_recursive',
             'assert_options' => 'Safe\assert_options',
             'base64_decode' => 'Safe\base64_decode',
             'bindtextdomain' => 'Safe\bindtextdomain',

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -13,7 +13,6 @@ return [
     'apcu_fetch',
     'apcu_inc',
     'apcu_sma_info',
-    'array_walk_recursive',
     'assert_options',
     'base64_decode',
     'bindtextdomain',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -21,7 +21,6 @@ return static function (RectorConfig $rectorConfig): void {
             'apcu_fetch' => 'Safe\apcu_fetch',
             'apcu_inc' => 'Safe\apcu_inc',
             'apcu_sma_info' => 'Safe\apcu_sma_info',
-            'array_walk_recursive' => 'Safe\array_walk_recursive',
             'assert_options' => 'Safe\assert_options',
             'base64_decode' => 'Safe\base64_decode',
             'bindtextdomain' => 'Safe\bindtextdomain',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -8,6 +8,7 @@
  */
 return [
     'array_all', // false is not an error
+    'array_walk_recursive', // actually returns always true, see https://github.com/php/doc-en/commit/cec5275f23d2db648df30a5702b378044431be97
     'sodium_crypto_auth_verify', // boolean return value is expected from verify
     'sodium_crypto_sign_verify_detached', // boolean return value is expected from verify
     'pack', // this function no longer returns false since PHP 8.0, but the doc has only been updated since PHP 8.4


### PR DESCRIPTION
It seems that this function has never return something else than `true`. See https://github.com/php/doc-en/commit/cec5275f23d2db648df30a5702b378044431be97