### PR TITLE
Ignore `long2ip()` that is actually safe

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -493,7 +493,6 @@ return [
     'ldap_unbind',
     'libxml_set_external_entity_loader',
     'link',
-    'long2ip',
     'lstat',
     'lzf_compress',
     'lzf_decompress',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -501,7 +501,6 @@ return static function (RectorConfig $rectorConfig): void {
             'ldap_unbind' => 'Safe\ldap_unbind',
             'libxml_set_external_entity_loader' => 'Safe\libxml_set_external_entity_loader',
             'link' => 'Safe\link',
-            'long2ip' => 'Safe\long2ip',
             'lstat' => 'Safe\lstat',
             'lzf_compress' => 'Safe\lzf_compress',
             'lzf_decompress' => 'Safe\lzf_decompress',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -490,7 +490,6 @@ return [
     'ldap_unbind',
     'libxml_set_external_entity_loader',
     'link',
-    'long2ip',
     'lstat',
     'lzf_compress',
     'lzf_decompress',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -498,7 +498,6 @@ return static function (RectorConfig $rectorConfig): void {
             'ldap_unbind' => 'Safe\ldap_unbind',
             'libxml_set_external_entity_loader' => 'Safe\libxml_set_external_entity_loader',
             'link' => 'Safe\link',
-            'long2ip' => 'Safe\long2ip',
             'lstat' => 'Safe\lstat',
             'lzf_compress' => 'Safe\lzf_compress',
             'lzf_decompress' => 'Safe\lzf_decompress',

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -490,7 +490,6 @@ return [
     'ldap_unbind',
     'libxml_set_external_entity_loader',
     'link',
-    'long2ip',
     'lstat',
     'lzf_compress',
     'lzf_decompress',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -498,7 +498,6 @@ return static function (RectorConfig $rectorConfig): void {
             'ldap_unbind' => 'Safe\ldap_unbind',
             'libxml_set_external_entity_loader' => 'Safe\libxml_set_external_entity_loader',
             'link' => 'Safe\link',
-            'long2ip' => 'Safe\long2ip',
             'lstat' => 'Safe\lstat',
             'lzf_compress' => 'Safe\lzf_compress',
             'lzf_decompress' => 'Safe\lzf_decompress',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -11,6 +11,7 @@ return [
     'array_walk_recursive', // actually returns always true, see https://github.com/php/doc-en/commit/cec5275f23d2db648df30a5702b378044431be97
     'date', // this function throws an error instead of returning false PHP 8.0, but the doc has only been updated since PHP 8.4
     'getallheaders', // always return an array since PHP 7, see https://github.com/php/doc-en/commit/68e52ef14de33f6752a8fdda1ae83c861c5babdb
+    'long2ip', // false return type cannot actually be returned, see https://github.com/php/php-src/pull/13395
     'pack', // this function no longer returns false since PHP 8.0, but the doc has only been updated since PHP 8.4
     'imagesx', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/0462f49fb00dd5abaec3aa322009f2eb40a3279d
     'imagesy', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/37f858a5579386dafaddaffbe15034dbcd0f55c8


### PR DESCRIPTION
See https://github.com/php/php-src/pull/13395 and the mentioned https://github.com/vimeo/psalm/pull/9537#discussion_r1140799451 discussion.

The `false` return value documented for the `long2ip()` function can actually never happen. Using `Safe/long2ip()` instead will then never have any value.

I propose to ignore it. This will prevent to have differences in detected error between PHP 8.4 and previous PHP versions.