### PR TITLE
Fix `mysqli_get_client_stats()` on PHP 8.1

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -526,7 +526,6 @@ return [
     'msg_send',
     'msg_set_queue',
     'msg_stat_queue',
-    'mysqli_get_client_stats',
     'mysql_close',
     'mysql_connect',
     'mysql_create_db',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -534,7 +534,6 @@ return static function (RectorConfig $rectorConfig): void {
             'msg_send' => 'Safe\msg_send',
             'msg_set_queue' => 'Safe\msg_set_queue',
             'msg_stat_queue' => 'Safe\msg_stat_queue',
-            'mysqli_get_client_stats' => 'Safe\mysqli_get_client_stats',
             'mysql_close' => 'Safe\mysql_close',
             'mysql_connect' => 'Safe\mysql_connect',
             'mysql_create_db' => 'Safe\mysql_create_db',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -18,6 +18,7 @@ return [
     'gmp_random_seed', // this function throws an error instead of returning false since PHP 8.0
     'hash_hkdf', // this function throws an error instead of returning false since PHP 8.0
     'long2ip', // false return type cannot actually be returned, see https://github.com/php/php-src/pull/13395
+    'mysqli_get_client_stats', // false is actually never returned, see https://github.com/php/doc-en/pull/1055
     'pack', // this function no longer returns false since PHP 8.0, but the doc has only been updated since PHP 8.4
     'imagesx', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/0462f49fb00dd5abaec3aa322009f2eb40a3279d
     'imagesy', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/37f858a5579386dafaddaffbe15034dbcd0f55c8


### PR DESCRIPTION
According to https://github.com/php/doc-en/pull/1055, this function never returned a `false` value.