### PR TITLE
Always reset docs to master after generation

### DIFF
--- a/generator/src/Commands/GenerateCommand.php
+++ b/generator/src/Commands/GenerateCommand.php
@@ -91,6 +91,11 @@ class GenerateCommand extends Command
             $fileCreator->generateRectorFile($res->methods, "$genDir/rector-migrate.php");
         }
 
+        // always reset docs to master, even if the most-recently-supported-version
+        // in $versions is pinned to a specific commit - this is so that at the end
+        // of a `generate` run, we don't have docs stuck in the past
+        $this->checkout(DocPage::referenceDir(), "master");
+
         foreach (\array_keys($modules) as $moduleName) {
             $fileCreator->generateVersionSplitters($moduleName, FileCreator::getSafeRootDir() . "/generated/", \array_keys($versions));
             $fileCreator->createExceptionFile((string) $moduleName);


### PR DESCRIPTION

When eg we support up to 8.5, then 8.5 was an alias for master and we ended up on master by default; but with 8.5 being released as stable, we want to pin it to a specific version - but even with 8.5 pinned to a specific version, we still want the docs to end up on master after the process is complete, so let's set it there explicitly instead of implicitly
