### PR TITLE
Fix `passthru()` on PHP 8.1

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -698,6 +698,7 @@ return [
     'parse_ini_file',
     'parse_ini_string',
     'parse_url',
+    'passthru',
     'pclose',
     'pcntl_getpriority',
     'pcntl_setpriority',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -706,6 +706,7 @@ return static function (RectorConfig $rectorConfig): void {
             'parse_ini_file' => 'Safe\parse_ini_file',
             'parse_ini_string' => 'Safe\parse_ini_string',
             'parse_url' => 'Safe\parse_url',
+            'passthru' => 'Safe\passthru',
             'pclose' => 'Safe\pclose',
             'pcntl_getpriority' => 'Safe\pcntl_getpriority',
             'pcntl_setpriority' => 'Safe\pcntl_setpriority',

--- a/generated/8.2/exec.php
+++ b/generated/8.2/exec.php
@@ -44,35 +44,6 @@ function exec(string $command, ?array &$output = null, ?int &$result_code = null
 
 
 /**
- * The passthru function is similar to the
- * exec function in that it executes a
- * command. This function
- * should be used in place of exec or
- * system when the output from the Unix command
- * is binary data which needs to be passed directly back to the
- * browser.  A common use for this is to execute something like the
- * pbmplus utilities that can output an image stream directly.  By
- * setting the Content-type to image/gif and
- * then calling a pbmplus program to output a gif, you can create
- * PHP scripts that output images directly.
- *
- * @param string $command The command that will be executed.
- * @param int|null $result_code If the result_code argument is present, the
- * return status of the Unix command will be placed here.
- * @throws ExecException
- *
- */
-function passthru(string $command, ?int &$result_code = null): void
-{
-    error_clear_last();
-    $safeResult = \passthru($command, $result_code);
-    if ($safeResult === false) {
-        throw ExecException::createFromPhpError();
-    }
-}
-
-
-/**
  * proc_close is similar to pclose
  * except that it only works on processes opened by
  * proc_open.

--- a/generated/8.3/exec.php
+++ b/generated/8.3/exec.php
@@ -44,35 +44,6 @@ function exec(string $command, ?array &$output = null, ?int &$result_code = null
 
 
 /**
- * The passthru function is similar to the
- * exec function in that it executes a
- * command. This function
- * should be used in place of exec or
- * system when the output from the Unix command
- * is binary data which needs to be passed directly back to the
- * browser.  A common use for this is to execute something like the
- * pbmplus utilities that can output an image stream directly.  By
- * setting the Content-type to image/gif and
- * then calling a pbmplus program to output a gif, you can create
- * PHP scripts that output images directly.
- *
- * @param string $command The command that will be executed.
- * @param int|null $result_code If the result_code argument is present, the
- * return status of the Unix command will be placed here.
- * @throws ExecException
- *
- */
-function passthru(string $command, ?int &$result_code = null): void
-{
-    error_clear_last();
-    $safeResult = \passthru($command, $result_code);
-    if ($safeResult === false) {
-        throw ExecException::createFromPhpError();
-    }
-}
-
-
-/**
  * proc_close is similar to pclose
  * except that it only works on processes opened by
  * proc_open.

--- a/generated/8.4/exec.php
+++ b/generated/8.4/exec.php
@@ -44,35 +44,6 @@ function exec(string $command, ?array &$output = null, ?int &$result_code = null
 
 
 /**
- * The passthru function is similar to the
- * exec function in that it executes a
- * command. This function
- * should be used in place of exec or
- * system when the output from the Unix command
- * is binary data which needs to be passed directly back to the
- * browser.  A common use for this is to execute something like the
- * pbmplus utilities that can output an image stream directly.  By
- * setting the Content-type to image/gif and
- * then calling a pbmplus program to output a gif, you can create
- * PHP scripts that output images directly.
- *
- * @param string $command The command that will be executed.
- * @param int|null $result_code If the result_code argument is present, the
- * return status of the Unix command will be placed here.
- * @throws ExecException
- *
- */
-function passthru(string $command, ?int &$result_code = null): void
-{
-    error_clear_last();
-    $safeResult = \passthru($command, $result_code);
-    if ($safeResult === false) {
-        throw ExecException::createFromPhpError();
-    }
-}
-
-
-/**
  * proc_close is similar to pclose
  * except that it only works on processes opened by
  * proc_open.

--- a/generated/8.5/exec.php
+++ b/generated/8.5/exec.php
@@ -44,35 +44,6 @@ function exec(string $command, ?array &$output = null, ?int &$result_code = null
 
 
 /**
- * The passthru function is similar to the
- * exec function in that it executes a
- * command. This function
- * should be used in place of exec or
- * system when the output from the Unix command
- * is binary data which needs to be passed directly back to the
- * browser.  A common use for this is to execute something like the
- * pbmplus utilities that can output an image stream directly.  By
- * setting the Content-type to image/gif and
- * then calling a pbmplus program to output a gif, you can create
- * PHP scripts that output images directly.
- *
- * @param string $command The command that will be executed.
- * @param int|null $result_code If the result_code argument is present, the
- * return status of the Unix command will be placed here.
- * @throws ExecException
- *
- */
-function passthru(string $command, ?int &$result_code = null): void
-{
-    error_clear_last();
-    $safeResult = \passthru($command, $result_code);
-    if ($safeResult === false) {
-        throw ExecException::createFromPhpError();
-    }
-}
-
-
-/**
  * proc_close is similar to pclose
  * except that it only works on processes opened by
  * proc_open.

--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -17,6 +17,7 @@ use Safe\Exceptions\OpensslException;
 use Safe\Exceptions\PcreException;
 use Safe\Exceptions\SimplexmlException;
 use Safe\Exceptions\FilesystemException;
+use Safe\Exceptions\ExecException;
 
 use const PREG_NO_ERROR;
 
@@ -398,4 +399,32 @@ function fgetcsv($stream, ?int $length = null, string $separator = ",", string $
         throw FilesystemException::createFromPhpError();
     }
     return $safeResult;
+}
+
+/**
+ * The passthru function is similar to the
+ * exec function in that it executes a
+ * command. This function
+ * should be used in place of exec or
+ * system when the output from the Unix command
+ * is binary data which needs to be passed directly back to the
+ * browser.  A common use for this is to execute something like the
+ * pbmplus utilities that can output an image stream directly.  By
+ * setting the Content-type to image/gif and
+ * then calling a pbmplus program to output a gif, you can create
+ * PHP scripts that output images directly.
+ *
+ * @param string $command The command that will be executed.
+ * @param int|null $result_code If the result_code argument is present, the
+ * return status of the Unix command will be placed here.
+ * @throws ExecException
+ *
+ */
+function passthru(string $command, ?int &$result_code = null): void
+{
+    error_clear_last();
+    $safeResult = \passthru($command, $result_code);
+    if ($safeResult === false) {
+        throw ExecException::createFromPhpError();
+    }
 }


### PR DESCRIPTION
The `passthru()` documentation has been fixed in PHP 8.2. Prior to that, the mention to the the `false` return value on failure was missing.