### PR TITLE
Fix `array_combine()` on PHP 8.1

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -13,7 +13,6 @@ return [
     'apcu_fetch',
     'apcu_inc',
     'apcu_sma_info',
-    'array_combine',
     'array_flip',
     'array_replace',
     'array_replace_recursive',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -21,7 +21,6 @@ return static function (RectorConfig $rectorConfig): void {
             'apcu_fetch' => 'Safe\apcu_fetch',
             'apcu_inc' => 'Safe\apcu_inc',
             'apcu_sma_info' => 'Safe\apcu_sma_info',
-            'array_combine' => 'Safe\array_combine',
             'array_flip' => 'Safe\array_flip',
             'array_replace' => 'Safe\array_replace',
             'array_replace_recursive' => 'Safe\array_replace_recursive',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -8,6 +8,7 @@
  */
 return [
     'array_all', // false is not an error
+    'array_combine', // this function throws an error instead of returning false since PHP 8.0
     'array_walk_recursive', // actually returns always true, see https://github.com/php/doc-en/commit/cec5275f23d2db648df30a5702b378044431be97
     'date', // this function throws an error instead of returning false PHP 8.0, but the doc has only been updated since PHP 8.4
     'getallheaders', // always return an array since PHP 7, see https://github.com/php/doc-en/commit/68e52ef14de33f6752a8fdda1ae83c861c5babdb


### PR DESCRIPTION
According to the [documentation](https://www.php.net/manual/en/function.array-combine.php):
> As of PHP 8.0.0, a ValueError is thrown if the number of elements in keys and values does not match. Prior to PHP 8.0.0, a E_WARNING was emitted instead.