### PR TITLE
feat(chore): better display of unsafe methods in `scan-objects` command

### DIFF
--- a/generator/src/Commands/ScanObjectsCommand.php
+++ b/generator/src/Commands/ScanObjectsCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class ScanObjectsCommand extends Command
+final class ScanObjectsCommand extends Command
 {
     private SymfonyStyle $io;
     private Scanner $scanner;
@@ -26,7 +26,7 @@ class ScanObjectsCommand extends Command
         ;
     }
 
-    public function initialize(InputInterface $input, OutputInterface $output): void
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $this->io = new SymfonyStyle($input, $output);
         $this->scanner = new Scanner(DocPage::referenceDir());

--- a/generator/src/Domain/MethodDefinition.php
+++ b/generator/src/Domain/MethodDefinition.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Safe\Domain;
+
+use Safe\XmlDocParser\ErrorType;
+
+final class MethodDefinition implements \Stringable
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly ErrorType $errorType,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/generator/src/XmlDocParser/ScannerResponse.php
+++ b/generator/src/XmlDocParser/ScannerResponse.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Safe\XmlDocParser;
 
+use Safe\Domain\MethodDefinition;
+
 class ScannerResponse
 {
     /**
      * @param Method[] $methods
-     * @param string[] $overloadedFunctions
+     * @param MethodDefinition[] $overloadedFunctions
      */
     public function __construct(
         public readonly array $methods,


### PR DESCRIPTION
**Before**

![CleanShot 2025-05-16 at 09 08 46@2x](https://github.com/user-attachments/assets/c9ff5d5c-011c-4951-98ec-190483994a3f)

**After**

![CleanShot 2025-05-16 at 09 06 17@2x](https://github.com/user-attachments/assets/1fceb7d6-19d0-45e7-8c2f-1f0f44f325e8)

![CleanShot 2025-05-16 at 09 06 47@2x](https://github.com/user-attachments/assets/18e2e6c2-fc48-4fc2-9641-ea572c05422b)
