### PR TITLE
pin php 8.5 version of the library to 8.5's release date

### DIFF
--- a/generated/8.5/cubrid.php
+++ b/generated/8.5/cubrid.php
@@ -13,6 +13,106 @@ use Safe\Exceptions\CubridException;
  *
  * The following table shows the types of substitute values.
  *
+ *
+ * CUBRID Bind Date Types
+ *
+ *
+ *
+ * Support
+ * Bind Type
+ * Corresponding SQL Type
+ *
+ *
+ *
+ *
+ * Supported
+ * STRING
+ * CHAR, VARCHAR
+ *
+ *
+ *
+ * NCHAR
+ * NCHAR, NVARCHAR
+ *
+ *
+ *
+ * BIT
+ * BIT, VARBIT
+ *
+ *
+ *
+ * NUMERIC or NUMBER
+ * SHORT, INT, NUMERIC
+ *
+ *
+ *
+ * FLOAT
+ * FLOAT
+ *
+ *
+ *
+ * DOUBLE
+ * DOUBLE
+ *
+ *
+ *
+ * TIME
+ * TIME
+ *
+ *
+ *
+ * DATE
+ * DATE
+ *
+ *
+ *
+ * TIMESTAMP
+ * TIMESTAMP
+ *
+ *
+ *
+ * OBJECT
+ * OBJECT
+ *
+ *
+ *
+ * ENUM
+ * ENUM
+ *
+ *
+ *
+ * BLOB
+ * BLOB
+ *
+ *
+ *
+ * CLOB
+ * CLOB
+ *
+ *
+ *
+ * NULL
+ * NULL
+ *
+ *
+ * Not supported
+ * SET
+ * SET
+ *
+ *
+ *
+ * MULTISET
+ * MULTISET
+ *
+ *
+ *
+ * SEQUENCE
+ * SEQUENCE
+ *
+ *
+ *
+ *
+ *
  * @param resource $req_identifier Request identifier as a result of
  * cubrid_prepare.
  * @param int $bind_index Location of binding parameters. It starts with 1.
@@ -155,6 +255,38 @@ function cubrid_commit($conn_identifier): void
  * &lt;time&gt; := SECOND
  *
  * &lt;milli_sec&gt; := MILLI SECOND
+ *
+ *
+ * host : A host name or IP address of the master database
+ * db_name : A name of the database
+ * db_user : A name of the database user
+ * db_password : A database user password
+ *
+ * alhosts : Specifies the broker information of the standby server, which is
+ * used for failover when it is impossible to connect to the active server.
+ * You can specify multiple brokers for failover, and the connection to the brokers
+ * is attempted in the order listed in alhosts
+ *
+ * rctime : An interval between the attempts to connect to the active broker in
+ * which failure occurred. After a failure occurs, the system connects to the
+ * broker specified by althosts (failover), terminates the transaction, and then
+ * attempts to connect to the active broker of the master database at every rctime.
+ * The default value is 600 seconds.
+ *
+ * login_timeout : Timeout value (unit: msec.) for database login. The default
+ * value is 0, which means infinite postponement.
+ *
+ *
+ * query_timeout : Timeout value (unit: msec.) for query request. Upon timeout,
+ * a message to cancel requesting a query transferred to server is sent. The return
+ * value can depend on the disconnect_on_query_timeout configuration; even though the
+ * message to cancel a request is sent to server, that request may succeed.
+ *
+ *
+ * disconnect_on_query_timeout : Configures a value whether to immediately return
+ * an error of function being executed upon timeout. The default value is false.
+ *
+ *
  *
  * @param string $conn_url A character string that contains server connection information.
  * @param string $userid User name for the database.
