### PR TITLE
avoid conflicting definitions for readgzfile

### DIFF
--- a/generated/8.1/zlib.php
+++ b/generated/8.1/zlib.php
@@ -676,13 +676,13 @@ function inflate_init(int $encoding, array $options = []): \InflateContext
  *
  * @param string $filename The file name. This file will be opened from the filesystem and its
  * contents written to standard output.
- * @param int $use_include_path You can set this optional parameter to 1, if you
+ * @param  $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
  * @return 0|positive-int Returns the number of (uncompressed) bytes read from the file on success
  * @throws ZlibException
  *
  */
-function readgzfile(string $filename, int $use_include_path = 0): int
+function readgzfile(string $filename, $use_include_path = 0): int
 {
     error_clear_last();
     $safeResult = \readgzfile($filename, $use_include_path);

--- a/generated/8.2/zlib.php
+++ b/generated/8.2/zlib.php
@@ -676,13 +676,13 @@ function inflate_init(int $encoding, array $options = []): \InflateContext
  *
  * @param string $filename The file name. This file will be opened from the filesystem and its
  * contents written to standard output.
- * @param int $use_include_path You can set this optional parameter to 1, if you
+ * @param  $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
  * @return 0|positive-int Returns the number of (uncompressed) bytes read from the file on success
  * @throws ZlibException
  *
  */
-function readgzfile(string $filename, int $use_include_path = 0): int
+function readgzfile(string $filename, $use_include_path = 0): int
 {
     error_clear_last();
     $safeResult = \readgzfile($filename, $use_include_path);

--- a/generated/8.3/zlib.php
+++ b/generated/8.3/zlib.php
@@ -676,13 +676,13 @@ function inflate_init(int $encoding, array $options = []): \InflateContext
  *
  * @param string $filename The file name. This file will be opened from the filesystem and its
  * contents written to standard output.
- * @param int $use_include_path You can set this optional parameter to 1, if you
+ * @param  $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
  * @return 0|positive-int Returns the number of (uncompressed) bytes read from the file on success
  * @throws ZlibException
  *
  */
-function readgzfile(string $filename, int $use_include_path = 0): int
+function readgzfile(string $filename, $use_include_path = 0): int
 {
     error_clear_last();
     $safeResult = \readgzfile($filename, $use_include_path);

--- a/generated/8.4/zlib.php
+++ b/generated/8.4/zlib.php
@@ -668,13 +668,13 @@ function inflate_init(int $encoding, array $options = []): \InflateContext
  *
  * @param string $filename The file name. This file will be opened from the filesystem and its
  * contents written to standard output.
- * @param int $use_include_path You can set this optional parameter to 1, if you
+ * @param  $use_include_path You can set this optional parameter to 1, if you
  * want to search for the file in the include_path too.
  * @return 0|positive-int Returns the number of (uncompressed) bytes read from the file on success
  * @throws ZlibException
  *
  */
-function readgzfile(string $filename, int $use_include_path = 0): int
+function readgzfile(string $filename, $use_include_path = 0): int
 {
     error_clear_last();
     $safeResult = \readgzfile($filename, $use_include_path);

--- a/generated/8.5/zlib.php
+++ b/generated/8.5/zlib.php
@@ -668,14 +668,14 @@ function inflate_init(int $encoding, array $options = []): \InflateContext
  *
  * @param string $filename The file name. This file will be opened from the filesystem and its
  * contents written to standard output.
- * @param int $use_include_path When set to TRUE the
+ * @param  $use_include_path When set to TRUE the
  * include_path
  * will be used to determine which file to open.
  * @return 0|positive-int Returns the number of (uncompressed) bytes read from the file on success
  * @throws ZlibException
  *
  */
-function readgzfile(string $filename, int $use_include_path = false): int
+function readgzfile(string $filename, $use_include_path = false): int
 {
     error_clear_last();
     $safeResult = \readgzfile($filename, $use_include_path);

--- a/generator/config/CustomPhpStanFunctionMap.php
+++ b/generator/config/CustomPhpStanFunctionMap.php
@@ -31,4 +31,7 @@ return [
     'socket_addrinfo_connect' => ['resource|false', 'addrinfo'=>'resource'], // doesn't return null
     'socket_addrinfo_lookup' => ['AddressInfo[]|false', 'node'=>'string', 'service='=>'mixed', 'hints='=>'array'], // returns AddressInfo[], not resource[]
     'socket_create_pair' => ['bool', 'domain'=>'int', 'type'=>'int', 'protocol'=>'int', '&w_fd'=>'Socket[]'], // fd is Socket[], not resource[]
+
+	// use_include_path is an int in 8.1-8.4 and a bool in 8.5
+	'readgzfile' => ['0|positive-int|false', 'filename'=>'string', 'use_include_path='=>''],
 ];


### PR DESCRIPTION

- official docs don't give it a type at all
- in php 8.1-8.4 it defaulted to "0"
- in php 8.5 it defaults to "false"

phpstan 2.1's database says it's an int, but assigning `false` to int is a syntax error, so let's override that to leave the type unspecified, which is compatible with both `0` and `false`
