### PR TITLE
Fix `sleep()` on PHP 8.1

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -927,7 +927,6 @@ return [
     'simplexml_import_dom',
     'simplexml_load_file',
     'simplexml_load_string',
-    'sleep',
     'socket_accept',
     'socket_addrinfo_bind',
     'socket_addrinfo_connect',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -935,7 +935,6 @@ return static function (RectorConfig $rectorConfig): void {
             'simplexml_import_dom' => 'Safe\simplexml_import_dom',
             'simplexml_load_file' => 'Safe\simplexml_load_file',
             'simplexml_load_string' => 'Safe\simplexml_load_string',
-            'sleep' => 'Safe\sleep',
             'socket_accept' => 'Safe\socket_accept',
             'socket_addrinfo_bind' => 'Safe\socket_addrinfo_bind',
             'socket_addrinfo_connect' => 'Safe\socket_addrinfo_connect',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -22,4 +22,5 @@ return [
     'imagesy', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/37f858a5579386dafaddaffbe15034dbcd0f55c8
     'sodium_crypto_auth_verify', // boolean return value is expected from verify
     'sodium_crypto_sign_verify_detached', // boolean return value is expected from verify
+    'sleep', // this function throws an error instead of returning false since PHP 8.0
 ];


### PR DESCRIPTION
According to the [documentation](https://www.php.net/manual/en/function.sleep.php#refsect1-function.sleep-changelog), since PHP 8.0:
> 	The function throws a ValueError on negative seconds; previously, an E_WARNING was raised instead, and the function returned false.