### PR TITLE
Fix `hash_hkdf()` on PHP 8.1

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -269,7 +269,6 @@ return [
     'gztell',
     'gzuncompress',
     'gzwrite',
-    'hash_hkdf',
     'hash_update_file',
     'header_register_callback',
     'hex2bin',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -277,7 +277,6 @@ return static function (RectorConfig $rectorConfig): void {
             'gztell' => 'Safe\gztell',
             'gzuncompress' => 'Safe\gzuncompress',
             'gzwrite' => 'Safe\gzwrite',
-            'hash_hkdf' => 'Safe\hash_hkdf',
             'hash_update_file' => 'Safe\hash_update_file',
             'header_register_callback' => 'Safe\header_register_callback',
             'hex2bin' => 'Safe\hex2bin',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -16,6 +16,7 @@ return [
     'date', // this function throws an error instead of returning false PHP 8.0, but the doc has only been updated since PHP 8.4
     'getallheaders', // always return an array since PHP 7, see https://github.com/php/doc-en/commit/68e52ef14de33f6752a8fdda1ae83c861c5babdb
     'gmp_random_seed', // this function throws an error instead of returning false since PHP 8.0
+    'hash_hkdf', // this function throws an error instead of returning false since PHP 8.0
     'long2ip', // false return type cannot actually be returned, see https://github.com/php/php-src/pull/13395
     'pack', // this function no longer returns false since PHP 8.0, but the doc has only been updated since PHP 8.4
     'imagesx', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/0462f49fb00dd5abaec3aa322009f2eb40a3279d


### PR DESCRIPTION
According to the [documentation](https://www.php.net/manual/en/function.hash-hkdf.php#refsect1-function.hash-hkdf-changelog):
> Now throws a ValueError exception on error. Previously, false was returned and an E_WARNING message was emitted.