### PR TITLE
Ignore the already safe `getallheaders()` function

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -231,7 +231,6 @@ return [
     'ftp_systype',
     'ftruncate',
     'fwrite',
-    'getallheaders',
     'getcwd',
     'gethostname',
     'getimagesize',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -239,7 +239,6 @@ return static function (RectorConfig $rectorConfig): void {
             'ftp_systype' => 'Safe\ftp_systype',
             'ftruncate' => 'Safe\ftruncate',
             'fwrite' => 'Safe\fwrite',
-            'getallheaders' => 'Safe\getallheaders',
             'getcwd' => 'Safe\getcwd',
             'gethostname' => 'Safe\gethostname',
             'getimagesize' => 'Safe\getimagesize',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -230,7 +230,6 @@ return [
     'ftp_systype',
     'ftruncate',
     'fwrite',
-    'getallheaders',
     'getcwd',
     'gethostname',
     'getimagesize',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -238,7 +238,6 @@ return static function (RectorConfig $rectorConfig): void {
             'ftp_systype' => 'Safe\ftp_systype',
             'ftruncate' => 'Safe\ftruncate',
             'fwrite' => 'Safe\fwrite',
-            'getallheaders' => 'Safe\getallheaders',
             'getcwd' => 'Safe\getcwd',
             'gethostname' => 'Safe\gethostname',
             'getimagesize' => 'Safe\getimagesize',

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -230,7 +230,6 @@ return [
     'ftp_systype',
     'ftruncate',
     'fwrite',
-    'getallheaders',
     'getcwd',
     'gethostname',
     'getimagesize',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -238,7 +238,6 @@ return static function (RectorConfig $rectorConfig): void {
             'ftp_systype' => 'Safe\ftp_systype',
             'ftruncate' => 'Safe\ftruncate',
             'fwrite' => 'Safe\fwrite',
-            'getallheaders' => 'Safe\getallheaders',
             'getcwd' => 'Safe\getcwd',
             'gethostname' => 'Safe\gethostname',
             'getimagesize' => 'Safe\getimagesize',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -9,7 +9,8 @@
 return [
     'array_all', // false is not an error
     'array_walk_recursive', // actually returns always true, see https://github.com/php/doc-en/commit/cec5275f23d2db648df30a5702b378044431be97
+    'getallheaders', // always return an array since PHP 7, see https://github.com/php/doc-en/commit/68e52ef14de33f6752a8fdda1ae83c861c5babdb
+    'pack', // this function no longer returns false since PHP 8.0, but the doc has only been updated since PHP 8.4
     'sodium_crypto_auth_verify', // boolean return value is expected from verify
     'sodium_crypto_sign_verify_detached', // boolean return value is expected from verify
-    'pack', // this function no longer returns false since PHP 8.0, but the doc has only been updated since PHP 8.4
 ];


### PR DESCRIPTION
This function always return an `array` since PHP 7. See https://github.com/php/doc-en/commit/68e52ef14de33f6752a8fdda1ae83c861c5babdb.