### PR TITLE
Fix `date_create()` on PHP < 8.4

### DIFF
--- a/generated/8.2/datetime.php
+++ b/generated/8.2/datetime.php
@@ -5,6 +5,36 @@ namespace Safe;
 use Safe\Exceptions\DatetimeException;
 
 /**
+ * This is the procedural version of
+ * DateTime::__construct.
+ *
+ * Unlike the DateTime constructor, it will return
+ * FALSE instead of an exception if the passed in
+ * datetime string is invalid.
+ *
+ * @param null|string $datetime
+ * @param \DateTimeZone|null $timezone
+ * @return \DateTime Returns a new DateTime instance.
+ * Procedural style returns FALSE on failure.
+ * @throws DatetimeException
+ *
+ */
+function date_create(?string $datetime = "now", ?\DateTimeZone $timezone = null): \DateTime
+{
+    error_clear_last();
+    if ($timezone !== null) {
+        $safeResult = \date_create($datetime, $timezone);
+    } else {
+        $safeResult = \date_create($datetime);
+    }
+    if ($safeResult === false) {
+        throw DatetimeException::createFromPhpError();
+    }
+    return $safeResult;
+}
+
+
+/**
  * Returns associative array with detailed info about given date/time.
  *
  * @param string $format Documentation on how the format is used, please

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -102,6 +102,7 @@ return [
     'curl_share_setopt',
     'curl_unescape',
     'curl_upkeep',
+    'date_create',
     'date_parse_from_format',
     'date_sunrise',
     'date_sunset',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -110,6 +110,7 @@ return static function (RectorConfig $rectorConfig): void {
             'curl_share_setopt' => 'Safe\curl_share_setopt',
             'curl_unescape' => 'Safe\curl_unescape',
             'curl_upkeep' => 'Safe\curl_upkeep',
+            'date_create' => 'Safe\date_create',
             'date_parse_from_format' => 'Safe\date_parse_from_format',
             'date_sunrise' => 'Safe\date_sunrise',
             'date_sunset' => 'Safe\date_sunset',

--- a/generated/8.3/datetime.php
+++ b/generated/8.3/datetime.php
@@ -5,6 +5,36 @@ namespace Safe;
 use Safe\Exceptions\DatetimeException;
 
 /**
+ * This is the procedural version of
+ * DateTime::__construct.
+ *
+ * Unlike the DateTime constructor, it will return
+ * FALSE instead of an exception if the passed in
+ * datetime string is invalid.
+ *
+ * @param null|string $datetime
+ * @param \DateTimeZone|null $timezone
+ * @return \DateTime Returns a new DateTime instance.
+ * Procedural style returns FALSE on failure.
+ * @throws DatetimeException
+ *
+ */
+function date_create(?string $datetime = "now", ?\DateTimeZone $timezone = null): \DateTime
+{
+    error_clear_last();
+    if ($timezone !== null) {
+        $safeResult = \date_create($datetime, $timezone);
+    } else {
+        $safeResult = \date_create($datetime);
+    }
+    if ($safeResult === false) {
+        throw DatetimeException::createFromPhpError();
+    }
+    return $safeResult;
+}
+
+
+/**
  * Returns associative array with detailed info about given date/time.
  *
  * @param string $format Documentation on how the format is used, please

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -102,6 +102,7 @@ return [
     'curl_share_setopt',
     'curl_unescape',
     'curl_upkeep',
+    'date_create',
     'date_parse_from_format',
     'date_sunrise',
     'date_sunset',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -110,6 +110,7 @@ return static function (RectorConfig $rectorConfig): void {
             'curl_share_setopt' => 'Safe\curl_share_setopt',
             'curl_unescape' => 'Safe\curl_unescape',
             'curl_upkeep' => 'Safe\curl_upkeep',
+            'date_create' => 'Safe\date_create',
             'date_parse_from_format' => 'Safe\date_parse_from_format',
             'date_sunrise' => 'Safe\date_sunrise',
             'date_sunset' => 'Safe\date_sunset',

--- a/generator/config/detectErrorType.php
+++ b/generator/config/detectErrorType.php
@@ -56,6 +56,7 @@ return function (string $text): ErrorType {
         '/&false;\s+if\s+the\s+timestamp\s+doesn\'t\s+fit\s+in\s+a\s+PHP\s+integer./m', // gmmktime / mktime
         '/<function>mktime<\/function>\s+returns\s+the\s+Unix\s+timestamp\s+of\s+the\s+arguments\s+given./', // mktime before https://github.com/php/doc-en/pull/2651
         '/The name of the socket/', // stream_socket_get_name (PHP 8.1)
+        '/&return.falseforfailure.style.procedural;/', // date_create (8.1 - 8.3)
     ];
     foreach ($falsies as $falsie) {
         if (preg_match($falsie, $text)) {


### PR DESCRIPTION
See previous `date_create()` documentation in https://github.com/php/doc-en/commit/71692b6f4cace8dca72a18ccd80d4cd7305e5d4e.