### PR TITLE
Fix `curl_share_errno()` on PHP < 8.4

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -101,7 +101,6 @@ return [
     'curl_multi_init',
     'curl_multi_setopt',
     'curl_setopt',
-    'curl_share_errno',
     'curl_share_setopt',
     'curl_unescape',
     'date_parse',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -109,7 +109,6 @@ return static function (RectorConfig $rectorConfig): void {
             'curl_multi_init' => 'Safe\curl_multi_init',
             'curl_multi_setopt' => 'Safe\curl_multi_setopt',
             'curl_setopt' => 'Safe\curl_setopt',
-            'curl_share_errno' => 'Safe\curl_share_errno',
             'curl_share_setopt' => 'Safe\curl_share_setopt',
             'curl_unescape' => 'Safe\curl_unescape',
             'date_parse' => 'Safe\date_parse',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -101,7 +101,6 @@ return [
     'curl_multi_init',
     'curl_multi_setopt',
     'curl_setopt',
-    'curl_share_errno',
     'curl_share_setopt',
     'curl_unescape',
     'curl_upkeep',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -109,7 +109,6 @@ return static function (RectorConfig $rectorConfig): void {
             'curl_multi_init' => 'Safe\curl_multi_init',
             'curl_multi_setopt' => 'Safe\curl_multi_setopt',
             'curl_setopt' => 'Safe\curl_setopt',
-            'curl_share_errno' => 'Safe\curl_share_errno',
             'curl_share_setopt' => 'Safe\curl_share_setopt',
             'curl_unescape' => 'Safe\curl_unescape',
             'curl_upkeep' => 'Safe\curl_upkeep',

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -101,7 +101,6 @@ return [
     'curl_multi_init',
     'curl_multi_setopt',
     'curl_setopt',
-    'curl_share_errno',
     'curl_share_setopt',
     'curl_unescape',
     'curl_upkeep',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -109,7 +109,6 @@ return static function (RectorConfig $rectorConfig): void {
             'curl_multi_init' => 'Safe\curl_multi_init',
             'curl_multi_setopt' => 'Safe\curl_multi_setopt',
             'curl_setopt' => 'Safe\curl_setopt',
-            'curl_share_errno' => 'Safe\curl_share_errno',
             'curl_share_setopt' => 'Safe\curl_share_setopt',
             'curl_unescape' => 'Safe\curl_unescape',
             'curl_upkeep' => 'Safe\curl_upkeep',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -13,6 +13,7 @@ return [
     'array_replace', // this function throws an error instead of returning false since PHP 8.0, see https://github.com/php/doc-en/pull/1649
     'array_replace_recursive', // this function throws an error instead of returning false since PHP 8.0, see https://github.com/php/doc-en/pull/1649
     'array_walk_recursive', // actually returns always true, see https://github.com/php/doc-en/commit/cec5275f23d2db648df30a5702b378044431be97
+    'curl_share_errno', // this function does not anymore return false since PHP 8.0
     'date', // this function throws an error instead of returning false PHP 8.0, but the doc has only been updated since PHP 8.4
     'getallheaders', // always return an array since PHP 7, see https://github.com/php/doc-en/commit/68e52ef14de33f6752a8fdda1ae83c861c5babdb
     'gmp_random_seed', // this function throws an error instead of returning false since PHP 8.0


### PR DESCRIPTION
According to the [documentation](https://www.php.net/manual/en/function.curl-share-errno.php#refsect1-function.curl-share-errno-changelog), since PHP 8.0:
> The function no longer returns false on failure.