### PR TITLE
Fix `array_replace()` / `array_replace_recursive()` on PHP 8.1

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -13,8 +13,6 @@ return [
     'apcu_fetch',
     'apcu_inc',
     'apcu_sma_info',
-    'array_replace',
-    'array_replace_recursive',
     'assert_options',
     'base64_decode',
     'bindtextdomain',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -21,8 +21,6 @@ return static function (RectorConfig $rectorConfig): void {
             'apcu_fetch' => 'Safe\apcu_fetch',
             'apcu_inc' => 'Safe\apcu_inc',
             'apcu_sma_info' => 'Safe\apcu_sma_info',
-            'array_replace' => 'Safe\array_replace',
-            'array_replace_recursive' => 'Safe\array_replace_recursive',
             'assert_options' => 'Safe\assert_options',
             'base64_decode' => 'Safe\base64_decode',
             'bindtextdomain' => 'Safe\bindtextdomain',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -10,6 +10,8 @@ return [
     'array_all', // false is not an error
     'array_combine', // this function throws an error instead of returning false since PHP 8.0
     'array_flip', // always return an array since PHP 8.0, see https://github.com/php/doc-en/issues/1178
+    'array_replace', // this function throws an error instead of returning false since PHP 8.0, see https://github.com/php/doc-en/pull/1649
+    'array_replace_recursive', // this function throws an error instead of returning false since PHP 8.0, see https://github.com/php/doc-en/pull/1649
     'array_walk_recursive', // actually returns always true, see https://github.com/php/doc-en/commit/cec5275f23d2db648df30a5702b378044431be97
     'date', // this function throws an error instead of returning false PHP 8.0, but the doc has only been updated since PHP 8.4
     'getallheaders', // always return an array since PHP 7, see https://github.com/php/doc-en/commit/68e52ef14de33f6752a8fdda1ae83c861c5babdb


### PR DESCRIPTION
These functions were returning `null` prior to PHP 8.0 when unexpected parameter types were passed. Now an error is thrown.
See https://github.com/php/doc-en/pull/1649.