@@ -381,6 +513,50 @@ function cubrid_get_client_info(): string
 
 
 /**
+ * This function returns the CUBRID database parameters.
+ * It returns an associative array with the values for the following parameters:
+ *
+ *
+ * PARAM_ISOLATION_LEVEL
+ * PARAM_LOCK_TIMEOUT
+ * PARAM_MAX_STRING_LENGTH
+ * PARAM_AUTO_COMMIT
+ *
+ *
+ *
+ * Database parameters
+ *
+ *
+ *
+ * Parameter
+ * Description
+ *
+ *
+ *
+ *
+ * PARAM_ISOLATION_LEVEL
+ * The transaction isolation level.
+ *
+ *
+ * LOCK_TIMEOUT
+ * CUBRID provides the lock timeout feature, which sets the waiting
+ * time (in seconds) for the lock until the transaction lock setting is
+ * allowed. The default value of the lock_timeout_in_secs parameter is
+ * -1, which means the application client will wait indefinitely until
+ * the transaction lock is allowed.
+ *
+ *
+ *
+ * PARAM_AUTO_COMMIT
+ * In CUBRID PHP, auto-commit mode is disabled by default for
+ * transaction management. It can be set by using
+ * cubrid_set_autocommit.
+ *
+ *
+ *
+ *
+ *
+ *
  * The following table shows the isolation levels from 1 to 6. It consists of
  * table schema (row) and isolation level:
  *
@@ -1085,6 +1261,38 @@ function cubrid_next_result($result): void
  *
  * &lt;milli_sec&gt; := MILLI SECOND
  *
+ *
+ * host : A host name or IP address of the master database
+ * db_name : A name of the database
+ * db_user : A name of the database user
+ * db_password : A database user password
+ *
+ * alhosts : Specifies the broker information of the standby server, which is
+ * used for failover when it is impossible to connect to the active server.
+ * You can specify multiple brokers for failover, and the connection to the brokers
+ * is attempted in the order listed in alhosts
+ *
+ * rctime : An interval between the attempts to connect to the active broker in
+ * which failure occurred. After a failure occurs, the system connects to the
+ * broker specified by althosts (failover), terminates the transaction, and then
+ * attempts to connect to the active broker of the master database at every rctime.
+ * The default value is 600 seconds.
+ *
+ * login_timeout : Timeout value (unit: msec.) for database login. The default
+ * value is 0, which means infinite postponement.
+ *
+ *
+ * query_timeout : Timeout value (unit: msec.) for query request. Upon timeout,
+ * a message to cancel requesting a query transferred to server is sent. The return
+ * value can depend on the disconnect_on_query_timeout configuration; even though the
+ * message to cancel a request is sent to server, that request may succeed.
+ *
+ *
+ * disconnect_on_query_timeout : Configures a value whether to immediately return
+ * an error of function being executed upon timeout. The default value is false.
+ *
+ *
+ *
  * @param string $conn_url A character string that contains server connection information.
  * @param string $userid User name for the database.
  * @param string $passwd User password.
@@ -1252,6 +1460,375 @@ function cubrid_rollback($conn_identifier): void
  * tables shows types of schema and the column structure of the result array to
  * be returned based on the schema type.
  *
+ *
+ * Result Composition of Each Type
+ *
+ *
+ *
+ * Schema
+ * Column Number
+ * Column Name
+ * Value
+ *
+ *
+ *
+ *
+ * CUBRID_SCH_CLASS
+ * 1
+ * NAME
+ *
+ *
+ *
+ *
+ * 2
+ * TYPE
+ * 0:system class 1:vclass 2:class
+ *
+ *
+ *
+ * CUBRID_SCH_VCLASS
+ * 1
+ * NAME
+ *
+ *
+ *
+ *
+ * 2
+ * TYPE
+ * 1:vclass
+ *
+ *
+ *
+ * CUBRID_SCH_QUERY_SPEC
+ * 1
+ * QUERY_SPEC
+ *
+ *
+ *
+ *
+ * CUBRID_SCH_ATTRIBUTE / CUBRID_SCH_CLASS_ATTRIBUTE
+ * 1
+ * ATTR_NAME
+ *
+ *
+ *
+ *
+ * 2
+ * DOMAIN
+ *
+ *
+ *
+ *
+ * 3
+ * SCALE
+ *
+ *
+ *
+ *
+ * 4
+ * PRECISION
+ *
+ *
+ *
+ *
+ * 5
+ * INDEXED
+ * 1:indexed
+ *
+ *
+ *
+ * 6
+ * NOT NULL
+ * 1:not null
+ *
+ *
+ *
+ * 7
+ * SHARED
+ * 1:shared
+ *
+ *
+ *
+ * 8
+ * UNIQUE
+ * 1:unique
+ *
+ *
+ *
+ * 9
+ * DEFAULT
+ *
+ *
+ *
+ *
+ * 10
+ * ATTR_ORDER
+ * base:1
+ *
+ *
+ *
+ * 11
+ * CLASS_NAME
+ *
+ *
+ *
+ *
+ * 12
+ * SOURCE_CLASS
+ *
+ *
+ *
+ *
+ * 13
+ * IS_KEY
+ * 1:key
+ *
+ *
+ *
+ * CUBRID_SCH_METHOD / CUBRID_SCH_CLASS_METHOD
+ * 1
+ * NAME
+ *
+ *
+ *
+ *
+ * 2
+ * RET_DOMAIN
+ *
+ *
+ *
+ *
+ * 3
+ * ARG_DOMAIN
+ *
+ *
+ *
+ *
+ * CUBRID_SCH_METHOD_FILE
+ * 1
+ * METHOD_FILE
+ *
+ *
+ *
+ *
+ * CUBRID_SCH_SUPERCLASS / CUBRID_SCH_DIRECT_SUPER_CLASS / CUBRID_SCH_SUBCLASS
+ * 1
+ * CLASS_NAME
+ *
+ *
+ *
+ *
+ * 2
+ * TYPE
+ * 0:system class 1:vclass 2:class
+ *
+ *
+ *
+ * CUBRID_SCH_CONSTRAINT
+ * 1
+ * TYPE
+ * 0:unique 1:index 2:reverse unique 3:reverse index
+ *
+ *
+ *
+ * 2
+ * NAME
+ *
+ *
+ *
+ *
+ * 3
+ * ATTR_NAME
+ *
+ *
+ *
+ *
+ * 4
+ * NUM_PAGES
+ *
+ *
+ *
+ *
+ * 5
+ * NUM_KEYS
+ *
+ *
+ *
+ *
+ * 6
+ * PRIMARY_KEY
+ * 1:primary key
+ *
+ *
+ *
+ * 7
+ * KEY_ORDER
+ * base:1
+ *
+ *
+ *
+ * CUBRID_SCH_TRIGGER
+ * 1
+ * NAME
+ *
+ *
+ *
+ *
+ * 2
+ * STATUS
+ *
+ *
+ *
+ *
+ * 3
+ * EVENT
+ *
+ *
+ *
+ *
+ * 4
+ * TARGET_CLASS
+ *
+ *
+ *
+ *
+ * 5
+ * TARGET_ATTR
+ *
+ *
+ *
+ *
+ * 6
+ * ACTION_TIME
+ *
+ *
+ *
+ *
+ * 7
+ * ACTION
+ *
+ *
+ *
+ *
+ * 8
+ * PRIORITY
+ *
+ *
+ *
+ *
+ * 9
+ * CONDITION_TIME
+ *
+ *
+ *
+ *
+ * 10
+ * CONDITION
+ *
+ *
+ *
+ *
+ * CUBRID_SCH_CLASS_PRIVILEGE / CUBRID_SCH_ATTR_PRIVILEGE
+ * 1
+ * CLASS_NAME / ATTR_NAME
+ *
+ *
+ *
+ *
+ * 2
+ * PRIVILEGE
+ *
+ *
+ *
+ *
+ * 3
+ * GRANTABLE
+ *
+ *
+ *
+ *
+ * CUBRID_SCH_PRIMARY_KEY
+ * 1
+ * CLASS_NAME
+ *
+ *
+ *
+ *
+ * 2
+ * ATTR_NAME
+ *
+ *
+ *
+ *
+ * 3
+ * KEY_SEQ
+ * base:1
+ *
+ *
+ *
+ * 4
+ * KEY_NAME
+ *
+ *
+ *
+ *
+ * CUBRID_SCH_IMPORTED_KEYS / CUBRID_SCH_EXPORTED_KEYS / CUBRID_SCH_CROSS_REFERENCE
+ * 1
+ * PKTABLE_NAME
+ *
+ *
+ *
+ *
+ * 2
+ * PKCOLUMN_NAME
+ *
+ *
+ *
+ *
+ * 3
+ * FKTABLE_NAME
+ * base:1
+ *
+ *
+ *
+ * 4
+ * FKCOLUMN_NAME
+ *
+ *
+ *
+ *
+ * 5
+ * KEY_SEQ
+ * base:1
+ *
+ *
+ *
+ * 6
+ * UPDATE_ACTION
+ * 0:cascade 1:restrict 2:no action 3:set null
+ *
+ *
+ *
+ * 7
+ * DELETE_ACTION
+ * 0:cascade 1:restrict 2:no action 3:set null
+ *
+ *
+ *
+ * 8
+ * FK_NAME
+ *
+ *
+ *
+ *
+ * 9
+ * PK_NAME
+ *
+ *
+ *
+ *
+ *
+ *
  * @param resource $conn_identifier Connection identifier.
  * @param int $schema_type Schema data that you want to know.
  * @param string $class_name Class you want to know the schema of.
@@ -1375,6 +1952,11 @@ function cubrid_set_add($conn_identifier, string $oid, string $attr_name, string
  *
  * @param resource $conn_identifier Connection identifier.
  * @param bool $mode Auto-commit mode. The following constants can be used:
+ *
+ *
+ * CUBRID_AUTOCOMMIT_FALSE
+ * CUBRID_AUTOCOMMIT_TRUE
+ *
  * @throws CubridException
  *
  */
