### PR TITLE
Fix `apache_request_headers()`/`apache_response_headers()` on PHP < 8.4

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -4,8 +4,6 @@ return [
     'apache_getenv',
     'apache_get_version',
     'apache_lookup_uri',
-    'apache_request_headers',
-    'apache_response_headers',
     'apache_setenv',
     'apcu_cache_info',
     'apcu_cas',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -12,8 +12,6 @@ return static function (RectorConfig $rectorConfig): void {
         [            'apache_getenv' => 'Safe\apache_getenv',
             'apache_get_version' => 'Safe\apache_get_version',
             'apache_lookup_uri' => 'Safe\apache_lookup_uri',
-            'apache_request_headers' => 'Safe\apache_request_headers',
-            'apache_response_headers' => 'Safe\apache_response_headers',
             'apache_setenv' => 'Safe\apache_setenv',
             'apcu_cache_info' => 'Safe\apcu_cache_info',
             'apcu_cas' => 'Safe\apcu_cas',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -4,8 +4,6 @@ return [
     'apache_getenv',
     'apache_get_version',
     'apache_lookup_uri',
-    'apache_request_headers',
-    'apache_response_headers',
     'apache_setenv',
     'apcu_cache_info',
     'apcu_cas',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -12,8 +12,6 @@ return static function (RectorConfig $rectorConfig): void {
         [            'apache_getenv' => 'Safe\apache_getenv',
             'apache_get_version' => 'Safe\apache_get_version',
             'apache_lookup_uri' => 'Safe\apache_lookup_uri',
-            'apache_request_headers' => 'Safe\apache_request_headers',
-            'apache_response_headers' => 'Safe\apache_response_headers',
             'apache_setenv' => 'Safe\apache_setenv',
             'apcu_cache_info' => 'Safe\apcu_cache_info',
             'apcu_cas' => 'Safe\apcu_cas',

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -4,8 +4,6 @@ return [
     'apache_getenv',
     'apache_get_version',
     'apache_lookup_uri',
-    'apache_request_headers',
-    'apache_response_headers',
     'apache_setenv',
     'apcu_cache_info',
     'apcu_cas',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -12,8 +12,6 @@ return static function (RectorConfig $rectorConfig): void {
         [            'apache_getenv' => 'Safe\apache_getenv',
             'apache_get_version' => 'Safe\apache_get_version',
             'apache_lookup_uri' => 'Safe\apache_lookup_uri',
-            'apache_request_headers' => 'Safe\apache_request_headers',
-            'apache_response_headers' => 'Safe\apache_response_headers',
             'apache_setenv' => 'Safe\apache_setenv',
             'apcu_cache_info' => 'Safe\apcu_cache_info',
             'apcu_cas' => 'Safe\apcu_cas',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -7,6 +7,8 @@
  * to suggest that users should be using them.
  */
 return [
+    'apache_request_headers', // always return an array since PHP 7, see https://github.com/php/doc-en/pull/4076
+    'apache_response_headers', // always return an array since PHP 7, see https://github.com/php/doc-en/pull/4076
     'array_all', // false is not an error
     'array_combine', // this function throws an error instead of returning false since PHP 8.0
     'array_flip', // always return an array since PHP 8.0, see https://github.com/php/doc-en/issues/1178


### PR DESCRIPTION
These functions are always returning an array since PHP 7.
See https://github.com/php/doc-en/pull/4076.