### PR TITLE
Fix `openssl_random_pseudo_bytes()` on PHP 8.1

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -668,7 +668,6 @@ return [
     'openssl_private_encrypt',
     'openssl_public_decrypt',
     'openssl_public_encrypt',
-    'openssl_random_pseudo_bytes',
     'openssl_seal',
     'openssl_sign',
     'openssl_spki_export',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -676,7 +676,6 @@ return static function (RectorConfig $rectorConfig): void {
             'openssl_private_encrypt' => 'Safe\openssl_private_encrypt',
             'openssl_public_decrypt' => 'Safe\openssl_public_decrypt',
             'openssl_public_encrypt' => 'Safe\openssl_public_encrypt',
-            'openssl_random_pseudo_bytes' => 'Safe\openssl_random_pseudo_bytes',
             'openssl_seal' => 'Safe\openssl_seal',
             'openssl_sign' => 'Safe\openssl_sign',
             'openssl_spki_export' => 'Safe\openssl_spki_export',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -24,6 +24,7 @@ return [
     'imagecolorsforindex', // this function throws an error instead of returning false since PHP 8.0
     'long2ip', // false return type cannot actually be returned, see https://github.com/php/php-src/pull/13395
     'mysqli_get_client_stats', // false is actually never returned, see https://github.com/php/doc-en/pull/1055
+    'openssl_random_pseudo_bytes', // this function throws an error instead of returning false since PHP 7.4
     'pack', // this function no longer returns false since PHP 8.0, but the doc has only been updated since PHP 8.4
     'imagesx', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/0462f49fb00dd5abaec3aa322009f2eb40a3279d
     'imagesy', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/37f858a5579386dafaddaffbe15034dbcd0f55c8


### PR DESCRIPTION
According to the [documentation](https://www.php.net/manual/en/function.openssl-random-pseudo-bytes.php#refsect1-function.openssl-random-pseudo-bytes-changelog), since PHP 7.4:
> The function no longer returns false on failure, but throws an Exception instead.