### PR TITLE
Fix `array_flip()` on PHP 8.1

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -13,7 +13,6 @@ return [
     'apcu_fetch',
     'apcu_inc',
     'apcu_sma_info',
-    'array_flip',
     'array_replace',
     'array_replace_recursive',
     'assert_options',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -21,7 +21,6 @@ return static function (RectorConfig $rectorConfig): void {
             'apcu_fetch' => 'Safe\apcu_fetch',
             'apcu_inc' => 'Safe\apcu_inc',
             'apcu_sma_info' => 'Safe\apcu_sma_info',
-            'array_flip' => 'Safe\array_flip',
             'array_replace' => 'Safe\array_replace',
             'array_replace_recursive' => 'Safe\array_replace_recursive',
             'assert_options' => 'Safe\assert_options',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -9,6 +9,7 @@
 return [
     'array_all', // false is not an error
     'array_combine', // this function throws an error instead of returning false since PHP 8.0
+    'array_flip', // always return an array since PHP 8.0, see https://github.com/php/doc-en/issues/1178
     'array_walk_recursive', // actually returns always true, see https://github.com/php/doc-en/commit/cec5275f23d2db648df30a5702b378044431be97
     'date', // this function throws an error instead of returning false PHP 8.0, but the doc has only been updated since PHP 8.4
     'getallheaders', // always return an array since PHP 7, see https://github.com/php/doc-en/commit/68e52ef14de33f6752a8fdda1ae83c861c5babdb


### PR DESCRIPTION
Before PHP 8.0, `null` value was returned when something else than an array was passed to the function. Now it throws an error.
See https://github.com/php/doc-en/pull/1649.