### PR TITLE
Fix `date_parse()` on PHP < 8.4

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -104,7 +104,6 @@ return [
     'curl_share_errno',
     'curl_share_setopt',
     'curl_unescape',
-    'date_parse',
     'date_parse_from_format',
     'date_sunrise',
     'date_sunset',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -112,7 +112,6 @@ return static function (RectorConfig $rectorConfig): void {
             'curl_share_errno' => 'Safe\curl_share_errno',
             'curl_share_setopt' => 'Safe\curl_share_setopt',
             'curl_unescape' => 'Safe\curl_unescape',
-            'date_parse' => 'Safe\date_parse',
             'date_parse_from_format' => 'Safe\date_parse_from_format',
             'date_sunrise' => 'Safe\date_sunrise',
             'date_sunset' => 'Safe\date_sunset',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -105,7 +105,6 @@ return [
     'curl_share_setopt',
     'curl_unescape',
     'curl_upkeep',
-    'date_parse',
     'date_parse_from_format',
     'date_sunrise',
     'date_sunset',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -113,7 +113,6 @@ return static function (RectorConfig $rectorConfig): void {
             'curl_share_setopt' => 'Safe\curl_share_setopt',
             'curl_unescape' => 'Safe\curl_unescape',
             'curl_upkeep' => 'Safe\curl_upkeep',
-            'date_parse' => 'Safe\date_parse',
             'date_parse_from_format' => 'Safe\date_parse_from_format',
             'date_sunrise' => 'Safe\date_sunrise',
             'date_sunset' => 'Safe\date_sunset',

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -105,7 +105,6 @@ return [
     'curl_share_setopt',
     'curl_unescape',
     'curl_upkeep',
-    'date_parse',
     'date_parse_from_format',
     'date_sunrise',
     'date_sunset',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -113,7 +113,6 @@ return static function (RectorConfig $rectorConfig): void {
             'curl_share_setopt' => 'Safe\curl_share_setopt',
             'curl_unescape' => 'Safe\curl_unescape',
             'curl_upkeep' => 'Safe\curl_upkeep',
-            'date_parse' => 'Safe\date_parse',
             'date_parse_from_format' => 'Safe\date_parse_from_format',
             'date_sunrise' => 'Safe\date_sunrise',
             'date_sunset' => 'Safe\date_sunset',

--- a/generator/config/hiddenFunctions.php
+++ b/generator/config/hiddenFunctions.php
@@ -14,6 +14,7 @@ return [
     'array_replace_recursive', // this function throws an error instead of returning false since PHP 8.0, see https://github.com/php/doc-en/pull/1649
     'array_walk_recursive', // actually returns always true, see https://github.com/php/doc-en/commit/cec5275f23d2db648df30a5702b378044431be97
     'date', // this function throws an error instead of returning false PHP 8.0, but the doc has only been updated since PHP 8.4
+    'date_parse', // always return an array, see https://github.com/php/doc-en/pull/2395
     'getallheaders', // always return an array since PHP 7, see https://github.com/php/doc-en/commit/68e52ef14de33f6752a8fdda1ae83c861c5babdb
     'gmp_random_seed', // this function throws an error instead of returning false since PHP 8.0
     'hash_hkdf', // this function throws an error instead of returning false since PHP 8.0


### PR DESCRIPTION
This function always return an array, see https://github.com/php/doc-en/pull/2395.