### PR TITLE
Ignore the already safe `imagesx()`/`imagesy()` functions

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -388,8 +388,6 @@ return [
     'imagesettile',
     'imagestring',
     'imagestringup',
-    'imagesx',
-    'imagesy',
     'imagetruecolortopalette',
     'imagettfbbox',
     'imagettftext',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -396,8 +396,6 @@ return static function (RectorConfig $rectorConfig): void {
             'imagesettile' => 'Safe\imagesettile',
             'imagestring' => 'Safe\imagestring',
             'imagestringup' => 'Safe\imagestringup',
-            'imagesx' => 'Safe\imagesx',
-            'imagesy' => 'Safe\imagesy',
             'imagetruecolortopalette' => 'Safe\imagetruecolortopalette',
             'imagettfbbox' => 'Safe\imagettfbbox',
             'imagettftext' => 'Safe\imagettftext',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -385,8 +385,6 @@ return [
     'imagesettile',
     'imagestring',
     'imagestringup',
-    'imagesx',
-    'imagesy',
     'imagetruecolortopalette',
     'imagettfbbox',
     'imagettftext',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -393,8 +393,6 @@ return static function (RectorConfig $rectorConfig): void {
             'imagesettile' => 'Safe\imagesettile',
             'imagestring' => 'Safe\imagestring',
             'imagestringup' => 'Safe\imagestringup',
-            'imagesx' => 'Safe\imagesx',
-            'imagesy' => 'Safe\imagesy',
             'imagetruecolortopalette' => 'Safe\imagetruecolortopalette',
             'imagettfbbox' => 'Safe\imagettfbbox',
             'imagettftext' => 'Safe\imagettftext',

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -385,8 +385,6 @@ return [
     'imagesettile',
     'imagestring',
     'imagestringup',
-    'imagesx',
-    'imagesy',
     'imagetruecolortopalette',
     'imagettfbbox',
     'imagettftext',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -393,8 +393,6 @@ return static function (RectorConfig $rectorConfig): void {
             'imagesettile' => 'Safe\imagesettile',
             'imagestring' => 'Safe\imagestring',
             'imagestringup' => 'Safe\imagestringup',
-            'imagesx' => 'Safe\imagesx',
-            'imagesy' => 'Safe\imagesy',
             'imagetruecolortopalette' => 'Safe\imagetruecolortopalette',
             'imagettfbbox' => 'Safe\imagettfbbox',
             'imagettftext' => 'Safe\imagettftext',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -11,6 +11,8 @@ return [
     'array_walk_recursive', // actually returns always true, see https://github.com/php/doc-en/commit/cec5275f23d2db648df30a5702b378044431be97
     'getallheaders', // always return an array since PHP 7, see https://github.com/php/doc-en/commit/68e52ef14de33f6752a8fdda1ae83c861c5babdb
     'pack', // this function no longer returns false since PHP 8.0, but the doc has only been updated since PHP 8.4
+    'imagesx', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/0462f49fb00dd5abaec3aa322009f2eb40a3279d
+    'imagesy', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/37f858a5579386dafaddaffbe15034dbcd0f55c8
     'sodium_crypto_auth_verify', // boolean return value is expected from verify
     'sodium_crypto_sign_verify_detached', // boolean return value is expected from verify
 ];


### PR DESCRIPTION
Since PHP 8.0, these functions are throwing `TypeError` when the first argument is not a `GdImage` instance. See https://github.com/php/doc-en/commit/0462f49fb00dd5abaec3aa322009f2eb40a3279d and https://github.com/php/doc-en/commit/37f858a5579386dafaddaffbe15034dbcd0f55c8.