### PR TITLE
Fix `gmp_random_seed()` on PHP 8.1

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -245,7 +245,6 @@ return [
     'get_meta_tags',
     'glob',
     'gmmktime',
-    'gmp_random_seed',
     'gmstrftime',
     'gnupg_adddecryptkey',
     'gnupg_addencryptkey',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -253,7 +253,6 @@ return static function (RectorConfig $rectorConfig): void {
             'get_meta_tags' => 'Safe\get_meta_tags',
             'glob' => 'Safe\glob',
             'gmmktime' => 'Safe\gmmktime',
-            'gmp_random_seed' => 'Safe\gmp_random_seed',
             'gmstrftime' => 'Safe\gmstrftime',
             'gnupg_adddecryptkey' => 'Safe\gnupg_adddecryptkey',
             'gnupg_addencryptkey' => 'Safe\gnupg_addencryptkey',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -15,6 +15,7 @@ return [
     'array_walk_recursive', // actually returns always true, see https://github.com/php/doc-en/commit/cec5275f23d2db648df30a5702b378044431be97
     'date', // this function throws an error instead of returning false PHP 8.0, but the doc has only been updated since PHP 8.4
     'getallheaders', // always return an array since PHP 7, see https://github.com/php/doc-en/commit/68e52ef14de33f6752a8fdda1ae83c861c5babdb
+    'gmp_random_seed', // this function throws an error instead of returning false since PHP 8.0
     'long2ip', // false return type cannot actually be returned, see https://github.com/php/php-src/pull/13395
     'pack', // this function no longer returns false since PHP 8.0, but the doc has only been updated since PHP 8.4
     'imagesx', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/0462f49fb00dd5abaec3aa322009f2eb40a3279d


### PR DESCRIPTION
According to the [documentation](https://www.php.net/manual/en/function.gmp-random-seed.php#refsect1-function.gmp-random-seed-changelog), since PHP 8.0:
> If seed is invalid, gmp_random_seed() now throws a ValueError. Previously it emitted an E_WARNING and returned false.