### PR TITLE
Fix `shuffle()` on PHP < 8.4

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -922,7 +922,6 @@ return [
     'shm_put_var',
     'shm_remove',
     'shm_remove_var',
-    'shuffle',
     'simplexml_import_dom',
     'simplexml_load_file',
     'simplexml_load_string',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -930,7 +930,6 @@ return static function (RectorConfig $rectorConfig): void {
             'shm_put_var' => 'Safe\shm_put_var',
             'shm_remove' => 'Safe\shm_remove',
             'shm_remove_var' => 'Safe\shm_remove_var',
-            'shuffle' => 'Safe\shuffle',
             'simplexml_import_dom' => 'Safe\simplexml_import_dom',
             'simplexml_load_file' => 'Safe\simplexml_load_file',
             'simplexml_load_string' => 'Safe\simplexml_load_string',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -954,7 +954,6 @@ return [
     'shm_put_var',
     'shm_remove',
     'shm_remove_var',
-    'shuffle',
     'simplexml_import_dom',
     'simplexml_load_file',
     'simplexml_load_string',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -962,7 +962,6 @@ return static function (RectorConfig $rectorConfig): void {
             'shm_put_var' => 'Safe\shm_put_var',
             'shm_remove' => 'Safe\shm_remove',
             'shm_remove_var' => 'Safe\shm_remove_var',
-            'shuffle' => 'Safe\shuffle',
             'simplexml_import_dom' => 'Safe\simplexml_import_dom',
             'simplexml_load_file' => 'Safe\simplexml_load_file',
             'simplexml_load_string' => 'Safe\simplexml_load_string',

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -954,7 +954,6 @@ return [
     'shm_put_var',
     'shm_remove',
     'shm_remove_var',
-    'shuffle',
     'simplexml_import_dom',
     'simplexml_load_file',
     'simplexml_load_string',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -962,7 +962,6 @@ return static function (RectorConfig $rectorConfig): void {
             'shm_put_var' => 'Safe\shm_put_var',
             'shm_remove' => 'Safe\shm_remove',
             'shm_remove_var' => 'Safe\shm_remove_var',
-            'shuffle' => 'Safe\shuffle',
             'simplexml_import_dom' => 'Safe\simplexml_import_dom',
             'simplexml_load_file' => 'Safe\simplexml_load_file',
             'simplexml_load_string' => 'Safe\simplexml_load_string',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -21,6 +21,7 @@ return [
     'pack', // this function no longer returns false since PHP 8.0, but the doc has only been updated since PHP 8.4
     'imagesx', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/0462f49fb00dd5abaec3aa322009f2eb40a3279d
     'imagesy', // this function throws an error instead of returning false PHP 8.0, see https://github.com/php/doc-en/commit/37f858a5579386dafaddaffbe15034dbcd0f55c8
+    'shuffle', // actually returns always true
     'sodium_crypto_auth_verify', // boolean return value is expected from verify
     'sodium_crypto_sign_verify_detached', // boolean return value is expected from verify
 ];


### PR DESCRIPTION
This function actually always return `true`.