### PR TITLE
Fix `stream_socket_get_name()` on PHP 8.1

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -1027,6 +1027,7 @@ return [
     'stream_set_timeout',
     'stream_socket_accept',
     'stream_socket_client',
+    'stream_socket_get_name',
     'stream_socket_pair',
     'stream_socket_server',
     'stream_socket_shutdown',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -1035,6 +1035,7 @@ return static function (RectorConfig $rectorConfig): void {
             'stream_set_timeout' => 'Safe\stream_set_timeout',
             'stream_socket_accept' => 'Safe\stream_socket_accept',
             'stream_socket_client' => 'Safe\stream_socket_client',
+            'stream_socket_get_name' => 'Safe\stream_socket_get_name',
             'stream_socket_pair' => 'Safe\stream_socket_pair',
             'stream_socket_server' => 'Safe\stream_socket_server',
             'stream_socket_shutdown' => 'Safe\stream_socket_shutdown',

--- a/generated/8.1/stream.php
+++ b/generated/8.1/stream.php
@@ -457,6 +457,27 @@ function stream_socket_client(string $remote_socket, ?int &$errno = null, ?strin
 
 
 /**
+ * Returns the local or remote name of a given socket connection.
+ *
+ * @param resource $handle The socket to get the name of.
+ * @param bool $want_peer If set to TRUE the remote socket name will be returned, if set
+ * to FALSE the local socket name will be returned.
+ * @return string The name of the socket.
+ * @throws StreamException
+ *
+ */
+function stream_socket_get_name($handle, bool $want_peer): string
+{
+    error_clear_last();
+    $safeResult = \stream_socket_get_name($handle, $want_peer);
+    if ($safeResult === false) {
+        throw StreamException::createFromPhpError();
+    }
+    return $safeResult;
+}
+
+
+/**
  * stream_socket_pair creates a pair of connected,
  * indistinguishable socket streams. This function is commonly used in IPC
  * (Inter-Process Communication).

--- a/generator/config/detectErrorType.php
+++ b/generator/config/detectErrorType.php
@@ -55,6 +55,7 @@ return function (string $text): ErrorType {
         '/This function returns &true; if a session was successfully started,\s+otherwise &false;./m', // session_start
         '/&false;\s+if\s+the\s+timestamp\s+doesn\'t\s+fit\s+in\s+a\s+PHP\s+integer./m', // gmmktime / mktime
         '/<function>mktime<\/function>\s+returns\s+the\s+Unix\s+timestamp\s+of\s+the\s+arguments\s+given./', // mktime before https://github.com/php/doc-en/pull/2651
+        '/The name of the socket/', // stream_socket_get_name (PHP 8.1)
     ];
     foreach ($falsies as $falsie) {
         if (preg_match($falsie, $text)) {


### PR DESCRIPTION
This function may return a `false` value since its first implementation (see https://github.com/php/php-src/commit/1b53a2d12e520adec5cbbc60bf8f2b6d8e54eece#diff-4294bfe38876196fc83b34d3b3a8d16919acbc8aaa68ce2fc77859f0ef46b787R38-R246), but it was missing from the documentation until PHP 8.2 (see https://github.com/php/doc-en/commit/a1702b5d45ad950c5f7a077878378a37851a2df6).