### PR TITLE
Fix `imagecolorsforindex()` on PHP 8.1

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -319,7 +319,6 @@ return [
     'imagecolordeallocate',
     'imagecolormatch',
     'imagecolorset',
-    'imagecolorsforindex',
     'imageconvolution',
     'imagecopy',
     'imagecopymerge',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -327,7 +327,6 @@ return static function (RectorConfig $rectorConfig): void {
             'imagecolordeallocate' => 'Safe\imagecolordeallocate',
             'imagecolormatch' => 'Safe\imagecolormatch',
             'imagecolorset' => 'Safe\imagecolorset',
-            'imagecolorsforindex' => 'Safe\imagecolorsforindex',
             'imageconvolution' => 'Safe\imageconvolution',
             'imagecopy' => 'Safe\imagecopy',
             'imagecopymerge' => 'Safe\imagecopymerge',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -17,6 +17,7 @@ return [
     'getallheaders', // always return an array since PHP 7, see https://github.com/php/doc-en/commit/68e52ef14de33f6752a8fdda1ae83c861c5babdb
     'gmp_random_seed', // this function throws an error instead of returning false since PHP 8.0
     'hash_hkdf', // this function throws an error instead of returning false since PHP 8.0
+    'imagecolorsforindex', // this function throws an error instead of returning false since PHP 8.0
     'long2ip', // false return type cannot actually be returned, see https://github.com/php/php-src/pull/13395
     'pack', // this function no longer returns false since PHP 8.0, but the doc has only been updated since PHP 8.4
     'imagesx', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/0462f49fb00dd5abaec3aa322009f2eb40a3279d


### PR DESCRIPTION
According to the [documentation](https://www.php.net/manual/en/function.imagecolorsforindex.php#refsect1-function.imagecolorsforindex-changelog), since PHP 8.0:
> imagecolorsforindex() now throws a ValueError exception if color is out of range; previously, false was returned instead.