### PR TITLE
Fix `mktime()` on PHP 8.2 and 8.3

### DIFF
--- a/generated/8.2/datetime.php
+++ b/generated/8.2/datetime.php
@@ -730,11 +730,12 @@ function idate(string $format, ?int $timestamp = null): int
  * 1970-2000. On systems where time_t is a 32bit signed integer, as
  * most common today, the valid range for year
  * is somewhere between 1901 and 2038.
- * @return false|int mktime returns the Unix timestamp of the arguments
+ * @return int mktime returns the Unix timestamp of the arguments
  * given.
+ * @throws DatetimeException
  *
  */
-function mktime(int $hour, ?int $minute = null, ?int $second = null, ?int $month = null, ?int $day = null, ?int $year = null)
+function mktime(int $hour, ?int $minute = null, ?int $second = null, ?int $month = null, ?int $day = null, ?int $year = null): int
 {
     error_clear_last();
     if ($year !== null) {
@@ -749,6 +750,9 @@ function mktime(int $hour, ?int $minute = null, ?int $second = null, ?int $month
         $safeResult = \mktime($hour, $minute);
     } else {
         $safeResult = \mktime($hour);
+    }
+    if ($safeResult === false) {
+        throw DatetimeException::createFromPhpError();
     }
     return $safeResult;
 }

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -522,6 +522,7 @@ return [
     'md5_file',
     'mime_content_type',
     'mkdir',
+    'mktime',
     'msg_get_queue',
     'msg_queue_exists',
     'msg_receive',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -530,6 +530,7 @@ return static function (RectorConfig $rectorConfig): void {
             'md5_file' => 'Safe\md5_file',
             'mime_content_type' => 'Safe\mime_content_type',
             'mkdir' => 'Safe\mkdir',
+            'mktime' => 'Safe\mktime',
             'msg_get_queue' => 'Safe\msg_get_queue',
             'msg_queue_exists' => 'Safe\msg_queue_exists',
             'msg_receive' => 'Safe\msg_receive',

--- a/generated/8.3/datetime.php
+++ b/generated/8.3/datetime.php
@@ -730,11 +730,12 @@ function idate(string $format, ?int $timestamp = null): int
  * 1970-2000. On systems where time_t is a 32bit signed integer, as
  * most common today, the valid range for year
  * is somewhere between 1901 and 2038.
- * @return false|int mktime returns the Unix timestamp of the arguments
+ * @return int mktime returns the Unix timestamp of the arguments
  * given.
+ * @throws DatetimeException
  *
  */
-function mktime(int $hour, ?int $minute = null, ?int $second = null, ?int $month = null, ?int $day = null, ?int $year = null)
+function mktime(int $hour, ?int $minute = null, ?int $second = null, ?int $month = null, ?int $day = null, ?int $year = null): int
 {
     error_clear_last();
     if ($year !== null) {
@@ -749,6 +750,9 @@ function mktime(int $hour, ?int $minute = null, ?int $second = null, ?int $month
         $safeResult = \mktime($hour, $minute);
     } else {
         $safeResult = \mktime($hour);
+    }
+    if ($safeResult === false) {
+        throw DatetimeException::createFromPhpError();
     }
     return $safeResult;
 }

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -522,6 +522,7 @@ return [
     'md5_file',
     'mime_content_type',
     'mkdir',
+    'mktime',
     'msg_get_queue',
     'msg_queue_exists',
     'msg_receive',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -530,6 +530,7 @@ return static function (RectorConfig $rectorConfig): void {
             'md5_file' => 'Safe\md5_file',
             'mime_content_type' => 'Safe\mime_content_type',
             'mkdir' => 'Safe\mkdir',
+            'mktime' => 'Safe\mktime',
             'msg_get_queue' => 'Safe\msg_get_queue',
             'msg_queue_exists' => 'Safe\msg_queue_exists',
             'msg_receive' => 'Safe\msg_receive',

--- a/generator/config/detectErrorType.php
+++ b/generator/config/detectErrorType.php
@@ -54,6 +54,7 @@ return function (string $text): ErrorType {
         '/On failure to change the value, &false; is returned./m', // session_cache_expire, session_cache_limiter
         '/This function returns &true; if a session was successfully started,\s+otherwise &false;./m', // session_start
         '/&false;\s+if\s+the\s+timestamp\s+doesn\'t\s+fit\s+in\s+a\s+PHP\s+integer./m', // gmmktime / mktime
+        '/<function>mktime<\/function>\s+returns\s+the\s+Unix\s+timestamp\s+of\s+the\s+arguments\s+given./', // mktime before https://github.com/php/doc-en/pull/2651
     ];
     foreach ($falsies as $falsie) {
         if (preg_match($falsie, $text)) {


### PR DESCRIPTION
Before https://github.com/php/doc-en/commit/57e27d2a7615da2ee6de57ed27eb40b473d487cb, the `mktime()` documentation was not mentioning the `false` return value on the `mktime()` function.

This `false` return value exists for years, see https://github.com/php/php-src/commit/ed02f202f017d3c1ebddb202a0fc224cce1b9e78#diff-975ac482adc74b487c6ac9d8dde32153e4b8a803ef8ec41e8d6594f0a042db69R410-R414