### PR TITLE
Add missing `hash_file()` and `hash_hmac_file()` functions

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -264,6 +264,8 @@ return [
     'gztell',
     'gzuncompress',
     'gzwrite',
+    'hash_file',
+    'hash_hmac_file',
     'hash_update_file',
     'header_register_callback',
     'hex2bin',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -272,6 +272,8 @@ return static function (RectorConfig $rectorConfig): void {
             'gztell' => 'Safe\gztell',
             'gzuncompress' => 'Safe\gzuncompress',
             'gzwrite' => 'Safe\gzwrite',
+            'hash_file' => 'Safe\hash_file',
+            'hash_hmac_file' => 'Safe\hash_hmac_file',
             'hash_update_file' => 'Safe\hash_update_file',
             'header_register_callback' => 'Safe\header_register_callback',
             'hex2bin' => 'Safe\hex2bin',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -269,6 +269,8 @@ return [
     'gztell',
     'gzuncompress',
     'gzwrite',
+    'hash_file',
+    'hash_hmac_file',
     'hash_update_file',
     'header_register_callback',
     'hex2bin',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -277,6 +277,8 @@ return static function (RectorConfig $rectorConfig): void {
             'gztell' => 'Safe\gztell',
             'gzuncompress' => 'Safe\gzuncompress',
             'gzwrite' => 'Safe\gzwrite',
+            'hash_file' => 'Safe\hash_file',
+            'hash_hmac_file' => 'Safe\hash_hmac_file',
             'hash_update_file' => 'Safe\hash_update_file',
             'header_register_callback' => 'Safe\header_register_callback',
             'hex2bin' => 'Safe\hex2bin',

--- a/generated/8.3/functionsList.php
+++ b/generated/8.3/functionsList.php
@@ -269,6 +269,8 @@ return [
     'gztell',
     'gzuncompress',
     'gzwrite',
+    'hash_file',
+    'hash_hmac_file',
     'hash_update_file',
     'header_register_callback',
     'hex2bin',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -277,6 +277,8 @@ return static function (RectorConfig $rectorConfig): void {
             'gztell' => 'Safe\gztell',
             'gzuncompress' => 'Safe\gzuncompress',
             'gzwrite' => 'Safe\gzwrite',
+            'hash_file' => 'Safe\hash_file',
+            'hash_hmac_file' => 'Safe\hash_hmac_file',
             'hash_update_file' => 'Safe\hash_update_file',
             'header_register_callback' => 'Safe\header_register_callback',
             'hex2bin' => 'Safe\hex2bin',

--- a/generated/8.4/functionsList.php
+++ b/generated/8.4/functionsList.php
@@ -268,6 +268,8 @@ return [
     'gztell',
     'gzuncompress',
     'gzwrite',
+    'hash_file',
+    'hash_hmac_file',
     'hash_update_file',
     'header_register_callback',
     'hex2bin',

--- a/generated/8.4/rector-migrate.php
+++ b/generated/8.4/rector-migrate.php
@@ -276,6 +276,8 @@ return static function (RectorConfig $rectorConfig): void {
             'gztell' => 'Safe\gztell',
             'gzuncompress' => 'Safe\gzuncompress',
             'gzwrite' => 'Safe\gzwrite',
+            'hash_file' => 'Safe\hash_file',
+            'hash_hmac_file' => 'Safe\hash_hmac_file',
             'hash_update_file' => 'Safe\hash_update_file',
             'header_register_callback' => 'Safe\header_register_callback',
             'hex2bin' => 'Safe\hex2bin',

--- a/generated/8.5/functionsList.php
+++ b/generated/8.5/functionsList.php
@@ -269,6 +269,7 @@ return [
     'gzuncompress',
     'gzwrite',
     'hash_file',
+    'hash_hmac_file',
     'hash_update_file',
     'header_register_callback',
     'hex2bin',

--- a/generated/8.5/hash.php
+++ b/generated/8.5/hash.php
@@ -8,34 +8,6 @@ use Safe\Exceptions\HashException;
  *
  *
  * @param string $algo Name of selected hashing algorithm (e.g. "sha256").
- * For a list of supported algorithms see hash_algos.
- * @param string $filename URL describing location of file to be hashed; Supports fopen wrappers.
- * @param bool $binary When set to TRUE, outputs raw binary data.
- * FALSE outputs lowercase hexits.
- * @param array $options An array of options for the various hashing algorithms.
- * Currently, only the "seed" parameter is
- * supported by the MurmurHash variants.
- * @return non-falsy-string Returns a string containing the calculated message digest as lowercase hexits
- * unless binary is set to true in which case the raw
- * binary representation of the message digest is returned.
- * @throws HashException
- *
- */
-function hash_file(string $algo, string $filename, bool $binary = false, array $options = []): string
-{
-    error_clear_last();
-    $safeResult = \hash_file($algo, $filename, $binary, $options);
-    if ($safeResult === false) {
-        throw HashException::createFromPhpError();
-    }
-    return $safeResult;
-}
-
-
-/**
- *
- *
- * @param string $algo Name of selected hashing algorithm (e.g. "sha256").
  * For a list of supported algorithms see hash_hmac_algos.
  *
  *

--- a/generated/8.5/rector-migrate.php
+++ b/generated/8.5/rector-migrate.php
@@ -277,6 +277,7 @@ return static function (RectorConfig $rectorConfig): void {
             'gzuncompress' => 'Safe\gzuncompress',
             'gzwrite' => 'Safe\gzwrite',
             'hash_file' => 'Safe\hash_file',
+            'hash_hmac_file' => 'Safe\hash_hmac_file',
             'hash_update_file' => 'Safe\hash_update_file',
             'header_register_callback' => 'Safe\header_register_callback',
             'hex2bin' => 'Safe\hex2bin',

--- a/lib/special_cases.php
+++ b/lib/special_cases.php
@@ -18,6 +18,7 @@ use Safe\Exceptions\OpensslException;
 use Safe\Exceptions\PcreException;
 use Safe\Exceptions\SimplexmlException;
 use Safe\Exceptions\FilesystemException;
+use Safe\Exceptions\HashException;
 
 use const PREG_NO_ERROR;
 
@@ -428,4 +429,65 @@ function passthru(string $command, ?int &$result_code = null): void
     if ($safeResult === false) {
         throw ExecException::createFromPhpError();
     }
+}
+
+/**
+ *
+ *
+ * @param string $algo Name of selected hashing algorithm (e.g. "sha256").
+ * For a list of supported algorithms see hash_algos.
+ * @param string $filename URL describing location of file to be hashed; Supports fopen wrappers.
+ * @param bool $binary When set to TRUE, outputs raw binary data.
+ * FALSE outputs lowercase hexits.
+ * @phpstan-param array<string, mixed> $options
+ * @param array $options An array of options for the various hashing algorithms.
+ * Currently, only the "seed" parameter is
+ * supported by the MurmurHash variants.
+ * @return non-falsy-string Returns a string containing the calculated message digest as lowercase hexits
+ * unless binary is set to true in which case the raw
+ * binary representation of the message digest is returned.
+ * @throws HashException
+ *
+ */
+function hash_file(string $algo, string $filename, bool $binary = false, array $options = []): string
+{
+    error_clear_last();
+    $safeResult = \hash_file($algo, $filename, $binary, $options);
+    if ($safeResult === false) {
+        throw HashException::createFromPhpError();
+    }
+    return $safeResult;
+}
+
+/**
+ *
+ *
+ * @param string $algo Name of selected hashing algorithm (e.g. "sha256").
+ * For a list of supported algorithms see hash_hmac_algos.
+ *
+ *
+ * Non-cryptographic hash functions are not allowed.
+ *
+ *
+ *
+ * Non-cryptographic hash functions are not allowed.
+ * @param string $filename URL describing location of file to be hashed; Supports fopen wrappers.
+ * @param string $key Shared secret key used for generating the HMAC variant of the message digest.
+ * @param bool $binary When set to TRUE, outputs raw binary data.
+ * FALSE outputs lowercase hexits.
+ * @return non-falsy-string Returns a string containing the calculated message digest as lowercase hexits
+ * unless binary is set to true in which case the raw
+ * binary representation of the message digest is returned.
+ * Returns FALSE if the file filename cannot be read.
+ * @throws HashException
+ *
+ */
+function hash_hmac_file(string $algo, string $filename, string $key, bool $binary = false): string
+{
+    error_clear_last();
+    $safeResult = \hash_hmac_file($algo, $filename, $key, $binary);
+    if ($safeResult === false) {
+        throw HashException::createFromPhpError();
+    }
+    return $safeResult;
 }


### PR DESCRIPTION
fixes #410

Multiple `hash_*` have the same exact return value documentation. It is therefore not possible to add a specific pattern to the `generator/config/detectErrorType.php` script to detect specifically `hash_file` and `hash_hmac_file` functions.