@@ -1392,6 +1974,11 @@ function cubrid_set_autocommit($conn_identifier, bool $mode): void
  * The cubrid_set_db_parameter function is used to set
  * the CUBRID database parameters. It can set the following CUBRID database
  * parameters:
+ *
+ *
+ * PARAM_ISOLATION_LEVEL
+ * PARAM_LOCK_TIMEOUT
+ *
  *
  * @param resource $conn_identifier The CUBRID connection. If the connection identifier is not specified,
  * the last link opened by cubrid_connect is assumed.

--- a/generated/8.5/eio.php
+++ b/generated/8.5/eio.php
@@ -35,7 +35,6 @@ function eio_busy(int $delay, int $pri = EIO_PRI_DEFAULT, ?callable $callback = 
  * new permissions are specified by mode.
  *
  * @param string $path Path to the target file or directory
- *
  * Avoid relative
  * paths
  * @param int $mode The new permissions. E.g. 0644.
@@ -87,7 +86,6 @@ function eio_chmod(string $path, int $mode, int $pri = EIO_PRI_DEFAULT, ?callabl
  * Changes file, or directory permissions.
  *
  * @param string $path Path to file or directory.
- *
  * Avoid relative
  * paths
  * @param int $uid User ID. Is ignored when equal to -1.
@@ -1114,7 +1112,77 @@ function eio_readahead($fd, int $offset, int $length, int $pri = EIO_PRI_DEFAULT
  *
  * is optional request resource which can be used with functions like eio_get_last_error.
  * @param null|string $data is custom data passed to the request.
- * @return resource Node types:
+ * @return resource eio_readdir returns request resource on success.
+ * Sets result argument of
+ * callback function according to
+ * flags:
+ *
+ *
+ *
+ *
+ *
+ *
+ * EIO_READDIR_DENTS
+ * (int)
+ *
+ *
+ *
+ * eio_readdir flag. If specified, the result argument of the callback
+ * becomes an array with the following keys:
+ * 'names' - array of directory names
+ * 'dents' - array of struct
+ * eio_dirent-like arrays having the following keys each:
+ * 'name' - the directory name;
+ * 'type' - one of EIO_DT_*
+ * constants;
+ * 'inode' - the inode number, if available, otherwise
+ * unspecified;
+ *
+ *
+ *
+ *
+ *
+ * EIO_READDIR_DIRS_FIRST
+ * (int)
+ *
+ *
+ *
+ * When this flag is specified, the names will be returned in an order
+ * where likely directories come first, in optimal stat order.
+ *
+ *
+ *
+ *
+ *
+ * EIO_READDIR_STAT_ORDER
+ * (int)
+ *
+ *
+ *
+ * When this flag is specified, then the names will be returned in an order
+ * suitable for stat'ing each one. When planning to
+ * stat all files in the given directory, the
+ * returned order will likely be
+ * fastest.
+ *
+ *
+ *
+ *
+ *
+ * EIO_READDIR_FOUND_UNKNOWN
+ * (int)
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ * Node types:
  *
  *
  *

--- a/generated/8.5/functionsList.php
+++ b/generated/8.5/functionsList.php
@@ -1087,6 +1087,7 @@ return [
     'xml_parser_free',
     'xml_parser_set_option',
     'yaml_parse',
+    'yaml_parse_file',
     'yaml_parse_url',
     'yaz_ccl_parse',
     'yaz_close',

--- a/generated/8.5/ibmDb2.php
+++ b/generated/8.5/ibmDb2.php
@@ -28,6 +28,10 @@ use Safe\Exceptions\IbmDb2Exception;
  *
  *
  *
+ *
+ * Turns AUTOCOMMIT off.
+ *
+ * Turns AUTOCOMMIT on.
  * @return \DB2_AUTOCOMMIT_OFF|\DB2_AUTOCOMMIT_ON|bool When db2_autocommit receives only the
  * connection parameter, it returns the current state
  * of AUTOCOMMIT for the requested connection as an integer value. A value of
@@ -431,6 +435,15 @@ function db2_free_stmt($stmt): void
  *
  *
  *
+ * Prior versions of ibm_db2 do not support these new options.
+ *
+ * When the value in each option is being set, some servers might not handle
+ * the entire length provided and might truncate the value.
+ *
+ * To ensure that the data specified in each option is converted correctly
+ * when transmitted to a host system, use only the characters A through Z,
+ * 0 through 9, and the underscore (_) or period (.).
+ *
  * SQL_ATTR_INFO_USERID - A pointer to a null-terminated
  * character string used to identify the client user ID sent to the host
  * database server when using DB2 Connect.
@@ -442,6 +455,10 @@ function db2_free_stmt($stmt): void
  *
  *
  *
+ * DB2 for z/OS and OS/390 servers support up to a length of 16 characters.
+ * This user-id is not to be confused with the authentication user-id, it is for
+ * identification purposes only and is not used for any authorization.
+ *
  * SQL_ATTR_INFO_ACCTSTR - A pointer to a null-terminated
  * character string used to identify the client accounting string sent to the
  * host database server when using DB2 Connect.
@@ -450,6 +467,8 @@ function db2_free_stmt($stmt): void
  * DB2 for z/OS and OS/390 servers support up to a length of 200 characters.
  *
  *
+ *
+ * DB2 for z/OS and OS/390 servers support up to a length of 200 characters.
  *
  * SQL_ATTR_INFO_APPLNAME - A pointer to a null-terminated
  * character string used to identify the client application name sent to the
@@ -460,6 +479,8 @@ function db2_free_stmt($stmt): void
  *
  *
  *
+ * DB2 for z/OS and OS/390 servers support up to a length of 32 characters.
+ *
  * SQL_ATTR_INFO_WRKSTNNAME - A pointer to a null-terminated
  * character string used to identify the client workstation name sent to the
  * host database server when using DB2 Connect.
@@ -468,6 +489,8 @@ function db2_free_stmt($stmt): void
  * DB2 for z/OS and OS/390 servers support up to a length of 18 characters.
  *
  *
+ *
+ * DB2 for z/OS and OS/390 servers support up to a length of 18 characters.
  * @return string Returns the current setting of the connection attribute provided on success.
  * @throws IbmDb2Exception
  *
@@ -525,6 +548,13 @@ function db2_num_rows($stmt): int
  * administration requests.
  *
  *
+ *
+ * If you have a persistent DB2 client connection created with
+ * db2_pconnect, you may use this function to close the
+ * connection. To avoid substantial connection performance penalties, this
+ * function should only be used in rare cases when the persistent connection
+ * has become unresponsive or the persistent connection will not be needed for
+ * a long period of time.
  *
  * @param resource $connection Specifies an active DB2 client connection.
  * @throws IbmDb2Exception
@@ -924,6 +954,54 @@ function db2_server_info($connection): \stdClass
  *
  *
  *
+ * Passing DB2_AUTOCOMMIT_ON turns
+ * autocommit on for the specified connection resource.
+ *
+ * Passing DB2_AUTOCOMMIT_OFF turns
+ * autocommit off for the specified connection resource.
+ *
+ * Passing DB2_FORWARD_ONLY specifies a
+ * forward-only cursor for a statement resource. This is the
+ * default cursor type, and is supported by all database
+ * servers.
+ *
+ * Passing DB2_SCROLLABLE specifies a
+ * scrollable cursor for a statement resource. Scrollable
+ * cursors enable result set rows to be accessed in
+ * non-sequential order, but are only supported by
+ * IBM DB2 Universal Database databases.
+ *
+ * Passing DB2_BINARY specifies that
+ * binary data will be returned as is. This is the default
+ * mode. This is the equivalent of setting
+ * ibm_db2.binmode=1 in php.ini.
+ *
+ * Passing DB2_CONVERT specifies that
+ * binary data will be converted to hexadecimal encoding,
+ * and will be returned as such. This is the equivalent of
+ * setting ibm_db2.binmode=2 in php.ini.
+ *
+ * Passing DB2_PASSTHRU specifies that
+ * binary data will be converted to NULL. This is the
+ * equivalent of setting ibm_db2.binmode=3
+ * in php.ini.
+ *
+ * Passing DB2_CASE_LOWER specifies that
+ * column names of the result set are returned in lower case.
+ *
+ * Passing DB2_CASE_UPPER specifies that
+ * column names of the result set are returned in upper case.
+ *
+ * Passing DB2_CASE_NATURAL specifies that
+ * column names of the result set are returned in natural
+ * case.
+ *
+ * Passing DB2_DEFERRED_PREPARE_ON turns deferred
+ * prepare on for the specified statement resource.
+ *
+ * Passing DB2_DEFERRED_PREPARE_OFF turns deferred
+ * prepare off for the specified statement resource.
+ *
  * The following new i5/OS options are available in ibm_db2 version 1.5.1
  * and later. These options apply only when running PHP and ibm_db2 natively on i5 systems.
  *
@@ -944,6 +1022,14 @@ function db2_server_info($connection): \stdClass
  *
  *
  *
+ * DB2_I5_FETCH_ON - Cursors are read-only
+ * and cannot be used for positioned updates or deletes. This
+ * is the default unless SQL_ATTR_FOR_FETCH_ONLY
+ * environment has been set to SQL_FALSE.
+ *
+ * DB2_I5_FETCH_OFF - Cursors can be used
+ * for positioned updates and deletes.
+ *
  * The following new option is available in ibm_db2 version 1.8.0 and later.
  *
  *
@@ -962,6 +1048,14 @@ function db2_server_info($connection): \stdClass
  *
  *
  *
+ *
+ * DB2_ROWCOUNT_PREFETCH_ON - Client can request
+ * the full row count prior to fetching, which means that
+ * db2_num_rows returns the number of rows selected
+ * even when a ROLLFORWARD_ONLY cursor is used.
+ *
+ * DB2_ROWCOUNT_PREFETCH_OFF - Client cannot request
+ * the full row count prior to fetching.
  *
  * The following new options are available in ibm_db2 version 1.7.0 and later.
  *
@@ -986,6 +1080,14 @@ function db2_server_info($connection): \stdClass
  *
  *
  *
+ *
+ * To switch the user to a trusted user, pass the User ID (String)
+ * of the trusted user as the value of this key. This option can
+ * be set on a connection resource only. To use this option, trusted
+ * context must be enabled on the connection resource.
+ *
+ * The password (String) that corresponds to the user specified
+ * by the trusted_user key.
  *
  * The following new options are available in ibm_db2 version 1.6.0 and later.
  * These options provide useful tracking information that can be accessed during
@@ -1066,6 +1168,13 @@ function db2_server_info($connection): \stdClass
  *
  *
  *
+ * When the value in each option is being set, some servers might not handle
+ * the entire length provided and might truncate the value.
+ *
+ * To ensure that the data specified in each option is converted correctly
+ * when transmitted to a host system, use only the characters A through Z,
+ * 0 through 9, and the underscore (_) or period (.).
+ *
  * SQL_ATTR_INFO_USERID - A pointer to a null-terminated
  * character string used to identify the client user ID sent to the host
  * database server when using DB2 Connect.
@@ -1077,6 +1186,10 @@ function db2_server_info($connection): \stdClass
  *
  *
  *
+ * DB2 for z/OS and OS/390 servers support up to a length of 16 characters.
+ * This user-id is not to be confused with the authentication user-id, it is for
+ * identification purposes only and is not used for any authorization.
+ *
  * SQL_ATTR_INFO_ACCTSTR - A pointer to a null-terminated
  * character string used to identify the client accounting string sent to the
  * host database server when using DB2 Connect.
@@ -1085,6 +1198,8 @@ function db2_server_info($connection): \stdClass
  * DB2 for z/OS and OS/390 servers support up to a length of 200 characters.
  *
  *
+ *
+ * DB2 for z/OS and OS/390 servers support up to a length of 200 characters.
  *
  * SQL_ATTR_INFO_APPLNAME - A pointer to a null-terminated
  * character string used to identify the client application name sent to the
@@ -1095,6 +1210,8 @@ function db2_server_info($connection): \stdClass
  *
  *
  *
+ * DB2 for z/OS and OS/390 servers support up to a length of 32 characters.
+ *
  * SQL_ATTR_INFO_WRKSTNNAME - A pointer to a null-terminated
  * character string used to identify the client workstation name sent to the
  * host database server when using DB2 Connect.
@@ -1103,6 +1220,8 @@ function db2_server_info($connection): \stdClass
  * DB2 for z/OS and OS/390 servers support up to a length of 18 characters.
  *
  *
+ *
+ * DB2 for z/OS and OS/390 servers support up to a length of 18 characters.
  * @param int $type Passing DB2_AUTOCOMMIT_ON turns
  * autocommit on for the specified connection resource.
  *

--- a/generated/8.5/ldap.php
+++ b/generated/8.5/ldap.php
@@ -491,9 +491,7 @@ function ldap_get_entries(\LDAP\Connection $ldap, \LDAP\Result $result): array
 /**
  * Sets value to the value of the specified option.
  *
- * @param \LDAP\Connection|null $ldap Either an LDAP\Connection instance, returned by
- * ldap_connect, to get the option for that connection,
- * or NULL to get the global option.
+ * @param \LDAP\Connection $ldap An LDAP\Connection instance, returned by ldap_connect.
  * @param int $option The parameter option can be one of:
  *
  *
@@ -672,7 +670,7 @@ function ldap_get_entries(\LDAP\Connection $ldap, \LDAP\Result $result): array
  * @throws LdapException
  *
  */
-function ldap_get_option(?\LDAP\Connection $ldap, int $option, &$value = null): void
+function ldap_get_option(\LDAP\Connection $ldap, int $option, &$value = null): void
 {
     error_clear_last();
     $safeResult = \ldap_get_option($ldap, $option, $value);

--- a/generated/8.5/mysql.php
+++ b/generated/8.5/mysql.php
@@ -5,6 +5,11 @@ namespace Safe;
 use Safe\Exceptions\MysqlException;
 
 /**
+ * mysql_close closes the non-persistent connection to
+ * the MySQL server that's associated with the specified link identifier. If
+ * link_identifier isn't specified, the last opened
+ * link is used.
+ *
  *
  * Open non-persistent MySQL connections and result sets are automatically destroyed when a
  * PHP script finishes its execution. So, while explicitly closing open

--- a/generated/8.5/openssl.php
+++ b/generated/8.5/openssl.php
@@ -81,11 +81,11 @@ function openssl_cms_decrypt(string $input_filename, string $output_filename, $c
  * @param int $flags Flags to be passed to CMS_sign.
  * @param int $encoding An encoding to output. One of OPENSSL_ENCODING_SMIME,
  * OPENSSL_ENCODING_DER or OPENSSL_ENCODING_PEM.
- * @param int|string $cipher_algo A cipher to use.
+ * @param int $cipher_algo A cypher to use.
  * @throws OpensslException
  *
  */
-function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, $cipher_algo = OPENSSL_CIPHER_AES_128_CBC): void
+function openssl_cms_encrypt(string $input_filename, string $output_filename, $certificate, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, int $cipher_algo = OPENSSL_CIPHER_AES_128_CBC): void
 {
     error_clear_last();
     $safeResult = \openssl_cms_encrypt($input_filename, $output_filename, $certificate, $headers, $flags, $encoding, $cipher_algo);
@@ -1471,18 +1471,13 @@ function openssl_pkey_new(?array $options = null): \OpenSSLAsymmetricKey
  * OPENSSL_SSLV23_PADDING,
  * OPENSSL_PKCS1_OAEP_PADDING,
  * OPENSSL_NO_PADDING.
- * @param null|string $digest_algo The digest algorithm for OAEP padding, or NULL to use the default algorithm.
  * @throws OpensslException
  *
  */
-function openssl_private_decrypt(string $data, ?string &$decrypted_data, $private_key, int $padding = OPENSSL_PKCS1_PADDING, ?string $digest_algo = null): void
+function openssl_private_decrypt(string $data, ?string &$decrypted_data, $private_key, int $padding = OPENSSL_PKCS1_PADDING): void
 {
     error_clear_last();
-    if ($digest_algo !== null) {
-        $safeResult = \openssl_private_decrypt($data, $decrypted_data, $private_key, $padding, $digest_algo);
-    } else {
-        $safeResult = \openssl_private_decrypt($data, $decrypted_data, $private_key, $padding);
-    }
+    $safeResult = \openssl_private_decrypt($data, $decrypted_data, $private_key, $padding);
     if ($safeResult === false) {
         throw OpensslException::createFromPhpError();
     }
@@ -1566,18 +1561,13 @@ function openssl_public_decrypt(string $data, ?string &$decrypted_data, $public_
  * OPENSSL_SSLV23_PADDING,
  * OPENSSL_PKCS1_OAEP_PADDING,
  * OPENSSL_NO_PADDING.
- * @param null|string $digest_algo The digest algorithm for OAEP padding, or NULL to use the default algorithm.
  * @throws OpensslException
  *
  */
-function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_key, int $padding = OPENSSL_PKCS1_PADDING, ?string $digest_algo = null): void
+function openssl_public_encrypt(string $data, ?string &$encrypted_data, $public_key, int $padding = OPENSSL_PKCS1_PADDING): void
 {
     error_clear_last();
-    if ($digest_algo !== null) {
-        $safeResult = \openssl_public_encrypt($data, $encrypted_data, $public_key, $padding, $digest_algo);
-    } else {
-        $safeResult = \openssl_public_encrypt($data, $encrypted_data, $public_key, $padding);
-    }
+    $safeResult = \openssl_public_encrypt($data, $encrypted_data, $public_key, $padding);
     if ($safeResult === false) {
         throw OpensslException::createFromPhpError();
     }
@@ -1667,14 +1657,13 @@ function openssl_seal(string $data, ?string &$sealed_data, ?array &$encrypted_ke
  * @param int|string $algorithm int - one of these Signature Algorithms.
  *
  * string - a valid string returned by openssl_get_md_methods example, "sha256WithRSAEncryption" or "sha384".
- * @param int $padding RSA PSS padding to use.
  * @throws OpensslException
  *
  */
-function openssl_sign(string $data, ?string &$signature, $private_key, $algorithm = OPENSSL_ALGO_SHA1, int $padding = 0): void
+function openssl_sign(string $data, ?string &$signature, $private_key, $algorithm = OPENSSL_ALGO_SHA1): void
 {
     error_clear_last();
-    $safeResult = \openssl_sign($data, $signature, $private_key, $algorithm, $padding);
+    $safeResult = \openssl_sign($data, $signature, $private_key, $algorithm);
     if ($safeResult === false) {
         throw OpensslException::createFromPhpError();
     }
@@ -1777,16 +1766,15 @@ function openssl_spki_verify(string $spki): void
  * @param int|string $algorithm int - one of these Signature Algorithms.
  *
  * string - a valid string returned by openssl_get_md_methods example, "sha1WithRSAEncryption" or "sha512".
- * @param int $padding RSA PSS padding to use.
  * @return -1|0|1 Returns 1 if the signature is correct, 0 if it is incorrect, and
  * -1.
  * @throws OpensslException
  *
  */
-function openssl_verify(string $data, string $signature, $public_key, $algorithm = OPENSSL_ALGO_SHA1, int $padding = 0): int
+function openssl_verify(string $data, string $signature, $public_key, $algorithm = OPENSSL_ALGO_SHA1): int
 {
     error_clear_last();
-    $safeResult = \openssl_verify($data, $signature, $public_key, $algorithm, $padding);
+    $safeResult = \openssl_verify($data, $signature, $public_key, $algorithm);
     if ($safeResult === false) {
         throw OpensslException::createFromPhpError();
     }

--- a/generated/8.5/pcntl.php
+++ b/generated/8.5/pcntl.php
@@ -5,18 +5,18 @@ namespace Safe;
 use Safe\Exceptions\PcntlException;
 
 /**
- * Retrieve the cpu affinity of the process_id.
+ * Retrieve the cpu affinity of the pid.
  *
- * @param int|null $process_id If NULL, the current process ID is used.
- * @return array Returns the cpu affinity mask of the process.
+ * @param int|null $pid If NULL, the current process ID is used.
+ * @return array|bool Returns the cpu affinity mask of the process.
  * @throws PcntlException
  *
  */
-function pcntl_getcpuaffinity(?int $process_id = null): array
+function pcntl_getcpuaffinity(?int $pid = null)
 {
     error_clear_last();
-    if ($process_id !== null) {
-        $safeResult = \pcntl_getcpuaffinity($process_id);
+    if ($pid !== null) {
+        $safeResult = \pcntl_getcpuaffinity($pid);
     } else {
         $safeResult = \pcntl_getcpuaffinity();
     }
@@ -60,21 +60,21 @@ function pcntl_getpriority(?int $process_id = null, int $mode = PRIO_PROCESS): i
 
 
 /**
- * Sets the cpu affinity for the process_id with the cpu affinity mask given by
- * cpu_ids.
+ * Sets the cpu affinity for the pid with the cpu affinity mask given by
+ * hmask.
  *
- * @param int|null $process_id If NULL, the current process ID is used.
- * @param array $cpu_ids The cpu affinity mask comprised of one or more cpu id for binding the process to.
+ * @param int|null $pid If NULL, the current process ID is used.
+ * @param array $hmask The cpu affinity mask comprised of one or more cpu id for binding the process to.
  * @throws PcntlException
  *
  */
-function pcntl_setcpuaffinity(?int $process_id = null, array $cpu_ids = []): void
+function pcntl_setcpuaffinity(?int $pid = null, ?array $hmask = null): void
 {
     error_clear_last();
-    if ($cpu_ids !== []) {
-        $safeResult = \pcntl_setcpuaffinity($process_id, $cpu_ids);
-    } elseif ($process_id !== null) {
-        $safeResult = \pcntl_setcpuaffinity($process_id);
+    if ($hmask !== null) {
+        $safeResult = \pcntl_setcpuaffinity($pid, $hmask);
+    } elseif ($pid !== null) {
+        $safeResult = \pcntl_setcpuaffinity($pid);
     } else {
         $safeResult = \pcntl_setcpuaffinity();
     }

--- a/generated/8.5/pcre.php
+++ b/generated/8.5/pcre.php
@@ -320,6 +320,9 @@ function preg_grep(string $pattern, array $array, int $flags = 0): array
  *
  * If this flag is passed, unmatched subpatterns are reported as NULL;
  * otherwise they are reported as an empty string.
+ *
+ * If no order flag is given, PREG_PATTERN_ORDER is
+ * assumed.
  * @param int $offset Orders results so that $matches[0] is an array of full
  * pattern matches, $matches[1] is an array of strings matched by
  * the first parenthesized subpattern, and so on.

--- a/generated/8.5/pgsql.php
+++ b/generated/8.5/pgsql.php
@@ -138,7 +138,7 @@ function pg_convert(\PgSql\Connection $connection, string $table_name, array $va
  *
  * @param \PgSql\Connection $connection An PgSql\Connection instance.
  * @param string $table_name Name of the table into which to copy the rows.
- * @param array $rows An iterable data to be copied into table_name.
+ * @param array $rows An array of data to be copied into table_name.
  * Each value in rows becomes a row in table_name.
  * Each value in rows should be a delimited string of the values
  * to insert into each field.  Values should be linefeed terminated.

--- a/generated/8.5/ps.php
+++ b/generated/8.5/ps.php
@@ -826,6 +826,8 @@ function ps_hyphenate($psdoc, string $text): array
 
 
 /**
+ * This function is
+ * currently not documented; only its argument list is available.
  *
  *
  * @param resource $psdoc Resource identifier of the postscript file
@@ -1375,6 +1377,8 @@ function ps_setdash($psdoc, float $on, float $off): void
 
 
 /**
+ * This function is
+ * currently not documented; only its argument list is available.
  *
  *
  * @param resource $psdoc Resource identifier of the postscript file
@@ -1522,6 +1526,8 @@ function ps_setmiterlimit($psdoc, float $value): void
 
 
 /**
+ * This function is
+ * currently not documented; only its argument list is available.
  *
  *
  * @param resource $psdoc Resource identifier of the postscript file
@@ -1677,6 +1683,8 @@ function ps_show_xy($psdoc, string $text, float $x, float $y): void
 
 
 /**
+ * This function is
+ * currently not documented; only its argument list is available.
  *
  *
  * @param resource $psdoc

--- a/generated/8.5/rector-migrate.php
+++ b/generated/8.5/rector-migrate.php
@@ -1095,6 +1095,7 @@ return static function (RectorConfig $rectorConfig): void {
             'xml_parser_free' => 'Safe\xml_parser_free',
             'xml_parser_set_option' => 'Safe\xml_parser_set_option',
             'yaml_parse' => 'Safe\yaml_parse',
+            'yaml_parse_file' => 'Safe\yaml_parse_file',
             'yaml_parse_url' => 'Safe\yaml_parse_url',
             'yaz_ccl_parse' => 'Safe\yaz_ccl_parse',
             'yaz_close' => 'Safe\yaz_close',

--- a/generated/8.5/sem.php
+++ b/generated/8.5/sem.php
@@ -298,6 +298,8 @@ function msg_set_queue(\SysvMessageQueue $queue, array $data): void
  *
  *
  *
+ *
+ * Returns FALSE on failure.
  * @throws SemException
  *
  */

--- a/generated/8.5/ssh2.php
+++ b/generated/8.5/ssh2.php
@@ -117,9 +117,132 @@ function ssh2_auth_pubkey_file($session, string $username, string $pubkeyfile, s
  * @param array $methods methods may be an associative array with up to four parameters
  * as described below.
  *
+ *
+ * methods may be an associative array
+ * with any or all of the following parameters.
+ *
+ *
+ *
+ * Index
+ * Meaning
+ * Supported Values*
+ *
+ *
+ *
+ *
+ * kex
+ *
+ * List of key exchange methods to advertise, comma separated
+ * in order of preference.
+ *
+ *
+ * diffie-hellman-group1-sha1,
+ * diffie-hellman-group14-sha1, and
+ * diffie-hellman-group-exchange-sha1
+ *
+ *
+ *
+ * hostkey
+ *
+ * List of hostkey methods to advertise, comma separated
+ * in order of preference.
+ *
+ *
+ * ssh-rsa and
+ * ssh-dss
+ *
+ *
+ *
+ * client_to_server
+ *
+ * Associative array containing crypt, compression, and
+ * message authentication code (MAC) method preferences
+ * for messages sent from client to server.
+ *
+ *
+ *
+ *
+ * server_to_client
+ *
+ * Associative array containing crypt, compression, and
+ * message authentication code (MAC) method preferences
+ * for messages sent from server to client.
+ *
+ *
+ *
+ *
+ *
+ *
+ *
  * * - Supported Values are dependent on methods supported by underlying library.
  * See libssh2 documentation for additional
  * information.
+ *
+ *
+ *
+ * client_to_server and
+ * server_to_client may be an associative array
+ * with any or all of the following parameters.
+ *
+ *
+ *
+ *
+ * Index
+ * Meaning
+ * Supported Values*
+ *
+ *
+ *
+ *
+ * crypt
+ * List of crypto methods to advertise, comma separated
+ * in order of preference.
+ *
+ * rijndael-cbc@lysator.liu.se,
+ * aes256-cbc,
+ * aes192-cbc,
+ * aes128-cbc,
+ * 3des-cbc,
+ * blowfish-cbc,
+ * cast128-cbc,
+ * arcfour, and
+ * none**
+ *
+ *
+ *
+ * comp
+ * List of compression methods to advertise, comma separated
+ * in order of preference.
+ *
+ * zlib and
+ * none
+ *
+ *
+ *
+ * mac
+ * List of MAC methods to advertise, comma separated
+ * in order of preference.
+ *
+ * hmac-sha1,
+ * hmac-sha1-96,
+ * hmac-ripemd160,
+ * hmac-ripemd160@openssh.com, and
+ * none**
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ * Crypt and MAC method "none"
+ *
+ * For security reasons, none is disabled by the underlying
+ * libssh2 library unless explicitly enabled
+ * during build time by using the appropriate ./configure options.  See documentation
+ * for the underlying library for more information.
+ *
+ *
  *
  * For security reasons, none is disabled by the underlying
  * libssh2 library unless explicitly enabled

--- a/generated/8.5/yaml.php
+++ b/generated/8.5/yaml.php
@@ -16,13 +16,11 @@ use Safe\Exceptions\YamlException;
  * tag =&gt; callable mappings. See
  * parse callbacks for more
  * details.
- * @return mixed Returns the value encoded in filename in the appropriate
- * PHP type.
- *
- * On failure, a string containing an error message is returned.
- *
- * If pos is -1, an array
- * will be returned with one entry for each document found in the stream.
+ * @return mixed Returns the value encoded in filename in appropriate
+ * PHP type. If pos is -1 an
+ * array will be returned with one entry for each document found
+ * in the stream.
+ * @throws YamlException
  *
  */
 function yaml_parse_file(string $filename, int $pos = 0, ?int &$ndocs = null, ?array $callbacks = null)
@@ -32,6 +30,9 @@ function yaml_parse_file(string $filename, int $pos = 0, ?int &$ndocs = null, ?a
         $safeResult = \yaml_parse_file($filename, $pos, $ndocs, $callbacks);
     } else {
         $safeResult = \yaml_parse_file($filename, $pos, $ndocs);
+    }
+    if ($safeResult === false) {
+        throw YamlException::createFromPhpError();
     }
     return $safeResult;
 }

--- a/generated/8.5/zlib.php
+++ b/generated/8.5/zlib.php
@@ -269,12 +269,13 @@ function gzencode(string $data, int $level = -1, int $encoding = ZLIB_ENCODING_G
  * it returns the file in an array.
  *
  * @param string $filename The file name.
- * @param int $use_include_path If set to TRUE, files in the include_path are searched for too.
+ * @param int $use_include_path You can set this optional parameter to 1, if you
+ * want to search for the file in the include_path too.
  * @return list An array containing the file, one line per cell, empty lines included, and with newlines still attached.
  * @throws ZlibException
  *
  */
-function gzfile(string $filename, int $use_include_path = false): array
+function gzfile(string $filename, int $use_include_path = 0): array
 {
     error_clear_last();
     $safeResult = \gzfile($filename, $use_include_path);
@@ -352,7 +353,8 @@ function gzinflate(string $data, int $max_length = 0): string
  * (See the description of deflateInit2
  * in zlib.h for
  * more information about the strategy parameter.)
- * @param int $use_include_path If set to TRUE, files in the include_path are searched for too.
+ * @param int $use_include_path You can set this optional parameter to 1, if you
+ * want to search for the file in the include_path too.
  * @return resource Returns a file pointer to the file opened, after that, everything you read
  * from this file descriptor will be transparently decompressed and what you
  * write gets compressed.
@@ -361,7 +363,7 @@ function gzinflate(string $data, int $max_length = 0): string
  * @throws ZlibException
  *
  */
-function gzopen(string $filename, string $mode, int $use_include_path = false)
+function gzopen(string $filename, string $mode, int $use_include_path = 0)
 {
     error_clear_last();
     $safeResult = \gzopen($filename, $mode, $use_include_path);

--- a/generator/src/Commands/GenerateCommand.php
+++ b/generator/src/Commands/GenerateCommand.php
@@ -48,7 +48,7 @@ class GenerateCommand extends Command
             "8.2" => "8f4e8cf3de08208e71eb0117f1c970c27e9120c9",
             "8.3" => "7453a50321f0834421cebea8edade14deef5466b",
             "8.4" => "d553fa36940639b0889ec4358fa3bbb92f123b69",
-            "8.5" => "master",
+            "8.5" => "ce397343296708654c8cdac774e23a9ee47ab27d",
         ];
 
         // Keep a track of which modules we have seen across all versions,


### PR DESCRIPTION

8.6 is changing the format of the docs quite a bit - now that 8.5 is released and ongoing work is aiming for 8.6, we should stop assuming master==8.5
