### PR TITLE
Add safe wrapper for unserialize

### DIFF
--- a/generated/8.1/functionsList.php
+++ b/generated/8.1/functionsList.php
@@ -1052,6 +1052,7 @@ return [
     'unixtojd',
     'unlink',
     'unpack',
+    'unserialize',
     'uopz_extend',
     'uopz_implement',
     'variant_date_to_timestamp',

--- a/generated/8.1/rector-migrate.php
+++ b/generated/8.1/rector-migrate.php
@@ -1060,6 +1060,7 @@ return static function (RectorConfig $rectorConfig): void {
             'unixtojd' => 'Safe\unixtojd',
             'unlink' => 'Safe\unlink',
             'unpack' => 'Safe\unpack',
+            'unserialize' => 'Safe\unserialize',
             'uopz_extend' => 'Safe\uopz_extend',
             'uopz_implement' => 'Safe\uopz_implement',
             'variant_date_to_timestamp' => 'Safe\variant_date_to_timestamp',

--- a/generated/8.2/functionsList.php
+++ b/generated/8.2/functionsList.php
@@ -1089,6 +1089,7 @@ return [
     'unixtojd',
     'unlink',
     'unpack',
+    'unserialize',
     'uopz_extend',
     'uopz_implement',
     'variant_date_to_timestamp',

--- a/generated/8.2/rector-migrate.php
+++ b/generated/8.2/rector-migrate.php
@@ -1097,6 +1097,7 @@ return static function (RectorConfig $rectorConfig): void {
             'unixtojd' => 'Safe\unixtojd',
             'unlink' => 'Safe\unlink',
             'unpack' => 'Safe\unpack',
+            'unserialize' => 'Safe\unserialize',
             'uopz_extend' => 'Safe\uopz_extend',
             'uopz_implement' => 'Safe\uopz_implement',
             'variant_date_to_timestamp' => 'Safe\variant_date_to_timestamp',

--- a/generated/8.3/rector-migrate.php
+++ b/generated/8.3/rector-migrate.php
@@ -1097,6 +1097,7 @@ return static function (RectorConfig $rectorConfig): void {
             'unixtojd' => 'Safe\unixtojd',
             'unlink' => 'Safe\unlink',
             'unpack' => 'Safe\unpack',
+            'unserialize' => 'Safe\unserialize',
             'uopz_extend' => 'Safe\uopz_extend',
             'uopz_implement' => 'Safe\uopz_implement',
             'variant_date_to_timestamp' => 'Safe\variant_date_to_timestamp',

--- a/generated/8.4/functionsList.php
+++ b/generated/8.4/functionsList.php
@@ -1066,6 +1066,7 @@ return [
     'unixtojd',
     'unlink',
     'unpack',
+    'unserialize',
     'uopz_extend',
     'uopz_implement',
     'variant_date_to_timestamp',

--- a/generated/8.4/rector-migrate.php
+++ b/generated/8.4/rector-migrate.php
@@ -1074,6 +1074,7 @@ return static function (RectorConfig $rectorConfig): void {
             'unixtojd' => 'Safe\unixtojd',
             'unlink' => 'Safe\unlink',
             'unpack' => 'Safe\unpack',
+            'unserialize' => 'Safe\unserialize',
             'uopz_extend' => 'Safe\uopz_extend',
             'uopz_implement' => 'Safe\uopz_implement',
             'variant_date_to_timestamp' => 'Safe\variant_date_to_timestamp',

--- a/generated/8.5/functionsList.php
+++ b/generated/8.5/functionsList.php
@@ -1068,6 +1068,7 @@ return [
     'unixtojd',
     'unlink',
     'unpack',
+    'unserialize',
     'uopz_extend',
     'uopz_implement',
     'variant_date_to_timestamp',

--- a/generated/8.5/rector-migrate.php
+++ b/generated/8.5/rector-migrate.php
@@ -1076,6 +1076,7 @@ return static function (RectorConfig $rectorConfig): void {
             'unixtojd' => 'Safe\unixtojd',
             'unlink' => 'Safe\unlink',
             'unpack' => 'Safe\unpack',
+            'unserialize' => 'Safe\unserialize',
             'uopz_extend' => 'Safe\uopz_extend',
             'uopz_implement' => 'Safe\uopz_implement',
             'variant_date_to_timestamp' => 'Safe\variant_date_to_timestamp',

--- a/generated/8.6/functionsList.php
+++ b/generated/8.6/functionsList.php
@@ -1068,6 +1068,7 @@ return [
     'unixtojd',
     'unlink',
     'unpack',
+    'unserialize',
     'uopz_extend',
     'uopz_implement',
     'variant_date_to_timestamp',

--- a/generated/8.6/rector-migrate.php
+++ b/generated/8.6/rector-migrate.php
@@ -1076,6 +1076,7 @@ return static function (RectorConfig $rectorConfig): void {
             'unixtojd' => 'Safe\unixtojd',
             'unlink' => 'Safe\unlink',
             'unpack' => 'Safe\unpack',
+            'unserialize' => 'Safe\unserialize',
             'uopz_extend' => 'Safe\uopz_extend',
             'uopz_implement' => 'Safe\uopz_implement',
             'variant_date_to_timestamp' => 'Safe\variant_date_to_timestamp',

--- a/tests/SpecialCasesTest.php
+++ b/tests/SpecialCasesTest.php
@@ -41,6 +41,23 @@ class SpecialCasesTest extends TestCase
         \fclose($handle);
     }
 
+    public function testUnserialize(): void
+    {
+        $data = new stdClass();
+        $serialized_data = \serialize($data);
+        $this->assertEquals($data, \Safe\unserialize($serialized_data));
+
+        $serialized_data = \serialize(false);
+        $this->assertFalse(\Safe\unserialize($serialized_data));
+    }
+
+    public function testUnserializeOnInvalidData(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('unserialize(): Error at offset 0 of 8 bytes');
+        \Safe\unserialize('invalid{');
+    }
+
     /*public function testFgetcsvThrowsOnError()
     {
         if (($handle = \fopen(__DIR__."/csv/test3.csv", "r")) === false) {


### PR DESCRIPTION
This is my first contribution to this repository, feedback is appreciated.

PHP default behavior for strings that cannot be unserialized is to return a false and emit an E_WARNING (or E_NOTICE depending on PHP version). 

This wrapper tries to guarantee that something like that will in fact throw an `ErrorException` by setting a custom error handler, executing the function, and then restoring it to its previous state.

I believe this is necessary because there is a scenario where an unserialize call, although successful, returns a false because the previous serialized value was indeed a false boolean, and not because an error happened during unserialization.